### PR TITLE
Ignore comments when parsing

### DIFF
--- a/src/parser/chord_pro_parser.js
+++ b/src/parser/chord_pro_parser.js
@@ -6,6 +6,7 @@ const SQUARE_END = ']';
 const CURLY_START = '{';
 const CURLY_END = '}';
 const COLON = ':';
+const SHARP_SIGN = '#';
 
 export default class ChordProParser {
   parse(document) {
@@ -24,6 +25,9 @@ export default class ChordProParser {
 
   readLyrics(chr) {
     switch (chr) {
+      case SHARP_SIGN:
+        this.processor = this.readComment;
+        break;
       case NEW_LINE:
         this.song.addLine();
         break;
@@ -75,6 +79,14 @@ export default class ChordProParser {
         break;
       default:
         this.tagValue += chr;
+    }
+  }
+
+  readComment(chr) {
+    switch (chr) {
+      case NEW_LINE:
+        this.processor = this.readLyrics;
+        break;
     }
   }
 

--- a/test/parser/chord_pro_parser.js
+++ b/test/parser/chord_pro_parser.js
@@ -12,14 +12,10 @@ Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be
 
 describe('ChordProParser', () => {
   it('parses a ChordPro chord sheet correctly', () => {
-    const parser = new ChordProParser();
-    const song = parser.parse(chordSheet);
+    const song = new ChordProParser().parse(chordSheet);
     const lines = song.lines;
 
     expect(lines.length).toEqual(4);
-
-    expect(song.title).toEqual('Let it be');
-    expect(song.subtitle).toEqual('ChordSheetJS example version');
 
     expect(lines[0].items.length).toEqual(1);
     expect(lines[0].items[0]).toBeTag('Chorus', '');
@@ -40,5 +36,12 @@ describe('ChordProParser', () => {
     expect(lines3Items[3]).toBeItem('C/E', ' ');
     expect(lines3Items[4]).toBeItem('Dm', ' ');
     expect(lines3Items[5]).toBeItem('C', '');
+  });
+
+  it('parses meta data', () => {
+    const song = new ChordProParser().parse(chordSheet);
+
+    expect(song.title).toEqual('Let it be');
+    expect(song.subtitle).toEqual('ChordSheetJS example version');
   });
 });

--- a/test/parser/chord_pro_parser.js
+++ b/test/parser/chord_pro_parser.js
@@ -44,4 +44,11 @@ describe('ChordProParser', () => {
     expect(song.title).toEqual('Let it be');
     expect(song.subtitle).toEqual('ChordSheetJS example version');
   });
+
+  it('ignores comments', () => {
+    const chordSheetWithComment = "# this is a comment\nLet it [Am]be, let it [C/G]be";
+    const song = new ChordProParser().parse(chordSheetWithComment);
+
+    expect(song.lines.length).toEqual(1);
+  });
 });


### PR DESCRIPTION
# Ignore comments when parsing

Comments are treated the same as in most programming languages: when encountering a '#', all characters until the next line feed.

Fixes #13 