### PR TITLE
Add option to not render blank lines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,17 @@
 language: node_js
 node_js:
-  - "4"
-  - "5"
-  - "6"
-  - "7"
-  - "8"
-  - "node"
+- '4'
+- '5'
+- '6'
+- '7'
+- '8'
+- node
+deploy:
+  provider: npm
+  email: martijnversluis@gmail.com
+  api_key:
+    secure: dqQPnpXMZ3uZdSKzXlhYCwO9+4o8MHjUT1Xq6belmjjb2HvWRpDlrrETauZ98hArdz3NmenxD1ed5vHusVvuo2LrpTdE1qKNtMI0BGyVDEobe57Q4ukwn3FM9tJMVDNC55dKx/UTds3tYxvxpbEDjnQbgIY2QHwM0heG366j6w8=
+  on:
+    branch: master
+    tags: true
+    repo: martijnversluis/ChordSheetJS

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chordsheetjs",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chordsheetjs",
   "author": "Martijn Versluis",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "A JavaScript library for parsing and formatting chord sheets",
   "main": "lib/chordsheet.js",
   "repository": {

--- a/src/formatter/html_div_formatter.js
+++ b/src/formatter/html_div_formatter.js
@@ -2,8 +2,9 @@ import HtmlFormatter from './html_formatter';
 import htmlEntitiesEncode from './html_entities_encode';
 
 export default class HtmlDivFormatter extends HtmlFormatter {
-  constructor() {
+  constructor({ renderBlankLines = true } = {}) {
     super();
+    this.renderBlankLines = renderBlankLines;
     this.line = '';
   }
 
@@ -66,11 +67,16 @@ export default class HtmlDivFormatter extends HtmlFormatter {
 
   row(contents) {
     let cssClasses = 'row';
+    const hasContents = !!contents;
 
-    if (!contents) {
-      cssClasses += ' empty-line';
+    if (hasContents || this.renderBlankLines) {
+      if (!hasContents) {
+        cssClasses += ' empty-line';
+      }
+
+      return this.div(cssClasses, contents);
     }
 
-    return this.div(cssClasses, contents);
+    return '';
   }
 }

--- a/src/formatter/html_table_formatter.js
+++ b/src/formatter/html_table_formatter.js
@@ -2,8 +2,9 @@ import HtmlFormatter from './html_formatter';
 import htmlEntitiesEncode from './html_entities_encode';
 
 export default class HtmlTableFormatter extends HtmlFormatter {
-  constructor() {
+  constructor({ renderBlankLines = true } = {}) {
     super();
+    this.renderBlankLines = renderBlankLines;
     this.chordsLine = '';
     this.lyricsLine = '';
   }
@@ -54,12 +55,17 @@ export default class HtmlTableFormatter extends HtmlFormatter {
   }
 
   row(contents) {
-    const attr = contents ? '' : ' class="empty-line"';
-    return `<tr${attr}>${contents}</tr>`;
+    return `<tr>${contents}</tr>`;
   }
 
   table(contents) {
-    const attr = contents ? '' : ' class="empty-line"';
-    return `<table${attr}>${contents}</table>`;
+    const hasContents = !!contents;
+
+    if (hasContents || this.renderBlankLines) {
+      const attr = hasContents ? '' : ' class="empty-line"';
+      return `<table${attr}>${contents}</table>`;
+    }
+
+    return '';
   }
 }

--- a/test/formatter/html_div_formatter.js
+++ b/test/formatter/html_div_formatter.js
@@ -117,4 +117,40 @@ describe('HtmlDivFormatter', () => {
 
     expect(formatter.format(songWithHtmlEntities)).to.equalText(expectedChordSheet);
   });
+
+  context('with option renderBlankLines:false', () => {
+    it('does not include HTML for blank lines', () => {
+      const songWithBlankLine = createSong([
+        createLine([
+          createChordLyricsPair('C', 'Whisper words of wisdom'),
+        ]),
+
+        createLine([]),
+
+        createLine([
+          createChordLyricsPair('Am', 'Whisper words of wisdom'),
+        ]),
+      ]);
+
+      const expectedChordSheet =
+        '<div class="chord-sheet">' +
+          '<div class="row">' +
+            '<div class="column">' +
+              '<div class="chord">C</div>' +
+              '<div class="lyrics">Whisper words of wisdom</div>' +
+            '</div>' +
+          '</div>' +
+          '<div class="row">' +
+            '<div class="column">' +
+              '<div class="chord">Am</div>' +
+              '<div class="lyrics">Whisper words of wisdom</div>' +
+            '</div>' +
+          '</div>' +
+        '</div>';
+
+      const formatter = new HtmlDivFormatter({ renderBlankLines: false });
+
+      expect(formatter.format(songWithBlankLine)).to.equalText(expectedChordSheet);
+    });
+  });
 });

--- a/test/formatter/html_table_formatter.js
+++ b/test/formatter/html_table_formatter.js
@@ -97,4 +97,42 @@ describe('HtmlTableFormatter', () => {
 
     expect(formatter.format(songWithHtmlEntities)).to.equalText(expectedChordSheet);
   });
+
+  context('with option renderBlankLines:false', () => {
+    it('does not include HTML for blank lines', () => {
+      const songWithBlankLine = createSong([
+        createLine([
+          createChordLyricsPair('C', 'Whisper words of wisdom'),
+        ]),
+
+        createLine([]),
+
+        createLine([
+          createChordLyricsPair('Am', 'Whisper words of wisdom'),
+        ]),
+      ]);
+
+      const expectedChordSheet =
+        '<table>' +
+          '<tr>' +
+            '<td class="chord">C</td>' +
+          '</tr>' +
+          '<tr>' +
+            '<td class="lyrics">Whisper words of wisdom</td>' +
+          '</tr>' +
+        '</table>' +
+        '<table>' +
+          '<tr>' +
+            '<td class="chord">Am</td>' +
+          '</tr>' +
+          '<tr>' +
+            '<td class="lyrics">Whisper words of wisdom</td>' +
+          '</tr>' +
+        '</table>';
+
+      const formatter = new HtmlTableFormatter({ renderBlankLines: false });
+
+      expect(formatter.format(songWithBlankLine)).to.equalText(expectedChordSheet);
+    });
+  });
 });


### PR DESCRIPTION
This PR adds an configuration option to the HTML formatters that can enables or disables rendering blank lines:

```js
const song = (perform your parsing here);
const formatter = new ChordSheetJS.HtmlDivFormatter({ renderBlankLines: false });
const formattedChordSheet = formatter.format(song);
```