### PR TITLE
Add alias `c` for `comment` tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chordsheetjs",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chordsheetjs",
   "author": "Martijn Versluis",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "A JavaScript library for parsing and formatting chord sheets",
   "main": "lib/chordsheet.js",
   "repository": {

--- a/src/chord_sheet/tag.js
+++ b/src/chord_sheet/tag.js
@@ -4,6 +4,7 @@ const RENDERABLE_TAGS = ['comment'];
 const ALIASES = {
   t: 'title',
   st: 'subtitle',
+  c: 'comment',
 };
 
 const TAG_REGEX = /^([^:\s]+)(:?\s*(.+))?$/;

--- a/test/chord_sheet/tag.js
+++ b/test/chord_sheet/tag.js
@@ -5,6 +5,7 @@ describe('Tag', () => {
   const expectedAliases = {
     t: 'title',
     st: 'subtitle',
+    c: 'comment',
   };
 
   Object.keys(expectedAliases).forEach((alias) => {


### PR DESCRIPTION
#48, which added support for `{comment}` tags, lacked support for the `{c}` alias.