### PR TITLE
Make whitespace preservation optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chordsheetjs",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chordsheetjs",
   "author": "Martijn Versluis",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A JavaScript library for parsing and formatting chord sheets",
   "main": "lib/chordsheet.js",
   "repository": {

--- a/src/parser/chord_sheet_parser.js
+++ b/src/parser/chord_sheet_parser.js
@@ -4,6 +4,10 @@ const WHITE_SPACE = /\s/;
 const CHORD_LINE_REGEX = /^\s*((([A-G])(#|b)?([^\/\s]*)(\/([A-G])(#|b)?)?)(\s|$)+)+(\s|$)+/;
 
 export default class ChordSheetParser {
+  constructor({preserveWhitespace = true} = {}) {
+    this.preserveWhitespace = (preserveWhitespace === true);
+  }
+
   parse(document) {
     this.initialize(document);
 
@@ -88,7 +92,7 @@ export default class ChordSheetParser {
   }
 
   shouldAddCharacterToChords(nextChar) {
-    return (nextChar && WHITE_SPACE.test(nextChar));
+    return (nextChar && WHITE_SPACE.test(nextChar) && this.preserveWhitespace);
   }
 
   ensureChordLyricsPairInitialized() {

--- a/test/parser/chord_sheet_parser.js
+++ b/test/parser/chord_sheet_parser.js
@@ -31,4 +31,54 @@ describe('ChordSheetParser', () => {
     expect(line1Items[4]).toBeChordLyricsPair('Dm', '');
     expect(line1Items[5]).toBeChordLyricsPair('C', '');
   });
+
+  context('with option preserveWhitespace:true', () => {
+    it('parses a regular chord sheet correctly', () => {
+      const parser = new ChordSheetParser({preserveWhitespace: true});
+      const song = parser.parse(chordSheet);
+      const lines = song.lines;
+
+      expect(lines.length).toEqual(2);
+
+      const line0Items = lines[0].items;
+      expect(line0Items[0]).toBeChordLyricsPair('      ', 'Let it ');
+      expect(line0Items[1]).toBeChordLyricsPair('Am        ', 'be, let it ');
+      expect(line0Items[2]).toBeChordLyricsPair('C/G       ', 'be, let it ');
+      expect(line0Items[3]).toBeChordLyricsPair('F         ', 'be, let it ');
+      expect(line0Items[4]).toBeChordLyricsPair('C', 'be');
+
+      const line1Items = lines[1].items;
+      expect(line1Items[0]).toBeChordLyricsPair('C               ', 'Whisper words of ');
+      expect(line1Items[1]).toBeChordLyricsPair('G             ', 'wisdom, let it ');
+      expect(line1Items[2]).toBeChordLyricsPair('F ', 'be');
+      expect(line1Items[3]).toBeChordLyricsPair('C/E', '');
+      expect(line1Items[4]).toBeChordLyricsPair('Dm', '');
+      expect(line1Items[5]).toBeChordLyricsPair('C', '');
+    });
+  });
+
+  context('with option preserveWhitespace:false', () => {
+    it('parses a regular chord sheet correctly', () => {
+      const parser = new ChordSheetParser({preserveWhitespace: false});
+      const song = parser.parse(chordSheet);
+      const lines = song.lines;
+
+      expect(lines.length).toEqual(2);
+
+      const line0Items = lines[0].items;
+      expect(line0Items[0]).toBeChordLyricsPair('', 'Let it ');
+      expect(line0Items[1]).toBeChordLyricsPair('Am', 'be, let it ');
+      expect(line0Items[2]).toBeChordLyricsPair('C/G', 'be, let it ');
+      expect(line0Items[3]).toBeChordLyricsPair('F', 'be, let it ');
+      expect(line0Items[4]).toBeChordLyricsPair('C', 'be');
+
+      const line1Items = lines[1].items;
+      expect(line1Items[0]).toBeChordLyricsPair('C', 'Whisper words of ');
+      expect(line1Items[1]).toBeChordLyricsPair('G', 'wisdom, let it ');
+      expect(line1Items[2]).toBeChordLyricsPair('F', 'be');
+      expect(line1Items[3]).toBeChordLyricsPair('C/E', '');
+      expect(line1Items[4]).toBeChordLyricsPair('Dm', '');
+      expect(line1Items[5]).toBeChordLyricsPair('C', '');
+    });
+  });
 });


### PR DESCRIPTION
This commit makes the parsing changes introduced in PR #36
(https://github.com/martijnversluis/ChordSheetJS/pull/36) configurable
using the parser option `preserveWhitespace`.