### PR TITLE
Obey white space

### DIFF
--- a/src/parser/chord_sheet_parser.js
+++ b/src/parser/chord_sheet_parser.js
@@ -37,7 +37,7 @@ export default class ChordSheetParser {
     this.lines = document.split("\n");
     this.currentLine = 0;
     this.lineCount = this.lines.length;
-    this.processingText = false;
+    this.processingText = true;
   }
 
   readLine() {
@@ -66,11 +66,16 @@ export default class ChordSheetParser {
   processCharacters(line, nextLine) {
     for (let c = 0, charCount = line.length; c < charCount; c++) {
       const chr = line[c];
+      const nextChar = line[c + 1];
+      const isWhiteSpace = WHITE_SPACE.test(chr);
 
-      if (WHITE_SPACE.test(chr)) {
+      if (isWhiteSpace) {
         this.processingText = false;
       } else {
         this.ensureChordLyricsPairInitialized();
+      }
+
+      if (!isWhiteSpace || (nextChar && WHITE_SPACE.test(nextChar))) {
         this.chordLyricsPair.chords += chr;
       }
 

--- a/src/parser/chord_sheet_parser.js
+++ b/src/parser/chord_sheet_parser.js
@@ -50,37 +50,45 @@ export default class ChordSheetParser {
     return this.currentLine < this.lineCount;
   }
 
-  parseLyricsWithChords(line, nextLine) {
-    this.processCharacters(line, nextLine);
+  parseLyricsWithChords(chordsLine, lyricsLine) {
+    this.processCharacters(chordsLine, lyricsLine);
 
-    this.chordLyricsPair.lyrics += nextLine.substring(line.length);
+    this.chordLyricsPair.lyrics += lyricsLine.substring(chordsLine.length);
 
     this.chordLyricsPair.chords = this.chordLyricsPair.chords.trim();
     this.chordLyricsPair.lyrics = this.chordLyricsPair.lyrics.trim();
 
-    if (!nextLine.trim().length) {
+    if (!lyricsLine.trim().length) {
       this.songLine = this.song.addLine();
     }
   }
 
-  processCharacters(line, nextLine) {
-    for (let c = 0, charCount = line.length; c < charCount; c++) {
-      const chr = line[c];
-      const nextChar = line[c + 1];
+  processCharacters(chordsLine, lyricsLine) {
+    for (let c = 0, charCount = chordsLine.length; c < charCount; c++) {
+      const chr = chordsLine[c];
+      const nextChar = chordsLine[c + 1];
       const isWhiteSpace = WHITE_SPACE.test(chr);
+      this.addCharacter(chr, nextChar);
 
-      if (isWhiteSpace) {
-        this.processingText = false;
-      } else {
-        this.ensureChordLyricsPairInitialized();
-      }
-
-      if (!isWhiteSpace || (nextChar && WHITE_SPACE.test(nextChar))) {
-        this.chordLyricsPair.chords += chr;
-      }
-
-      this.chordLyricsPair.lyrics += nextLine[c] || '';
+      this.chordLyricsPair.lyrics += lyricsLine[c] || '';
+      this.processingText = !isWhiteSpace;
     }
+  }
+
+  addCharacter(chr, nextChar) {
+    const isWhiteSpace = WHITE_SPACE.test(chr);
+
+    if (!isWhiteSpace) {
+      this.ensureChordLyricsPairInitialized();
+    }
+
+    if (!isWhiteSpace || this.shouldAddCharacterToChords(nextChar)) {
+      this.chordLyricsPair.chords += chr;
+    }
+  }
+
+  shouldAddCharacterToChords(nextChar) {
+    return (nextChar && WHITE_SPACE.test(nextChar));
   }
 
   ensureChordLyricsPairInitialized() {

--- a/test/parser/chord_sheet_parser.js
+++ b/test/parser/chord_sheet_parser.js
@@ -17,16 +17,16 @@ describe('ChordSheetParser', () => {
     expect(lines.length).toEqual(2);
 
     const line0Items = lines[0].items;
-    expect(line0Items[0]).toBeChordLyricsPair('', 'Let it ');
-    expect(line0Items[1]).toBeChordLyricsPair('Am', 'be, let it ');
-    expect(line0Items[2]).toBeChordLyricsPair('C/G', 'be, let it ');
-    expect(line0Items[3]).toBeChordLyricsPair('F', 'be, let it ');
+    expect(line0Items[0]).toBeChordLyricsPair('      ', 'Let it ');
+    expect(line0Items[1]).toBeChordLyricsPair('Am        ', 'be, let it ');
+    expect(line0Items[2]).toBeChordLyricsPair('C/G       ', 'be, let it ');
+    expect(line0Items[3]).toBeChordLyricsPair('F         ', 'be, let it ');
     expect(line0Items[4]).toBeChordLyricsPair('C', 'be');
 
     const line1Items = lines[1].items;
-    expect(line1Items[0]).toBeChordLyricsPair('C', 'Whisper words of ');
-    expect(line1Items[1]).toBeChordLyricsPair('G', 'wisdom, let it ');
-    expect(line1Items[2]).toBeChordLyricsPair('F', 'be');
+    expect(line1Items[0]).toBeChordLyricsPair('C               ', 'Whisper words of ');
+    expect(line1Items[1]).toBeChordLyricsPair('G             ', 'wisdom, let it ');
+    expect(line1Items[2]).toBeChordLyricsPair('F ', 'be');
     expect(line1Items[3]).toBeChordLyricsPair('C/E', '');
     expect(line1Items[4]).toBeChordLyricsPair('Dm', '');
     expect(line1Items[5]).toBeChordLyricsPair('C', '');


### PR DESCRIPTION
This PR fixes the way white space is parsed and formatted.

# Changes for `ChordSheetParser`:

```
C                G
Whisper words of wisdom
```

There are 15 spaces between the C and G chord. Parsing this will return
the first pair as a C and 14 spaces. Keeping the white space is
important when the line ends with some chords having multiple spaces in
between, like this:

```
C                G              F  C/E Dm          C
Whisper words of wisdom, let it be
```

The white space between Dm and C is important for formatting purposes.

Fixes #35 