### PR TITLE
Rename Line#chordLyricsPairs to items

### DIFF
--- a/src/chord_sheet/line.js
+++ b/src/chord_sheet/line.js
@@ -4,12 +4,12 @@ import {pushNew} from '../utilities';
 
 export default class Line {
   constructor() {
-    this.chordLyricsPairs = [];
+    this.items = [];
     this.currentChordLyricsPair = null;
   }
 
   addChordLyricsPair() {
-    this.currentChordLyricsPair = pushNew(this.chordLyricsPairs, ChordLyricsPair);
+    this.currentChordLyricsPair = pushNew(this.items, ChordLyricsPair);
     return this.currentChordLyricsPair;
   }
 
@@ -31,7 +31,7 @@ export default class Line {
 
   addTag(name, value) {
     const tag = (name instanceof Tag) ? name : new Tag(name, value);
-    this.chordLyricsPairs.push(tag);
+    this.items.push(tag);
     return tag;
   }
 }

--- a/test/parser/chord_pro_parser.js
+++ b/test/parser/chord_pro_parser.js
@@ -17,25 +17,25 @@ describe('ChordProParser', () => {
 
     expect(lines.length).toEqual(6);
 
-    expect(lines[0].chordLyricsPairs.length).toEqual(1);
-    expect(lines[0].chordLyricsPairs[0]).toBeTag('title', 'Let it be');
+    expect(lines[0].items.length).toEqual(1);
+    expect(lines[0].items[0]).toBeTag('title', 'Let it be');
 
-    expect(lines[1].chordLyricsPairs.length).toEqual(1);
-    expect(lines[1].chordLyricsPairs[0]).toBeTag('subtitle', 'ChordSheetJS example version');
+    expect(lines[1].items.length).toEqual(1);
+    expect(lines[1].items[0]).toBeTag('subtitle', 'ChordSheetJS example version');
 
-    expect(lines[2].chordLyricsPairs.length).toEqual(1);
-    expect(lines[2].chordLyricsPairs[0]).toBeTag('Chorus', '');
+    expect(lines[2].items.length).toEqual(1);
+    expect(lines[2].items[0]).toBeTag('Chorus', '');
 
-    expect(lines[3].chordLyricsPairs.length).toEqual(0);
+    expect(lines[3].items.length).toEqual(0);
 
-    const line4Pairs = lines[4].chordLyricsPairs;
+    const line4Pairs = lines[4].items;
     expect(line4Pairs[0]).toBeChordLyricsPair('', 'Let it ');
     expect(line4Pairs[1]).toBeChordLyricsPair('Am', 'be, let it ');
     expect(line4Pairs[2]).toBeChordLyricsPair('C/G', 'be, let it ');
     expect(line4Pairs[3]).toBeChordLyricsPair('F', 'be, let it ');
     expect(line4Pairs[4]).toBeChordLyricsPair('C', 'be');
 
-    const lines5Pairs = lines[5].chordLyricsPairs;
+    const lines5Pairs = lines[5].items;
     expect(lines5Pairs[0]).toBeChordLyricsPair('C', 'Whisper words of ');
     expect(lines5Pairs[1]).toBeChordLyricsPair('G', 'wisdom, let it ');
     expect(lines5Pairs[2]).toBeChordLyricsPair('F', 'be ');

--- a/test/parser/chord_sheet_parser.js
+++ b/test/parser/chord_sheet_parser.js
@@ -16,19 +16,19 @@ describe('ChordSheetParser', () => {
 
     expect(lines.length).toEqual(2);
 
-    const line0Pairs = lines[0].chordLyricsPairs;
-    expect(line0Pairs[0]).toBeChordLyricsPair('', 'Let it ');
-    expect(line0Pairs[1]).toBeChordLyricsPair('Am', 'be, let it ');
-    expect(line0Pairs[2]).toBeChordLyricsPair('C/G', 'be, let it ');
-    expect(line0Pairs[3]).toBeChordLyricsPair('F', 'be, let it ');
-    expect(line0Pairs[4]).toBeChordLyricsPair('C', 'be');
+    const line0Items = lines[0].items;
+    expect(line0Items[0]).toBeChordLyricsPair('', 'Let it ');
+    expect(line0Items[1]).toBeChordLyricsPair('Am', 'be, let it ');
+    expect(line0Items[2]).toBeChordLyricsPair('C/G', 'be, let it ');
+    expect(line0Items[3]).toBeChordLyricsPair('F', 'be, let it ');
+    expect(line0Items[4]).toBeChordLyricsPair('C', 'be');
 
-    const line1Pairs = lines[1].chordLyricsPairs;
-    expect(line1Pairs[0]).toBeChordLyricsPair('C', 'Whisper words of ');
-    expect(line1Pairs[1]).toBeChordLyricsPair('G', 'wisdom, let it ');
-    expect(line1Pairs[2]).toBeChordLyricsPair('F', 'be');
-    expect(line1Pairs[3]).toBeChordLyricsPair('C/E', '');
-    expect(line1Pairs[4]).toBeChordLyricsPair('Dm', '');
-    expect(line1Pairs[5]).toBeChordLyricsPair('C', '');
+    const line1Items = lines[1].items;
+    expect(line1Items[0]).toBeChordLyricsPair('C', 'Whisper words of ');
+    expect(line1Items[1]).toBeChordLyricsPair('G', 'wisdom, let it ');
+    expect(line1Items[2]).toBeChordLyricsPair('F', 'be');
+    expect(line1Items[3]).toBeChordLyricsPair('C/E', '');
+    expect(line1Items[4]).toBeChordLyricsPair('Dm', '');
+    expect(line1Items[5]).toBeChordLyricsPair('C', '');
   });
 });


### PR DESCRIPTION
It can hold both instances of ChordLyricsPair and Tag, so the name has
to be more generic