### PR TITLE
Automatically translate tag alias to full tag name

### DIFF
--- a/src/chord_sheet/tag.js
+++ b/src/chord_sheet/tag.js
@@ -1,8 +1,21 @@
 const META_TAGS = ['title', 'subtitle'];
 
+const ALIASES = {
+  t: 'title',
+  st: 'subtitle'
+};
+
+const translateTagNameAlias = function (name) {
+  if (name in ALIASES) {
+    return ALIASES[name];
+  }
+
+  return name;
+};
+
 export default class Tag {
   constructor(name, value) {
-    this._name = name;
+    this._name = translateTagNameAlias(name);
     this._value = value;
   }
 

--- a/test/chord_sheet/tag.js
+++ b/test/chord_sheet/tag.js
@@ -1,0 +1,17 @@
+import expect from 'expect';
+import Tag from '../../src/chord_sheet/tag';
+
+describe('Tag', () => {
+  it('translates tag aliases to their full tag name', () => {
+    const expectedAliases = {
+      t: 'title',
+      st: 'subtitle'
+    };
+
+    for (const alias in expectedAliases) {
+      const fullTagName = expectedAliases[alias];
+      expect(new Tag(fullTagName, 'value').name).toEqual(fullTagName);
+      expect(new Tag(alias, 'value').name).toEqual(fullTagName);
+    }
+  });
+});


### PR DESCRIPTION
Automatically translate tag alias to full tag name.

The current supported tags are `title` and `subtitle`. They can now also be used by their aliases: `t` and `st`.