### PR TITLE
Fix text formatter tag support bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mocha": "^2.4.5"
   },
   "scripts": {
-    "test": "mocha --compilers js:babel-register",
+    "test": "mocha --recursive --compilers js:babel-register",
     "build": "babel src --out-dir lib",
     "prepublish": "npm test && npm run build"
   }

--- a/src/formatter/text_formatter.js
+++ b/src/formatter/text_formatter.js
@@ -1,4 +1,5 @@
 import FormatterBase from './formatter_base';
+import Tag from '../chord_sheet/tag';
 
 const NEW_LINE = '\n';
 
@@ -39,6 +40,10 @@ export default class TextFormatter extends FormatterBase {
   }
 
   formatItem(item) {
+    if (item instanceof Tag) {
+      return this.formatTag(item);
+    }
+
     let chordsLength = item.chords.length;
 
     if (chordsLength) {
@@ -49,5 +54,13 @@ export default class TextFormatter extends FormatterBase {
     this.chordsLine += this.padString(item.chords, length);
     this.lyricsLine += this.padString(item.lyrics, length);
     this.dirtyLine = true;
+  }
+
+  formatTag(tag) {
+    if (tag.value.length) {
+      return tag.value;
+    }
+
+    return tag.name;
   }
 }

--- a/src/formatter/text_formatter.js
+++ b/src/formatter/text_formatter.js
@@ -15,10 +15,10 @@ export default class TextFormatter extends FormatterBase {
     let output = '';
 
     if (this.chordsLine.trim().length) {
-      output += this.chordsLine + NEW_LINE;
+      output += this.chordsLine.trimRight() + NEW_LINE;
     }
 
-    output += this.lyricsLine + NEW_LINE;
+    output += this.lyricsLine.trimRight() + NEW_LINE;
     this.output(output);
     this.chordsLine = '';
     this.lyricsLine = '';

--- a/test/formatter/text_formatter.js
+++ b/test/formatter/text_formatter.js
@@ -1,0 +1,60 @@
+import expect from 'expect';
+import '../matchers';
+import { createSong, createLine, createItem, createTag } from '../utilities';
+import TextFormatter from '../../src/formatter/text_formatter';
+import Item from '../../src/chord_sheet/item';
+import Line from '../../src/chord_sheet/line';
+import Song from '../../src/chord_sheet/song';
+import Tag from '../../src/chord_sheet/tag';
+
+describe('TextFormatter', () => {
+  it('formats a song to a text chord sheet correctly', () => {
+    // Mimic the following chord sheet:
+    //
+    // {title: Let it be}
+    // {Chorus}
+    //
+    // Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be
+    // [C]Whisper words of [G]wisdom, let it [F]be [C/E] [Dm] [C]
+
+    const song = createSong([
+      createLine([
+        createTag('title', 'Let it be')
+      ]),
+
+      createLine([
+        createTag('Chorus', '')
+      ]),
+
+      createLine([]),
+
+      createLine([
+        createItem('', 'Let it '),
+        createItem('Am', 'be, let it '),
+        createItem('C/G', 'be, let it '),
+        createItem('F', 'be, let it '),
+        createItem('C', 'be')
+      ]),
+
+      createLine([
+        createItem('C', 'Whisper words of '),
+        createItem('G', 'wisdom, let it '),
+        createItem('F', 'be '),
+        createItem('C/E', ' '),
+        createItem('Dm', ' '),
+        createItem('C', '')
+      ])
+    ]);
+
+    const formatter = new TextFormatter();
+
+    const expectedChordSheet = `
+       Am         C/G        F          C
+Let it be, let it be, let it be, let it be
+C                G              F  C/E Dm C
+Whisper words of wisdom, let it be
+`.substring(1);
+
+    expect(formatter.format(song)).toEqual(expectedChordSheet);
+  });
+});

--- a/test/parser/chord_pro_parser.js
+++ b/test/parser/chord_pro_parser.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
-import './matchers';
-import ChordProParser from '../src/parser/chord_pro_parser';
+import '../matchers';
+import ChordProParser from '../../src/parser/chord_pro_parser';
 
 const chordSheet = `
 {title: Let it be}

--- a/test/parser/chord_sheet_parser.js
+++ b/test/parser/chord_sheet_parser.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
-import './matchers';
-import ChordSheetParser from '../src/parser/chord_sheet_parser';
+import '../matchers';
+import ChordSheetParser from '../../src/parser/chord_sheet_parser';
 
 const chordSheet = `
        Am         C/G        F          C

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -1,0 +1,30 @@
+import Item from '../src/chord_sheet/item';
+import Line from '../src/chord_sheet/line';
+import Song from '../src/chord_sheet/song';
+import Tag from '../src/chord_sheet/tag';
+
+export function createSong(lines) {
+  const song = new Song();
+  song.lines = lines;
+  return song;
+}
+
+export function createLine(items) {
+  const line = new Line();
+  line.items = items;
+  return line;
+}
+
+export function createItem(chords, lyrics) {
+  const item = new Item();
+  item.chords = chords;
+  item.lyrics = lyrics;
+  return item;
+}
+
+export function createTag(name, value) {
+  const tag = new Tag();
+  tag.name = name;
+  tag.value = value;
+  return tag;
+}


### PR DESCRIPTION
When trying to format a chord pro tag, the following error occurred:

```
TypeError: Cannot read property 'length' of undefined
      at TextFormatter.formatItem (src/formatter/text_formatter.js:42:24)
      at src/formatter/formatter_base.js:15:14
      at Array.forEach (native)
      at src/formatter/formatter_base.js:14:18
      at Array.forEach (native)
      at TextFormatter.format (src/formatter/formatter_base.js:11:16)
      at Context.<anonymous> (test/formatter/text_formatter.js:57:22)
```