### PR TITLE
Add clone method to entities

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
- "presets": [ "es2015" ]
+ "presets": ["es2015"],
+ "plugins": ["transform-object-rest-spread"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chordsheetjs",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -279,6 +279,12 @@
         "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
       }
     },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+      "dev": true
+    },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
@@ -489,6 +495,34 @@
         "babel-helper-regex": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
         "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
         "regexpu-core": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz"
+      }
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "babel-runtime": "6.26.0"
+      },
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
+          "requires": {
+            "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+            "regenerator-runtime": "0.11.1"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        }
       }
     },
     "babel-plugin-transform-regenerator": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "homepage": "https://github.com/martijnversluis/ChordSheetJS",
   "devDependencies": {
     "babel-cli": "^6.24.1",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-register": "^6.24.1",
     "expect": "^1.13.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chordsheetjs",
   "author": "Martijn Versluis",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "A JavaScript library for parsing and formatting chord sheets",
   "main": "lib/chordsheet.js",
   "repository": {

--- a/src/chord_sheet/chord_lyrics_pair.js
+++ b/src/chord_sheet/chord_lyrics_pair.js
@@ -1,6 +1,10 @@
 export default class ChordLyricsPair {
-  constructor() {
-    this.chords = '';
-    this.lyrics = '';
+  constructor(chords = '', lyrics = '') {
+    this.chords = chords;
+    this.lyrics = lyrics;
+  }
+
+  clone() {
+    return new ChordLyricsPair(this.chords, this.lyrics);
   }
 }

--- a/src/chord_sheet/line.js
+++ b/src/chord_sheet/line.js
@@ -34,4 +34,10 @@ export default class Line {
     this.items.push(tag);
     return tag;
   }
+
+  clone() {
+    const clonedLine = new Line();
+    clonedLine.items = this.items.map(item => item.clone());
+    return clonedLine;
+  }
 }

--- a/src/chord_sheet/song.js
+++ b/src/chord_sheet/song.js
@@ -61,4 +61,11 @@ export default class Song {
   get subtitle() {
     return this.metaData[SUBTITLE] || "";
   }
+
+  clone() {
+    const clonedSong = new Song();
+    clonedSong.lines = this.lines.map(line => line.clone());
+    clonedSong.metaData = {...this.metaData};
+    return clonedSong;
+  }
 }

--- a/src/chord_sheet/tag.js
+++ b/src/chord_sheet/tag.js
@@ -47,4 +47,8 @@ export default class Tag {
   isMetaTag() {
     return META_TAGS.indexOf(this.name) !== -1;
   }
+
+  clone() {
+    return new Tag(this.name, this.value);
+  }
 }

--- a/test/chord_sheet/chord_lyrics_pair.js
+++ b/test/chord_sheet/chord_lyrics_pair.js
@@ -1,0 +1,14 @@
+import expect from 'expect';
+import ChordLyricsPair from '../../src/chord_sheet/chord_lyrics_pair';
+
+describe('ChordLyricsPair', () => {
+  describe('#clone', () => {
+    it('returns a clone of the chord lyrics pair', () => {
+      const chordLyricsPair = new ChordLyricsPair('C', 'Let it');
+      const clonedChordLyricsPair = chordLyricsPair.clone();
+
+      expect(clonedChordLyricsPair.chords).toEqual('C');
+      expect(clonedChordLyricsPair.lyrics).toEqual('Let it');
+    });
+  });
+});

--- a/test/chord_sheet/line.js
+++ b/test/chord_sheet/line.js
@@ -1,0 +1,16 @@
+import expect from 'expect';
+import Line from '../../src/chord_sheet/line';
+import ItemStub from '../cloneable_stub';
+
+describe('Line', () => {
+  describe('#clone', () => {
+    it('returns a clone of the line', () => {
+      const line = new Line();
+      line.items = ['foo', 'bar'].map(value => new ItemStub(value));
+      const clonedLine = line.clone();
+
+      const actualValues = clonedLine.items.map(item => item.value);
+      expect(actualValues).toEqual(['foo', 'bar']);
+    });
+  });
+});

--- a/test/chord_sheet/song.js
+++ b/test/chord_sheet/song.js
@@ -1,0 +1,18 @@
+import expect from 'expect';
+import Song from '../../src/chord_sheet/song';
+import LineStub from '../cloneable_stub';
+
+describe('Song', () => {
+  describe('#clone', () => {
+    it('returns a clone of the song', () => {
+      const song = new Song();
+      song.lines = ['foo', 'bar'].map(value => new LineStub(value));
+      song.metaData = {foo: 'bar'};
+      const clonedSong = song.clone();
+
+      const actualValues = clonedSong.lines.map(line => line.value);
+      expect(actualValues).toEqual(['foo', 'bar']);
+      expect(clonedSong.metaData).toEqual({foo: 'bar'});
+    });
+  });
+});

--- a/test/chord_sheet/tag.js
+++ b/test/chord_sheet/tag.js
@@ -30,4 +30,14 @@ describe('Tag', () => {
       expect(new Tag('foo', 'bar').hasValue()).toBe(true);
     });
   });
+
+  describe('#clone', () => {
+    it('returns a clone of the tag', () => {
+      const tag = new Tag('foo', 'bar');
+      const clonedTag = tag.clone();
+
+      expect(clonedTag.name).toEqual('foo');
+      expect(clonedTag.value).toEqual('bar');
+    });
+  });
 });

--- a/test/cloneable_stub.js
+++ b/test/cloneable_stub.js
@@ -1,0 +1,9 @@
+export default class CloneableStub {
+  constructor(value) {
+    this.value = value;
+  }
+
+  clone() {
+    return new CloneableStub(this.value);
+  }
+}


### PR DESCRIPTION
This PR adds clone methods to the `ChordLyricsPair`, `Line`, `Song` and `Tag` entity classes. This makes it easier to use and manipulate a parsed song without having to mutate properties. Cloning always results in a deep clone:

- cloning a song:
  - clones the meta data
  - clones the lines, which: 
    - clones the chords lyrics pairs
    - clones the tags