### PR TITLE
Add responsive html formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,17 @@ const disp = formatter.format(song);
 
 #### HTML format
 
+##### Table-based layout
+
 ```javascript
-const formatter = new ChordSheetJS.HtmlFormatter();
+const formatter = new ChordSheetJS.HtmlTableFormatter();
+const disp = formatter.format(song);
+```
+
+##### Div-based layout
+
+```javascript
+const formatter = new ChordSheetJS.HtmlDivFormatter();
 const disp = formatter.format(song);
 ```
 

--- a/src/chordsheet.js
+++ b/src/chordsheet.js
@@ -1,7 +1,8 @@
 import ChordProParser from './parser/chord_pro_parser';
 import ChordSheetParser from './parser/chord_sheet_parser';
 import TextFormatter from './formatter/text_formatter';
-import HtmlFormatter from './formatter/html_formatter';
+import HtmlTableFormatter from './formatter/html_table_formatter';
+import HtmlDivFormatter from './formatter/html_div_formatter';
 import ChordProFormatter from './formatter/chord_pro_formatter';
 import ChordLyricsPair from './chord_sheet/chord_lyrics_pair';
 import Line from './chord_sheet/line';
@@ -12,7 +13,8 @@ export default {
   ChordProParser,
   ChordSheetParser,
   TextFormatter,
-  HtmlFormatter,
+  HtmlTableFormatter,
+  HtmlDivFormatter,
   ChordProFormatter,
   ChordLyricsPair,
   Line,

--- a/src/formatter/formatter_base.js
+++ b/src/formatter/formatter_base.js
@@ -9,6 +9,7 @@ export default class FormatterBase {
 
   format(song) {
     this.formatMetaData(song);
+    this.startOfSong();
 
     song.lines.forEach((line) => {
       this.newLine();
@@ -23,4 +24,6 @@ export default class FormatterBase {
   }
 
   formatMetaData(name, value) { }
+  startOfSong() { }
+  endOfSong() { }
 }

--- a/src/formatter/html_div_formatter.js
+++ b/src/formatter/html_div_formatter.js
@@ -1,0 +1,79 @@
+import HtmlFormatter from './html_formatter';
+import Tag from '../chord_sheet/tag';
+
+const SPACE = '&nbsp;';
+
+export default class HtmlDivFormatter extends HtmlFormatter {
+  constructor() {
+    super();
+    this.line = '';
+  }
+
+  outputSong(song) {
+    return this.div('chord-sheet', song);
+  }
+
+  startOfSong() {
+    super.startOfSong();
+    this.output('<div class="chord-sheet">');
+  }
+
+  endOfSong() {
+    super.endOfSong();
+    this.output('</div>');
+  }
+
+  formatItem(item) {
+    if (item instanceof Tag) {
+      return;
+    }
+
+    let chords = item.chords.trim();
+    let lyrics = item.lyrics.trim();
+
+    if (chords.length || lyrics.length) {
+      if (chords.length > lyrics.length) {
+        chords += SPACE;
+      } else if (lyrics.length > chords.length) {
+        lyrics += SPACE;
+      }
+
+      this.line += this.column(this.chord(chords) + this.lyrics(lyrics));
+    }
+
+    this.dirtyLine = true;
+  }
+
+  finishLine() {
+    const row = this.row(this.line);
+    this.output(row);
+    this.line = '';
+  }
+
+  chord(chord) {
+    return this.div('chord', chord);
+  }
+
+  lyrics(lyrics) {
+    return this.div('lyrics', lyrics);
+  }
+
+  div(cssClasses, value) {
+    const attr = cssClasses ? ` class="${cssClasses}"` : '';
+    return `<div${attr}>${value}</div>`;
+  }
+
+  column(contents) {
+    return this.div('column', contents);
+  }
+
+  row(contents) {
+    let cssClasses = 'row';
+
+    if (!contents) {
+      cssClasses += ' empty-line';
+    }
+
+    return this.div(cssClasses, contents);
+  }
+}

--- a/src/formatter/html_div_formatter.js
+++ b/src/formatter/html_div_formatter.js
@@ -1,7 +1,4 @@
 import HtmlFormatter from './html_formatter';
-import Tag from '../chord_sheet/tag';
-
-const SPACE = '&nbsp;';
 
 export default class HtmlDivFormatter extends HtmlFormatter {
   constructor() {
@@ -23,25 +20,8 @@ export default class HtmlDivFormatter extends HtmlFormatter {
     this.output('</div>');
   }
 
-  formatItem(item) {
-    if (item instanceof Tag) {
-      return;
-    }
-
-    let chords = item.chords.trim();
-    let lyrics = item.lyrics.trim();
-
-    if (chords.length || lyrics.length) {
-      if (chords.length > lyrics.length) {
-        chords += SPACE;
-      } else if (lyrics.length > chords.length) {
-        lyrics += SPACE;
-      }
-
-      this.line += this.column(this.chord(chords) + this.lyrics(lyrics));
-    }
-
-    this.dirtyLine = true;
+  outputPair(chords, lyrics) {
+    this.line += this.column(this.chord(chords) + this.lyrics(lyrics));
   }
 
   finishLine() {

--- a/src/formatter/html_formatter.js
+++ b/src/formatter/html_formatter.js
@@ -1,15 +1,10 @@
 import FormatterBase from './formatter_base';
-import Tag from "../chord_sheet/tag";
-
-const SPACE = '&nbsp;';
 
 export default class HtmlFormatter extends FormatterBase {
   constructor() {
     super();
     this.dirtyLine = false;
     this.lineEmpty = true;
-    this.chordsLine = '';
-    this.lyricsLine = '';
   }
 
   formatMetaData(song) {
@@ -22,35 +17,6 @@ export default class HtmlFormatter extends FormatterBase {
     }
   }
 
-  formatItem(item) {
-    if (item instanceof Tag) {
-      return;
-    }
-
-    let chords = item.chords.trim();
-    let lyrics = item.lyrics.trim();
-
-    if (chords.length || lyrics.length) {
-      if (chords.length > lyrics.length) {
-        chords += SPACE;
-      } else if (lyrics.length > chords.length) {
-        lyrics += SPACE;
-      }
-
-      this.chordsLine += this.cell('chord', chords);
-      this.lyricsLine += this.cell('lyrics', lyrics);
-    }
-
-    this.dirtyLine = true;
-  }
-
-  finishLine() {
-    const rows = this.row(this.chordsLine) + this.row(this.lyricsLine);
-    this.output(this.table(rows));
-    this.chordsLine = '';
-    this.lyricsLine = '';
-  }
-
   newLine() {
     if (this.dirtyLine) {
       this.finishLine();
@@ -61,18 +27,5 @@ export default class HtmlFormatter extends FormatterBase {
     if (this.dirtyLine) {
       this.finishLine();
     }
-  }
-
-  cell(cssClass, value) {
-    return `<td class="${cssClass}">${value}</td>`;
-  }
-
-  row(contents) {
-    const attr = contents ? '' : ' class="empty-line"'
-    return `<tr${attr}>${contents}</tr>`;
-  }
-
-  table(contents) {
-    return `<table>${contents}</table>`;
   }
 }

--- a/src/formatter/html_formatter.js
+++ b/src/formatter/html_formatter.js
@@ -1,10 +1,34 @@
 import FormatterBase from './formatter_base';
+import Tag from '../chord_sheet/tag';
+
+const SPACE = '&nbsp;';
 
 export default class HtmlFormatter extends FormatterBase {
   constructor() {
     super();
     this.dirtyLine = false;
     this.lineEmpty = true;
+  }
+
+  formatItem(item) {
+    if (item instanceof Tag) {
+      return;
+    }
+
+    let chords = item.chords.trim();
+    let lyrics = item.lyrics.trim();
+
+    if (chords.length || lyrics.length) {
+      if (chords.length > lyrics.length) {
+        chords += SPACE;
+      } else if (lyrics.length > chords.length) {
+        lyrics += SPACE;
+      }
+
+      this.outputPair(chords, lyrics);
+    }
+
+    this.dirtyLine = true;
   }
 
   formatMetaData(song) {

--- a/src/formatter/html_table_formatter.js
+++ b/src/formatter/html_table_formatter.js
@@ -1,7 +1,4 @@
 import HtmlFormatter from './html_formatter';
-import Tag from "../chord_sheet/tag";
-
-const SPACE = '&nbsp;';
 
 export default class HtmlTableFormatter extends HtmlFormatter {
   constructor() {
@@ -10,26 +7,9 @@ export default class HtmlTableFormatter extends HtmlFormatter {
     this.lyricsLine = '';
   }
 
-  formatItem(item) {
-    if (item instanceof Tag) {
-      return;
-    }
-
-    let chords = item.chords.trim();
-    let lyrics = item.lyrics.trim();
-
-    if (chords.length || lyrics.length) {
-      if (chords.length > lyrics.length) {
-        chords += SPACE;
-      } else if (lyrics.length > chords.length) {
-        lyrics += SPACE;
-      }
-
-      this.chordsLine += this.cell('chord', chords);
-      this.lyricsLine += this.cell('lyrics', lyrics);
-    }
-
-    this.dirtyLine = true;
+  outputPair(chords, lyrics) {
+    this.chordsLine += this.cell('chord', chords);
+    this.lyricsLine += this.cell('lyrics', lyrics);
   }
 
   finishLine() {

--- a/src/formatter/html_table_formatter.js
+++ b/src/formatter/html_table_formatter.js
@@ -1,0 +1,54 @@
+import HtmlFormatter from './html_formatter';
+import Tag from "../chord_sheet/tag";
+
+const SPACE = '&nbsp;';
+
+export default class HtmlTableFormatter extends HtmlFormatter {
+  constructor() {
+    super();
+    this.chordsLine = '';
+    this.lyricsLine = '';
+  }
+
+  formatItem(item) {
+    if (item instanceof Tag) {
+      return;
+    }
+
+    let chords = item.chords.trim();
+    let lyrics = item.lyrics.trim();
+
+    if (chords.length || lyrics.length) {
+      if (chords.length > lyrics.length) {
+        chords += SPACE;
+      } else if (lyrics.length > chords.length) {
+        lyrics += SPACE;
+      }
+
+      this.chordsLine += this.cell('chord', chords);
+      this.lyricsLine += this.cell('lyrics', lyrics);
+    }
+
+    this.dirtyLine = true;
+  }
+
+  finishLine() {
+    const rows = this.row(this.chordsLine) + this.row(this.lyricsLine);
+    this.output(this.table(rows));
+    this.chordsLine = '';
+    this.lyricsLine = '';
+  }
+
+  cell(cssClass, value) {
+    return `<td class="${cssClass}">${value}</td>`;
+  }
+
+  row(contents) {
+    const attr = contents ? '' : ' class="empty-line"'
+    return `<tr${attr}>${contents}</tr>`;
+  }
+
+  table(contents) {
+    return `<table>${contents}</table>`;
+  }
+}

--- a/src/formatter/html_table_formatter.js
+++ b/src/formatter/html_table_formatter.js
@@ -44,7 +44,7 @@ export default class HtmlTableFormatter extends HtmlFormatter {
   }
 
   row(contents) {
-    const attr = contents ? '' : ' class="empty-line"'
+    const attr = contents ? '' : ' class="empty-line"';
     return `<tr${attr}>${contents}</tr>`;
   }
 

--- a/test/formatter/html_div_formatter.js
+++ b/test/formatter/html_div_formatter.js
@@ -1,0 +1,67 @@
+import expect from 'expect';
+import '../matchers';
+import HtmlDivFormatter from '../../src/formatter/html_div_formatter';
+import song from '../fixtures/song';
+
+describe('HtmlDivFormatter', () => {
+  it('formats a song to a html chord sheet correctly', () => {
+    const formatter = new HtmlDivFormatter();
+
+    const expectedChordSheet =
+      '<h1>Let it be</h1>' +
+      '<h2>ChordSheetJS example version</h2>' +
+      '<div class="chord-sheet">' +
+        '<div class="row">' +
+          '<div class="column">' +
+            '<div class="chord"></div>' +
+            '<div class="lyrics">Let it&nbsp;</div>' +
+          '</div>' +
+          '<div class="column">' +
+            '<div class="chord">Am</div>' +
+            '<div class="lyrics">be, let it&nbsp;</div>' +
+          '</div>' +
+          '<div class="column">' +
+            '<div class="chord">C/G</div>' +
+            '<div class="lyrics">be, let it&nbsp;</div>' +
+          '</div>' +
+          '<div class="column">' +
+            '<div class="chord">F</div>' +
+            '<div class="lyrics">be, let it&nbsp;</div>' +
+          '</div>' +
+          '<div class="column">' +
+            '<div class="chord">C</div>' +
+            '<div class="lyrics">be&nbsp;</div>' +
+          '</div>' +
+        '</div>' +
+
+        '<div class="row">' +
+          '<div class="column">' +
+            '<div class="chord">C</div>' +
+            '<div class="lyrics">Whisper words of&nbsp;</div>' +
+          '</div>' +
+          '<div class="column">' +
+            '<div class="chord">G</div>' +
+            '<div class="lyrics">wisdom, let it&nbsp;</div>' +
+          '</div>' +
+          '<div class="column">' +
+            '<div class="chord">F</div>' +
+            '<div class="lyrics">be&nbsp;</div>' +
+          '</div>' +
+          '<div class="column">' +
+            '<div class="chord">C/E&nbsp;</div>' +
+            '<div class="lyrics"></div>' +
+          '</div>' +
+          '<div class="column">' +
+            '<div class="chord">Dm&nbsp;</div>' +
+            '<div class="lyrics"></div>' +
+          '</div>' +
+          '<div class="column">' +
+            '<div class="chord">C&nbsp;</div>' +
+            '<div class="lyrics"></div>' +
+          '</div>' +
+        '</div>' +
+      '</div>';
+
+    expect(formatter.format(song)).toEqual(expectedChordSheet);
+  });
+});

--- a/test/formatter/html_table_formatter.js
+++ b/test/formatter/html_table_formatter.js
@@ -1,11 +1,11 @@
 import expect from 'expect';
 import '../matchers';
-import HtmlFormatter from '../../src/formatter/html_formatter';
+import HtmlTableFormatter from '../../src/formatter/html_table_formatter';
 import song from '../fixtures/song';
 
-describe('HtmlFormatter', () => {
+describe('HtmlTableFormatter', () => {
   it('formats a song to a html chord sheet correctly', () => {
-    const formatter = new HtmlFormatter();
+    const formatter = new HtmlTableFormatter();
 
     const expectedChordSheet =
       '<h1>Let it be</h1>' +


### PR DESCRIPTION
This PR:

- extracts `HtmlTableFormatter` from `HtmlFormatter` (which is now to be treated as abstract class)
- adds the `HtmlDivFormatter`, which formats the chord sheet in a layout built with `<div>` tags, which allows a responsive design. Output looks like this:

```html
<h1>Let it be</h1>
<h2>ChordSheetJS example version</h2>
<div class="chord-sheet">
  <div class="row">
    <div class="column">
      <div class="chord"></div>
      <div class="lyrics">Let it&nbsp;</div>
    </div>
    <div class="column">
      <div class="chord">Am</div>
      <div class="lyrics">be, let it&nbsp;</div>
    </div>
    <div class="column">
      <div class="chord">C/G</div>
      <div class="lyrics">be, let it&nbsp;</div>
    </div>
    <div class="column">
      <div class="chord">F</div>
      <div class="lyrics">be, let it&nbsp;</div>
    </div>
    <div class="column">
      <div class="chord">C</div>
      <div class="lyrics">be&nbsp;</div>
    </div>
  </div>
  <div class="row">
    <div class="column">
      <div class="chord">C</div>
      <div class="lyrics">Whisper words of&nbsp;</div>
    </div>
    <div class="column">
      <div class="chord">G</div>
      <div class="lyrics">wisdom, let it&nbsp;</div>
    </div>
    <div class="column">
      <div class="chord">F</div>
      <div class="lyrics">be&nbsp;</div>
    </div>
    <div class="column">
      <div class="chord">C/E&nbsp;</div>
      <div class="lyrics"></div>
    </div>
    <div class="column">
      <div class="chord">Dm&nbsp;</div>
      <div class="lyrics"></div>
    </div>
    <div class="column">
      <div class="chord">C&nbsp;</div>
      <div class="lyrics"></div>
    </div>
  </div>
</div>
```