### PR TITLE
Rename Item to ChordLyricsPair

### DIFF
--- a/src/chord_sheet/chord_lyrics_pair.js
+++ b/src/chord_sheet/chord_lyrics_pair.js
@@ -1,4 +1,4 @@
-export default class Item {
+export default class ChordLyricsPair {
   constructor() {
     this.chords = '';
     this.lyrics = '';

--- a/src/chord_sheet/line.js
+++ b/src/chord_sheet/line.js
@@ -1,37 +1,37 @@
-import Item from './item';
+import ChordLyricsPair from './chord_lyrics_pair';
 import Tag from './tag';
 import {pushNew} from '../utilities';
 
 export default class Line {
   constructor() {
-    this.items = [];
-    this.currentItem = null;
+    this.chordLyricsPairs = [];
+    this.currentChordLyricsPair = null;
   }
 
-  addItem() {
-    this.currentItem = pushNew(this.items, Item);
-    return this.currentItem;
+  addChordLyricsPair() {
+    this.currentChordLyricsPair = pushNew(this.chordLyricsPairs, ChordLyricsPair);
+    return this.currentChordLyricsPair;
   }
 
-  ensureItem() {
-    if (!this.currentItem) {
-      this.addItem();
+  ensureChordLyricsPair() {
+    if (!this.currentChordLyricsPair) {
+      this.addChordLyricsPair();
     }
   }
 
   chords(chr) {
-    this.ensureItem();
-    this.currentItem.chords += chr;
+    this.ensureChordLyricsPair();
+    this.currentChordLyricsPair.chords += chr;
   }
 
   lyrics(chr) {
-    this.ensureItem();
-    this.currentItem.lyrics += chr;
+    this.ensureChordLyricsPair();
+    this.currentChordLyricsPair.lyrics += chr;
   }
 
   addTag(name, value) {
     const tag = (name instanceof Tag) ? name : new Tag(name, value);
-    this.items.push(tag);
+    this.chordLyricsPairs.push(tag);
     return tag;
   }
 }

--- a/src/chord_sheet/song.js
+++ b/src/chord_sheet/song.js
@@ -26,9 +26,9 @@ export default class Song {
     return this.currentLine;
   }
 
-  addItem() {
+  addChordLyricsPair() {
     this.ensureLine();
-    return this.currentLine.addItem();
+    return this.currentLine.addChordLyricsPair();
   }
 
   dropLine() {

--- a/src/formatter/chord_pro_formatter.js
+++ b/src/formatter/chord_pro_formatter.js
@@ -8,12 +8,12 @@ export default class ChordProFormatter extends FormatterBase {
     this.dirtyLine = false;
   }
 
-  formatItem(item) {
-    if (item.chords) {
-      this.output('[' + item.chords + ']');
+  formatChordLyricsPair(chordLyricsPair) {
+    if (chordLyricsPair.chords) {
+      this.output('[' + chordLyricsPair.chords + ']');
     }
     
-    this.output(item.lyrics);
+    this.output(chordLyricsPair.lyrics);
     this.dirtyLine = true;
   }
 

--- a/src/parser/chord_pro_parser.js
+++ b/src/parser/chord_pro_parser.js
@@ -32,7 +32,7 @@ export default class ChordProParser {
         this.song.addLine();
         break;
       case SQUARE_START:
-        this.song.addItem();
+        this.song.addChordLyricsPair();
         this.processor = this.readChords;
         break;
       case CURLY_START:

--- a/src/parser/chord_sheet_parser.js
+++ b/src/parser/chord_sheet_parser.js
@@ -19,15 +19,15 @@ export default class ChordSheetParser {
     this.songLine = this.song.addLine();
 
     if (line.trim().length === 0) {
-      this.songItem = null;
+      this.chordLyricsPair = null;
     } else {
-      this.songItem = this.songLine.addItem();
+      this.chordLyricsPair = this.songLine.addChordLyricsPair();
 
       if (CHORD_LINE_REGEX.test(line) && this.hasNextLine()) {
         const nextLine = this.readLine();
         this.parseLyricsWithChords(line, nextLine);
       } else {
-        this.songItem.lyrics = line + '';
+        this.chordLyricsPair.lyrics = line + '';
       }
     }
   }
@@ -53,10 +53,10 @@ export default class ChordSheetParser {
   parseLyricsWithChords(line, nextLine) {
     this.processCharacters(line, nextLine);
 
-    this.songItem.lyrics += nextLine.substring(line.length);
+    this.chordLyricsPair.lyrics += nextLine.substring(line.length);
 
-    this.songItem.chords = this.songItem.chords.trim();
-    this.songItem.lyrics = this.songItem.lyrics.trim();
+    this.chordLyricsPair.chords = this.chordLyricsPair.chords.trim();
+    this.chordLyricsPair.lyrics = this.chordLyricsPair.lyrics.trim();
 
     if (!nextLine.trim().length) {
       this.songLine = this.song.addLine();
@@ -70,17 +70,17 @@ export default class ChordSheetParser {
       if (WHITE_SPACE.test(chr)) {
         this.processingText = false;
       } else {
-        this.ensureItemInitialized();
-        this.songItem.chords += chr;
+        this.ensureChordLyricsPairInitialized();
+        this.chordLyricsPair.chords += chr;
       }
 
-      this.songItem.lyrics += nextLine[c] || '';
+      this.chordLyricsPair.lyrics += nextLine[c] || '';
     }
   }
 
-  ensureItemInitialized() {
+  ensureChordLyricsPairInitialized() {
     if (!this.processingText) {
-      this.songItem = this.songLine.addItem();
+      this.chordLyricsPair = this.songLine.addChordLyricsPair();
       this.processingText = true;
     }
   }

--- a/test/fixtures/song.js
+++ b/test/fixtures/song.js
@@ -1,4 +1,4 @@
-import { createSong, createLine, createItem, createTag } from '../utilities';
+import { createSong, createLine, createChordLyricsPair, createTag } from '../utilities';
 
 // Mimic the following chord sheet:
 //
@@ -19,20 +19,20 @@ export default createSong([
   createLine([]),
 
   createLine([
-    createItem('', 'Let it '),
-    createItem('Am', 'be, let it '),
-    createItem('C/G', 'be, let it '),
-    createItem('F', 'be, let it '),
-    createItem('C', 'be')
+    createChordLyricsPair('', 'Let it '),
+    createChordLyricsPair('Am', 'be, let it '),
+    createChordLyricsPair('C/G', 'be, let it '),
+    createChordLyricsPair('F', 'be, let it '),
+    createChordLyricsPair('C', 'be')
   ]),
 
   createLine([
-    createItem('C', 'Whisper words of '),
-    createItem('G', 'wisdom, let it '),
-    createItem('F', 'be '),
-    createItem('C/E', ' '),
-    createItem('Dm', ' '),
-    createItem('C', '')
+    createChordLyricsPair('C', 'Whisper words of '),
+    createChordLyricsPair('G', 'wisdom, let it '),
+    createChordLyricsPair('F', 'be '),
+    createChordLyricsPair('C/E', ' '),
+    createChordLyricsPair('Dm', ' '),
+    createChordLyricsPair('C', '')
   ])
 ], {
   title: 'Let it be',

--- a/test/matchers.js
+++ b/test/matchers.js
@@ -1,10 +1,10 @@
 import expect from 'expect'
-import Item from '../src/chord_sheet/item';
+import ChordLyricsPair from '../src/chord_sheet/chord_lyrics_pair';
 import Tag from '../src/chord_sheet/tag';
 
 expect.extend({
-  toBeItem(chords, lyrics) {
-    expect(this.actual).toBeA(Item);
+  toBeChordLyricsPair(chords, lyrics) {
+    expect(this.actual).toBeA(ChordLyricsPair);
     expect(this.actual.chords).toEqual(chords);
     expect(this.actual.lyrics).toEqual(lyrics);
   },

--- a/test/parser/chord_pro_parser.js
+++ b/test/parser/chord_pro_parser.js
@@ -17,25 +17,25 @@ describe('ChordProParser', () => {
 
     expect(lines.length).toEqual(4);
 
-    expect(lines[0].items.length).toEqual(1);
-    expect(lines[0].items[0]).toBeTag('Chorus', '');
+    expect(lines[0].chordLyricsPairs.length).toEqual(1);
+    expect(lines[0].chordLyricsPairs[0]).toBeTag('Chorus', '');
 
-    expect(lines[1].items.length).toEqual(0);
+    expect(lines[1].chordLyricsPairs.length).toEqual(0);
 
-    const line2Items = lines[2].items;
-    expect(line2Items[0]).toBeItem('', 'Let it ');
-    expect(line2Items[1]).toBeItem('Am', 'be, let it ');
-    expect(line2Items[2]).toBeItem('C/G', 'be, let it ');
-    expect(line2Items[3]).toBeItem('F', 'be, let it ');
-    expect(line2Items[4]).toBeItem('C', 'be');
+    const line2Pairs = lines[2].chordLyricsPairs;
+    expect(line2Pairs[0]).toBeChordLyricsPair('', 'Let it ');
+    expect(line2Pairs[1]).toBeChordLyricsPair('Am', 'be, let it ');
+    expect(line2Pairs[2]).toBeChordLyricsPair('C/G', 'be, let it ');
+    expect(line2Pairs[3]).toBeChordLyricsPair('F', 'be, let it ');
+    expect(line2Pairs[4]).toBeChordLyricsPair('C', 'be');
 
-    const lines3Items = lines[3].items;
-    expect(lines3Items[0]).toBeItem('C', 'Whisper words of ');
-    expect(lines3Items[1]).toBeItem('G', 'wisdom, let it ');
-    expect(lines3Items[2]).toBeItem('F', 'be ');
-    expect(lines3Items[3]).toBeItem('C/E', ' ');
-    expect(lines3Items[4]).toBeItem('Dm', ' ');
-    expect(lines3Items[5]).toBeItem('C', '');
+    const lines3Pairs = lines[3].chordLyricsPairs;
+    expect(lines3Pairs[0]).toBeChordLyricsPair('C', 'Whisper words of ');
+    expect(lines3Pairs[1]).toBeChordLyricsPair('G', 'wisdom, let it ');
+    expect(lines3Pairs[2]).toBeChordLyricsPair('F', 'be ');
+    expect(lines3Pairs[3]).toBeChordLyricsPair('C/E', ' ');
+    expect(lines3Pairs[4]).toBeChordLyricsPair('Dm', ' ');
+    expect(lines3Pairs[5]).toBeChordLyricsPair('C', '');
   });
 
   it('parses meta data', () => {

--- a/test/parser/chord_sheet_parser.js
+++ b/test/parser/chord_sheet_parser.js
@@ -16,19 +16,19 @@ describe('ChordSheetParser', () => {
 
     expect(lines.length).toEqual(2);
 
-    const line0Items = lines[0].items;
-    expect(line0Items[0]).toBeItem('', 'Let it ');
-    expect(line0Items[1]).toBeItem('Am', 'be, let it ');
-    expect(line0Items[2]).toBeItem('C/G', 'be, let it ');
-    expect(line0Items[3]).toBeItem('F', 'be, let it ');
-    expect(line0Items[4]).toBeItem('C', 'be');
+    const line0Pairs = lines[0].chordLyricsPairs;
+    expect(line0Pairs[0]).toBeChordLyricsPair('', 'Let it ');
+    expect(line0Pairs[1]).toBeChordLyricsPair('Am', 'be, let it ');
+    expect(line0Pairs[2]).toBeChordLyricsPair('C/G', 'be, let it ');
+    expect(line0Pairs[3]).toBeChordLyricsPair('F', 'be, let it ');
+    expect(line0Pairs[4]).toBeChordLyricsPair('C', 'be');
 
-    const lines1Items = lines[1].items;
-    expect(lines1Items[0]).toBeItem('C', 'Whisper words of ');
-    expect(lines1Items[1]).toBeItem('G', 'wisdom, let it ');
-    expect(lines1Items[2]).toBeItem('F', 'be');
-    expect(lines1Items[3]).toBeItem('C/E', '');
-    expect(lines1Items[4]).toBeItem('Dm', '');
-    expect(lines1Items[5]).toBeItem('C', '');
+    const line1Pairs = lines[1].chordLyricsPairs;
+    expect(line1Pairs[0]).toBeChordLyricsPair('C', 'Whisper words of ');
+    expect(line1Pairs[1]).toBeChordLyricsPair('G', 'wisdom, let it ');
+    expect(line1Pairs[2]).toBeChordLyricsPair('F', 'be');
+    expect(line1Pairs[3]).toBeChordLyricsPair('C/E', '');
+    expect(line1Pairs[4]).toBeChordLyricsPair('Dm', '');
+    expect(line1Pairs[5]).toBeChordLyricsPair('C', '');
   });
 });

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -1,4 +1,4 @@
-import Item from '../src/chord_sheet/item';
+import ChordLyricsPair from '../src/chord_sheet/chord_lyrics_pair';
 import Line from '../src/chord_sheet/line';
 import Song from '../src/chord_sheet/song';
 import Tag from '../src/chord_sheet/tag';
@@ -15,11 +15,11 @@ export function createLine(items) {
   return line;
 }
 
-export function createItem(chords, lyrics) {
-  const item = new Item();
-  item.chords = chords;
-  item.lyrics = lyrics;
-  return item;
+export function createChordLyricsPair(chords, lyrics) {
+  const chordLyricsPair = new ChordLyricsPair();
+  chordLyricsPair.chords = chords;
+  chordLyricsPair.lyrics = lyrics;
+  return chordLyricsPair;
 }
 
 export function createTag(name, value) {


### PR DESCRIPTION
- it better idicates the purpose; it contains the combination of a chord
  and the lyrics until the next chord
- it removes the confusion between the `Item` class and the `items`
  property on a Line, which both contains instances of `Item` (now
  `ChordLyricsPair`) and `Tag`

Closes #23