### PR TITLE
Encode HTML entities for HTML formatters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chordsheetjs",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1645,11 +1645,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
         "string-width": {
           "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
@@ -1659,6 +1654,11 @@
             "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
           }
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
         },
         "stringstream": {
           "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
@@ -1894,6 +1894,11 @@
         "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
         "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
       }
+    },
+    "html-entities": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
     },
     "inflight": {
       "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -24,5 +24,7 @@
     "build": "babel src --out-dir lib",
     "prepublish": "npm test && npm run build"
   },
-  "dependencies": {}
+  "dependencies": {
+    "html-entities": "^1.2.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chordsheetjs",
   "author": "Martijn Versluis",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A JavaScript library for parsing and formatting chord sheets",
   "main": "lib/chordsheet.js",
   "repository": {

--- a/src/formatter/html_div_formatter.js
+++ b/src/formatter/html_div_formatter.js
@@ -1,4 +1,5 @@
 import HtmlFormatter from './html_formatter';
+import htmlEntitiesEncode from './html_entities_encode';
 
 export default class HtmlDivFormatter extends HtmlFormatter {
   constructor() {
@@ -31,11 +32,11 @@ export default class HtmlDivFormatter extends HtmlFormatter {
   }
 
   chord(chord) {
-    return this.div('chord', chord);
+    return this.div('chord', htmlEntitiesEncode(chord));
   }
 
   lyrics(lyrics) {
-    return this.div('lyrics', lyrics);
+    return this.div('lyrics',htmlEntitiesEncode(lyrics));
   }
 
   div(cssClasses, value) {

--- a/src/formatter/html_entities_encode.js
+++ b/src/formatter/html_entities_encode.js
@@ -1,0 +1,6 @@
+const Html5Entities = require("html-entities").Html5Entities;
+
+export default function htmlEntitiesEncode(data) {
+  const encoder = new Html5Entities();
+  return encoder.encode(data);
+}

--- a/src/formatter/html_formatter.js
+++ b/src/formatter/html_formatter.js
@@ -1,7 +1,7 @@
 import FormatterBase from './formatter_base';
 import Tag from '../chord_sheet/tag';
 
-const SPACE = '&nbsp;';
+const SPACE = ' ';
 
 export default class HtmlFormatter extends FormatterBase {
   constructor() {

--- a/src/formatter/html_table_formatter.js
+++ b/src/formatter/html_table_formatter.js
@@ -1,4 +1,5 @@
 import HtmlFormatter from './html_formatter';
+import htmlEntitiesEncode from './html_entities_encode';
 
 export default class HtmlTableFormatter extends HtmlFormatter {
   constructor() {
@@ -20,7 +21,7 @@ export default class HtmlTableFormatter extends HtmlFormatter {
   }
 
   cell(cssClass, value) {
-    return `<td class="${cssClass}">${value}</td>`;
+    return `<td class="${cssClass}">${htmlEntitiesEncode(value)}</td>`;
   }
 
   row(contents) {

--- a/test/formatter/html_div_formatter.js
+++ b/test/formatter/html_div_formatter.js
@@ -1,7 +1,9 @@
 import expect from 'expect';
 import '../matchers';
 import HtmlDivFormatter from '../../src/formatter/html_div_formatter';
+import htmlEntitiesEncode from '../../src/formatter/html_entities_encode';
 import song from '../fixtures/song';
+import { createChordLyricsPair, createLine, createSong } from '../utilities';
 
 describe('HtmlDivFormatter', () => {
   it('formats a song to a html chord sheet correctly', () => {
@@ -14,54 +16,76 @@ describe('HtmlDivFormatter', () => {
         '<div class="row">' +
           '<div class="column">' +
             '<div class="chord"></div>' +
-            '<div class="lyrics">Let it&nbsp;</div>' +
+            '<div class="lyrics">Let it </div>' +
           '</div>' +
           '<div class="column">' +
             '<div class="chord">Am</div>' +
-            '<div class="lyrics">be, let it&nbsp;</div>' +
+            '<div class="lyrics">be, let it </div>' +
           '</div>' +
           '<div class="column">' +
             '<div class="chord">C/G</div>' +
-            '<div class="lyrics">be, let it&nbsp;</div>' +
+            '<div class="lyrics">be, let it </div>' +
           '</div>' +
           '<div class="column">' +
             '<div class="chord">F</div>' +
-            '<div class="lyrics">be, let it&nbsp;</div>' +
+            '<div class="lyrics">be, let it </div>' +
           '</div>' +
           '<div class="column">' +
             '<div class="chord">C</div>' +
-            '<div class="lyrics">be&nbsp;</div>' +
+            '<div class="lyrics">be </div>' +
           '</div>' +
         '</div>' +
 
         '<div class="row">' +
           '<div class="column">' +
             '<div class="chord">C</div>' +
-            '<div class="lyrics">Whisper words of&nbsp;</div>' +
+            '<div class="lyrics">Whisper words of </div>' +
           '</div>' +
           '<div class="column">' +
             '<div class="chord">G</div>' +
-            '<div class="lyrics">wisdom, let it&nbsp;</div>' +
+            '<div class="lyrics">wisdom, let it </div>' +
           '</div>' +
           '<div class="column">' +
             '<div class="chord">F</div>' +
-            '<div class="lyrics">be&nbsp;</div>' +
+            '<div class="lyrics">be </div>' +
           '</div>' +
           '<div class="column">' +
-            '<div class="chord">C/E&nbsp;</div>' +
+            '<div class="chord">C/E </div>' +
             '<div class="lyrics"></div>' +
           '</div>' +
           '<div class="column">' +
-            '<div class="chord">Dm&nbsp;</div>' +
+            '<div class="chord">Dm </div>' +
             '<div class="lyrics"></div>' +
           '</div>' +
           '<div class="column">' +
-            '<div class="chord">C&nbsp;</div>' +
+            '<div class="chord">C </div>' +
             '<div class="lyrics"></div>' +
           '</div>' +
         '</div>' +
       '</div>';
 
     expect(formatter.format(song)).toEqual(expectedChordSheet);
+  });
+
+  it('encodes HTML entities', () => {
+    const formatter = new HtmlDivFormatter();
+
+    const songWithHtmlEntities = createSong([
+      createLine([
+        createChordLyricsPair('Am', '<h1>Let it</h1>')
+      ])
+    ]);
+
+    const expectedChordSheet =
+      '<div class="chord-sheet">' +
+        '<div class="row">' +
+          '<div class="column">' +
+            '<div class="chord">Am</div>' +
+            `<div class="lyrics">${htmlEntitiesEncode('<h1>Let it</h1>')} </div>` +
+          '</div>' +
+        '</div>' +
+      '</div>';
+
+    expect(formatter.format(songWithHtmlEntities)).toEqual(expectedChordSheet);
   });
 });

--- a/test/formatter/html_table_formatter.js
+++ b/test/formatter/html_table_formatter.js
@@ -1,7 +1,9 @@
 import expect from 'expect';
 import '../matchers';
 import HtmlTableFormatter from '../../src/formatter/html_table_formatter';
+import htmlEntitiesEncode from '../../src/formatter/html_entities_encode';
 import song from '../fixtures/song';
+import { createChordLyricsPair, createLine, createSong } from '../utilities';
 
 describe('HtmlTableFormatter', () => {
   it('formats a song to a html chord sheet correctly', () => {
@@ -19,11 +21,11 @@ describe('HtmlTableFormatter', () => {
         '<td class="chord">C</td>' +
         '</tr>' +
         '<tr>' +
-        '<td class="lyrics">Let it&nbsp;</td>' +
-        '<td class="lyrics">be, let it&nbsp;</td>' +
-        '<td class="lyrics">be, let it&nbsp;</td>' +
-        '<td class="lyrics">be, let it&nbsp;</td>' +
-        '<td class="lyrics">be&nbsp;</td>' +
+        '<td class="lyrics">Let it </td>' +
+        '<td class="lyrics">be, let it </td>' +
+        '<td class="lyrics">be, let it </td>' +
+        '<td class="lyrics">be, let it </td>' +
+        '<td class="lyrics">be </td>' +
         '</tr>' +
         '</table>' +
         '<table>' +
@@ -31,14 +33,14 @@ describe('HtmlTableFormatter', () => {
         '<td class="chord">C</td>' +
         '<td class="chord">G</td>' +
         '<td class="chord">F</td>' +
-        '<td class="chord">C/E&nbsp;</td>' +
-        '<td class="chord">Dm&nbsp;</td>' +
-        '<td class="chord">C&nbsp;</td>' +
+        '<td class="chord">C/E </td>' +
+        '<td class="chord">Dm </td>' +
+        '<td class="chord">C </td>' +
         '</tr>' +
         '<tr>' +
-        '<td class="lyrics">Whisper words of&nbsp;</td>' +
-        '<td class="lyrics">wisdom, let it&nbsp;</td>' +
-        '<td class="lyrics">be&nbsp;</td>' +
+        '<td class="lyrics">Whisper words of </td>' +
+        '<td class="lyrics">wisdom, let it </td>' +
+        '<td class="lyrics">be </td>' +
         '<td class="lyrics"></td>' +
         '<td class="lyrics"></td>' +
         '<td class="lyrics"></td>' +
@@ -46,5 +48,27 @@ describe('HtmlTableFormatter', () => {
         '</table>';
 
     expect(formatter.format(song)).toEqual(expectedChordSheet);
+  });
+
+  it('encodes HTML entities', () => {
+    const formatter = new HtmlTableFormatter();
+
+    const songWithHtmlEntities = createSong([
+      createLine([
+        createChordLyricsPair('Am', '<h1>Let it</h1>')
+      ])
+    ]);
+
+    const expectedChordSheet =
+      '<table>' +
+        '<tr>' +
+          '<td class="chord">Am</td>' +
+        '</tr>' +
+        '<tr>' +
+          `<td class="lyrics">${htmlEntitiesEncode('<h1>Let it</h1>')} </td>` +
+        '</tr>' +
+      '</table>';
+
+    expect(formatter.format(songWithHtmlEntities)).toEqual(expectedChordSheet);
   });
 });


### PR DESCRIPTION
This change ensures all HTML entities that might be found in a chord sheet are encoded before displaying them. This will for example prevent cross site scripting.