### PR TITLE
Add ChordProFormatter

### DIFF
--- a/src/chord_sheet/song.js
+++ b/src/chord_sheet/song.js
@@ -46,11 +46,10 @@ export default class Song {
 
     if (tag.isMetaTag()) {
       this.metaData[tag.name] = tag.value;
-      this.dropLine();
-    } else {
-      this.ensureLine();
-      this.currentLine.addTag(tag);
     }
+
+    this.ensureLine();
+    this.currentLine.addTag(tag);
 
     return tag;
   }

--- a/src/chord_sheet/tag.js
+++ b/src/chord_sheet/tag.js
@@ -15,16 +15,21 @@ const translateTagNameAlias = function (name) {
 
 export default class Tag {
   constructor(name, value) {
-    this._name = translateTagNameAlias(name);
-    this._value = value;
+    this.name = name;
+    this.value = value;
   }
 
   set name(name) {
-    this._name = name;
+    this._name = translateTagNameAlias(name);
+    this._originalName = name;
   }
 
   get name() {
     return this._name.trim();
+  }
+
+  get originalName() {
+    return this._originalName.trim();
   }
 
   set value(value) {
@@ -33,6 +38,10 @@ export default class Tag {
 
   get value() {
     return this._value.trim();
+  }
+
+  hasValue() {
+    return !!this._value.trim().length;
   }
 
   isMetaTag() {

--- a/src/formatter/chord_pro_formatter.js
+++ b/src/formatter/chord_pro_formatter.js
@@ -1,27 +1,40 @@
 import FormatterBase from './formatter_base';
+import Tag from "../chord_sheet/tag";
 
 const NEW_LINE = '\n';
 
 export default class ChordProFormatter extends FormatterBase {
   constructor() {
     super();
-    this.dirtyLine = false;
   }
 
-  formatChordLyricsPair(chordLyricsPair) {
-    if (chordLyricsPair.chords) {
-      this.output('[' + chordLyricsPair.chords + ']');
+  formatItem(item) {
+    if (item instanceof Tag) {
+      this.output(this.formatTag(item));
+    } else {
+      if (item.chords) {
+        this.output('[' + item.chords + ']');
+      }
+
+      if (item.lyrics) {
+        this.output(item.lyrics);
+      }
     }
-    
-    this.output(chordLyricsPair.lyrics);
-    this.dirtyLine = true;
   }
 
-  endOfSong() {
-    this.newLine();
+  formatTag(tag) {
+    if (tag.hasValue()) {
+      return `{${tag.originalName}: ${tag.value}}`;
+    }
+
+    return `{${tag.originalName}}`;
   }
+
+  endOfSong() { }
 
   newLine() {
-    this.output(NEW_LINE);
+    if (this.stringOutput) {
+      this.output(NEW_LINE);
+    }
   }
 }

--- a/src/formatter/text_formatter.js
+++ b/src/formatter/text_formatter.js
@@ -62,8 +62,11 @@ export default class TextFormatter extends FormatterBase {
 
   formatItem(item) {
     if (item instanceof Tag) {
-      this.lyricsLine += this.formatTag(item);
-      this.dirtyLine = true;
+      if (!item.isMetaTag()) {
+        this.lyricsLine += this.formatTag(item);
+        this.dirtyLine = true;
+      }
+
       return;
     }
 

--- a/test/chord_sheet/tag.js
+++ b/test/chord_sheet/tag.js
@@ -2,16 +2,32 @@ import expect from 'expect';
 import Tag from '../../src/chord_sheet/tag';
 
 describe('Tag', () => {
-  it('translates tag aliases to their full tag name', () => {
-    const expectedAliases = {
-      t: 'title',
-      st: 'subtitle'
-    };
+  const expectedAliases = {
+    t: 'title',
+    st: 'subtitle'
+  };
 
+  it('translates tag aliases to their full tag name', () => {
     for (const alias in expectedAliases) {
       const fullTagName = expectedAliases[alias];
       expect(new Tag(fullTagName, 'value').name).toEqual(fullTagName);
       expect(new Tag(alias, 'value').name).toEqual(fullTagName);
     }
+  });
+
+  describe('#originalName', () => {
+    it('returns the non-translated name', () => {
+      for (const alias in expectedAliases) {
+        expect(new Tag(alias, 'value').originalName).toEqual(alias);
+      }
+    });
+  });
+
+  describe('#hasValue', () => {
+    it('checks whether the tag value is present', () => {
+      expect(new Tag('foo', '').hasValue()).toBe(false);
+      expect(new Tag('foo', '  ').hasValue()).toBe(false);
+      expect(new Tag('foo', 'bar').hasValue()).toBe(true);
+    });
   });
 });

--- a/test/fixtures/song.js
+++ b/test/fixtures/song.js
@@ -1,7 +1,6 @@
 import { createSong, createLine, createChordLyricsPair, createTag } from '../utilities';
 
 // Mimic the following chord sheet:
-//
 // {title: Let it be}
 // {subtitle: ChordSheetJS example version}
 // {Chorus}
@@ -10,7 +9,13 @@ import { createSong, createLine, createChordLyricsPair, createTag } from '../uti
 // [C]Whisper words of [G]wisdom, let it [F]be [C/E] [Dm] [C]
 
 export default createSong([
-  createLine([]),
+  createLine([
+    createTag('title', 'Let it be')
+  ]),
+
+  createLine([
+    createTag('subtitle', 'ChordSheetJS example version')
+  ]),
 
   createLine([
     createTag('Chorus', '')

--- a/test/formatter/chord_pro_formatter.js
+++ b/test/formatter/chord_pro_formatter.js
@@ -1,0 +1,19 @@
+import expect from 'expect';
+import ChordProFormatter from '../../src/formatter/chord_pro_formatter';
+import song from '../fixtures/song';
+
+describe('ChordProFormatter', () => {
+  it('formats a song to a html chord sheet correctly', () => {
+    const formatter = new ChordProFormatter();
+
+    const expectedChordSheet = `
+{title: Let it be}
+{subtitle: ChordSheetJS example version}
+{Chorus}
+
+Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be
+[C]Whisper words of [G]wisdom, let it [F]be [C/E] [Dm] [C]`.substring(1);
+
+    expect(formatter.format(song)).toEqual(expectedChordSheet);
+  });
+});

--- a/test/parser/chord_pro_parser.js
+++ b/test/parser/chord_pro_parser.js
@@ -15,27 +15,33 @@ describe('ChordProParser', () => {
     const song = new ChordProParser().parse(chordSheet);
     const lines = song.lines;
 
-    expect(lines.length).toEqual(4);
+    expect(lines.length).toEqual(6);
 
     expect(lines[0].chordLyricsPairs.length).toEqual(1);
-    expect(lines[0].chordLyricsPairs[0]).toBeTag('Chorus', '');
+    expect(lines[0].chordLyricsPairs[0]).toBeTag('title', 'Let it be');
 
-    expect(lines[1].chordLyricsPairs.length).toEqual(0);
+    expect(lines[1].chordLyricsPairs.length).toEqual(1);
+    expect(lines[1].chordLyricsPairs[0]).toBeTag('subtitle', 'ChordSheetJS example version');
 
-    const line2Pairs = lines[2].chordLyricsPairs;
-    expect(line2Pairs[0]).toBeChordLyricsPair('', 'Let it ');
-    expect(line2Pairs[1]).toBeChordLyricsPair('Am', 'be, let it ');
-    expect(line2Pairs[2]).toBeChordLyricsPair('C/G', 'be, let it ');
-    expect(line2Pairs[3]).toBeChordLyricsPair('F', 'be, let it ');
-    expect(line2Pairs[4]).toBeChordLyricsPair('C', 'be');
+    expect(lines[2].chordLyricsPairs.length).toEqual(1);
+    expect(lines[2].chordLyricsPairs[0]).toBeTag('Chorus', '');
 
-    const lines3Pairs = lines[3].chordLyricsPairs;
-    expect(lines3Pairs[0]).toBeChordLyricsPair('C', 'Whisper words of ');
-    expect(lines3Pairs[1]).toBeChordLyricsPair('G', 'wisdom, let it ');
-    expect(lines3Pairs[2]).toBeChordLyricsPair('F', 'be ');
-    expect(lines3Pairs[3]).toBeChordLyricsPair('C/E', ' ');
-    expect(lines3Pairs[4]).toBeChordLyricsPair('Dm', ' ');
-    expect(lines3Pairs[5]).toBeChordLyricsPair('C', '');
+    expect(lines[3].chordLyricsPairs.length).toEqual(0);
+
+    const line4Pairs = lines[4].chordLyricsPairs;
+    expect(line4Pairs[0]).toBeChordLyricsPair('', 'Let it ');
+    expect(line4Pairs[1]).toBeChordLyricsPair('Am', 'be, let it ');
+    expect(line4Pairs[2]).toBeChordLyricsPair('C/G', 'be, let it ');
+    expect(line4Pairs[3]).toBeChordLyricsPair('F', 'be, let it ');
+    expect(line4Pairs[4]).toBeChordLyricsPair('C', 'be');
+
+    const lines5Pairs = lines[5].chordLyricsPairs;
+    expect(lines5Pairs[0]).toBeChordLyricsPair('C', 'Whisper words of ');
+    expect(lines5Pairs[1]).toBeChordLyricsPair('G', 'wisdom, let it ');
+    expect(lines5Pairs[2]).toBeChordLyricsPair('F', 'be ');
+    expect(lines5Pairs[3]).toBeChordLyricsPair('C/E', ' ');
+    expect(lines5Pairs[4]).toBeChordLyricsPair('Dm', ' ');
+    expect(lines5Pairs[5]).toBeChordLyricsPair('C', '');
   });
 
   it('parses meta data', () => {


### PR DESCRIPTION
In order to perform transformations like modulations there should be a ChordProFormatter to convert a edited song back to ChordPro format.

Fixes #26 