### PR TITLE
Add .npmignore to ensure lib/ is in the package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+node_modules
+.idea


### PR DESCRIPTION
Because `lib/` was added to `.gitignore`, and there was no `.npmignore`, the ES5 sources were excluded from the NPM package, making it unusable. 

This PR adds a `.npmignore` containing the items from `.gitignore`, except for `lib/`.