### PR TITLE
Expose parsed value objects

### DIFF
--- a/src/chordsheet.js
+++ b/src/chordsheet.js
@@ -3,5 +3,19 @@ import ChordSheetParser from './parser/chord_sheet_parser';
 import TextFormatter from './formatter/text_formatter';
 import HtmlFormatter from './formatter/html_formatter';
 import ChordProFormatter from './formatter/chord_pro_formatter';
+import ChordLyricsPair from './chord_sheet/chord_lyrics_pair';
+import Line from './chord_sheet/line';
+import Song from './chord_sheet/song';
+import Tag from './chord_sheet/tag';
 
-export default {ChordProParser, ChordSheetParser, TextFormatter, HtmlFormatter, ChordProFormatter};
+export default {
+  ChordProParser,
+  ChordSheetParser,
+  TextFormatter,
+  HtmlFormatter,
+  ChordProFormatter,
+  ChordLyricsPair,
+  Line,
+  Song,
+  Tag
+};


### PR DESCRIPTION
In order to use a parsed song from outside the package, the classes need to be exported in order to import them.