### PR TITLE
Add tests for html formatter

### DIFF
--- a/src/formatter/html_formatter.js
+++ b/src/formatter/html_formatter.js
@@ -15,7 +15,7 @@ export default class HtmlFormatter extends FormatterBase {
   formatItem(item) {
     if (item instanceof Tag) {
       return;
-    };
+    }
 
     let chords = item.chords.trim();
     let lyrics = item.lyrics.trim();

--- a/src/formatter/html_formatter.js
+++ b/src/formatter/html_formatter.js
@@ -1,4 +1,5 @@
 import FormatterBase from './formatter_base';
+import Tag from "../chord_sheet/tag";
 
 const SPACE = '&nbsp;';
 
@@ -12,6 +13,10 @@ export default class HtmlFormatter extends FormatterBase {
   }
 
   formatItem(item) {
+    if (item instanceof Tag) {
+      return;
+    };
+
     let chords = item.chords.trim();
     let lyrics = item.lyrics.trim();
 

--- a/test/fixtures/song.js
+++ b/test/fixtures/song.js
@@ -1,0 +1,39 @@
+import { createSong, createLine, createItem, createTag } from '../utilities';
+
+// Mimic the following chord sheet:
+//
+// {title: Let it be}
+// {Chorus}
+//
+// Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be
+// [C]Whisper words of [G]wisdom, let it [F]be [C/E] [Dm] [C]
+
+export default createSong([
+  createLine([]),
+
+  createLine([
+    createTag('Chorus', '')
+  ]),
+
+  createLine([]),
+
+  createLine([
+    createItem('', 'Let it '),
+    createItem('Am', 'be, let it '),
+    createItem('C/G', 'be, let it '),
+    createItem('F', 'be, let it '),
+    createItem('C', 'be')
+  ]),
+
+  createLine([
+    createItem('C', 'Whisper words of '),
+    createItem('G', 'wisdom, let it '),
+    createItem('F', 'be '),
+    createItem('C/E', ' '),
+    createItem('Dm', ' '),
+    createItem('C', '')
+  ])
+], {
+  title: 'Let it be',
+  subtitle: 'ChordSheetJS example version'
+});

--- a/test/formatter/html_formatter.js
+++ b/test/formatter/html_formatter.js
@@ -1,0 +1,48 @@
+import expect from 'expect';
+import '../matchers';
+import HtmlFormatter from '../../src/formatter/html_formatter';
+import song from '../fixtures/song';
+
+describe('HtmlFormatter', () => {
+  it('formats a song to a html chord sheet correctly', () => {
+    const formatter = new HtmlFormatter();
+
+    const expectedChordSheet =
+      '<table>' +
+        '<tr>' +
+        '<td class="chord"></td>' +
+        '<td class="chord">Am</td>' +
+        '<td class="chord">C/G</td>' +
+        '<td class="chord">F</td>' +
+        '<td class="chord">C</td>' +
+        '</tr>' +
+        '<tr>' +
+        '<td class="lyrics">Let it&nbsp;</td>' +
+        '<td class="lyrics">be, let it&nbsp;</td>' +
+        '<td class="lyrics">be, let it&nbsp;</td>' +
+        '<td class="lyrics">be, let it&nbsp;</td>' +
+        '<td class="lyrics">be&nbsp;</td>' +
+        '</tr>' +
+        '</table>' +
+        '<table>' +
+        '<tr>' +
+        '<td class="chord">C</td>' +
+        '<td class="chord">G</td>' +
+        '<td class="chord">F</td>' +
+        '<td class="chord">C/E&nbsp;</td>' +
+        '<td class="chord">Dm&nbsp;</td>' +
+        '<td class="chord">C&nbsp;</td>' +
+        '</tr>' +
+        '<tr>' +
+        '<td class="lyrics">Whisper words of&nbsp;</td>' +
+        '<td class="lyrics">wisdom, let it&nbsp;</td>' +
+        '<td class="lyrics">be&nbsp;</td>' +
+        '<td class="lyrics"></td>' +
+        '<td class="lyrics"></td>' +
+        '<td class="lyrics"></td>' +
+        '</tr>' +
+        '</table>';
+
+    expect(formatter.format(song)).toEqual(expectedChordSheet);
+  });
+});

--- a/test/formatter/text_formatter.js
+++ b/test/formatter/text_formatter.js
@@ -1,48 +1,10 @@
 import expect from 'expect';
 import '../matchers';
-import { createSong, createLine, createItem, createTag } from '../utilities';
 import TextFormatter from '../../src/formatter/text_formatter';
+import song from '../fixtures/song';
 
 describe('TextFormatter', () => {
   it('formats a song to a text chord sheet correctly', () => {
-    // Mimic the following chord sheet:
-    //
-    // {title: Let it be}
-    // {Chorus}
-    //
-    // Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be
-    // [C]Whisper words of [G]wisdom, let it [F]be [C/E] [Dm] [C]
-
-    const song = createSong([
-      createLine([]),
-
-      createLine([
-        createTag('Chorus', '')
-      ]),
-
-      createLine([]),
-
-      createLine([
-        createItem('', 'Let it '),
-        createItem('Am', 'be, let it '),
-        createItem('C/G', 'be, let it '),
-        createItem('F', 'be, let it '),
-        createItem('C', 'be')
-      ]),
-
-      createLine([
-        createItem('C', 'Whisper words of '),
-        createItem('G', 'wisdom, let it '),
-        createItem('F', 'be '),
-        createItem('C/E', ' '),
-        createItem('Dm', ' '),
-        createItem('C', '')
-      ])
-    ], {
-      title: 'Let it be',
-      subtitle: 'ChordSheetJS example version'
-    });
-
     const formatter = new TextFormatter();
 
     const expectedChordSheet = `

--- a/test/formatter/text_formatter.js
+++ b/test/formatter/text_formatter.js
@@ -2,10 +2,6 @@ import expect from 'expect';
 import '../matchers';
 import { createSong, createLine, createItem, createTag } from '../utilities';
 import TextFormatter from '../../src/formatter/text_formatter';
-import Item from '../../src/chord_sheet/item';
-import Line from '../../src/chord_sheet/line';
-import Song from '../../src/chord_sheet/song';
-import Tag from '../../src/chord_sheet/tag';
 
 describe('TextFormatter', () => {
   it('formats a song to a text chord sheet correctly', () => {


### PR DESCRIPTION
Add basic test coverage for `HtmlFormatter`.

The `HtmlFormatter` ignores tags for now, including `title` and `subtitle`.