### PR TITLE
Mark verse and chorus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chordsheetjs",
-  "version": "2.7.2",
+  "version": "2.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chordsheetjs",
   "author": "Martijn Versluis",
-  "version": "2.7.2",
+  "version": "2.8.0",
   "description": "A JavaScript library for parsing and formatting chord sheets",
   "main": "lib/chordsheet.js",
   "repository": {

--- a/src/chord_sheet/line.js
+++ b/src/chord_sheet/line.js
@@ -1,13 +1,13 @@
 import ChordLyricsPair from './chord_lyrics_pair';
 import Tag from './tag';
 import { pushNew } from '../utilities';
-import { CHORUS, VERSE } from '../constants';
+import { CHORUS, NONE, VERSE } from '../constants';
 
 export default class Line {
   constructor() {
     this.items = [];
     this.currentChordLyricsPair = null;
-    this.type = null;
+    this.type = NONE;
   }
 
   isEmpty() {

--- a/src/chord_sheet/line.js
+++ b/src/chord_sheet/line.js
@@ -58,4 +58,8 @@ export default class Line {
   isChorus() {
     return this.type === CHORUS;
   }
+
+  hasContent() {
+    return this.items.some(item => item instanceof ChordLyricsPair);
+  }
 }

--- a/src/chord_sheet/line.js
+++ b/src/chord_sheet/line.js
@@ -1,11 +1,13 @@
 import ChordLyricsPair from './chord_lyrics_pair';
 import Tag from './tag';
 import { pushNew } from '../utilities';
+import { CHORUS, VERSE } from '../constants';
 
 export default class Line {
   constructor() {
     this.items = [];
     this.currentChordLyricsPair = null;
+    this.type = null;
   }
 
   isEmpty() {
@@ -47,5 +49,13 @@ export default class Line {
     const clonedLine = new Line();
     clonedLine.items = this.items.map(item => item.clone());
     return clonedLine;
+  }
+
+  isVerse() {
+    return this.type === VERSE;
+  }
+
+  isChorus() {
+    return this.type === CHORUS;
   }
 }

--- a/src/chord_sheet/paragraph.js
+++ b/src/chord_sheet/paragraph.js
@@ -1,3 +1,5 @@
+import { INDETERMINATE } from '../constants';
+
 export default class Paragraph {
   constructor() {
     this.lines = [];
@@ -5,5 +7,16 @@ export default class Paragraph {
 
   addLine(line) {
     this.lines.push(line);
+  }
+
+  get type() {
+    const types = this.lines.map(line => line.type).filter(type => type !== NONE);
+    const uniqueTypes = [...new Set(types)];
+
+    if (uniqueTypes.length === 1) {
+      return uniqueTypes[0];
+    }
+
+    return INDETERMINATE;
   }
 }

--- a/src/chord_sheet/paragraph.js
+++ b/src/chord_sheet/paragraph.js
@@ -10,7 +10,7 @@ export default class Paragraph {
   }
 
   get type() {
-    const types = this.lines.map(line => line.type).filter(type => type !== NONE);
+    const types = this.lines.map(line => line.type);
     const uniqueTypes = [...new Set(types)];
 
     if (uniqueTypes.length === 1) {

--- a/src/chord_sheet/song.js
+++ b/src/chord_sheet/song.js
@@ -53,7 +53,7 @@ export default class Song {
     if (this.currentLine !== null) {
       if (this.currentLine.isEmpty()) {
         this.addParagraph();
-      } else {
+      } else if (this.currentLine.hasContent()) {
         this.currentParagraph.addLine(this.currentLine);
       }
     }

--- a/src/chord_sheet/song.js
+++ b/src/chord_sheet/song.js
@@ -43,6 +43,12 @@ export default class Song {
     return this.currentLine;
   }
 
+  setCurrentLineType(type) {
+    if (this.currentLine) {
+      this.currentLine.type = type;
+    }
+  }
+
   flushLine() {
     if (this.currentLine !== null) {
       if (this.currentLine.isEmpty()) {

--- a/src/chord_sheet/tag.js
+++ b/src/chord_sheet/tag.js
@@ -1,20 +1,42 @@
-const META_TAGS = ['title', 'subtitle'];
-const RENDERABLE_TAGS = ['comment'];
+export const TITLE = 'title';
+export const SUBTITLE = 'subtitle';
+export const COMMENT = 'comment';
+export const START_OF_CHORUS = 'start_of_chorus';
+export const END_OF_CHORUS = 'end_of_chorus';
+export const START_OF_VERSE = 'start_of_verse';
+export const END_OF_VERSE = 'end_of_verse';
+
+const TITLE_SHORT = 't';
+const SUBTITLE_SHORT = 'st';
+const COMMENT_SHORT = 'c';
+const START_OF_CHORUS_SHORT = 'soc';
+const END_OF_CHORUS_SHORT = 'eoc';
+
+const META_TAGS = [TITLE, SUBTITLE];
+const RENDERABLE_TAGS = [COMMENT];
 
 const ALIASES = {
-  t: 'title',
-  st: 'subtitle',
-  c: 'comment',
+  [TITLE_SHORT]: TITLE,
+  [SUBTITLE_SHORT]: SUBTITLE,
+  [COMMENT_SHORT]: COMMENT,
+  [START_OF_CHORUS_SHORT]: START_OF_CHORUS,
+  [END_OF_CHORUS_SHORT]: END_OF_CHORUS,
 };
 
 const TAG_REGEX = /^([^:\s]+)(:?\s*(.+))?$/;
 
 const translateTagNameAlias = (name) => {
-  if (name in ALIASES) {
-    return ALIASES[name];
+  if (!name) {
+    return name;
   }
 
-  return name;
+  const sanitizedName = name.trim();
+
+  if (sanitizedName in ALIASES) {
+    return ALIASES[sanitizedName];
+  }
+
+  return sanitizedName;
 };
 
 export default class Tag {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,2 @@
+export const VERSE = 'verse';
+export const CHORUS = 'chorus';

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,4 @@
 export const VERSE = 'verse';
 export const CHORUS = 'chorus';
 export const NONE = 'none';
+export const INDETERMINATE = 'indeterminate';

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,2 +1,3 @@
 export const VERSE = 'verse';
 export const CHORUS = 'chorus';
+export const NONE = 'none';

--- a/src/parser/chord_pro_parser.js
+++ b/src/parser/chord_pro_parser.js
@@ -1,6 +1,7 @@
 import Song from '../chord_sheet/song';
 import { END_OF_CHORUS, END_OF_VERSE, START_OF_CHORUS, START_OF_VERSE } from '../chord_sheet/tag';
 import { CHORUS, NONE, VERSE } from '../constants';
+import ParserWarning from './parser_warning';
 
 const NEW_LINE = '\n';
 const SQUARE_START = '[';
@@ -12,6 +13,8 @@ const SHARP_SIGN = '#';
 export default class ChordProParser {
   parse(document) {
     this.song = new Song();
+    this.lineNumber = 1;
+    this.warnings = [];
     this.sectionType = NONE;
     this.resetTag();
     this.processor = this.readLyrics;
@@ -32,6 +35,7 @@ export default class ChordProParser {
         this.processor = this.readComment;
         break;
       case NEW_LINE:
+        this.lineNumber += 1;
         this.song.addLine();
         this.song.setCurrentLineType(this.sectionType);
         break;
@@ -95,22 +99,45 @@ export default class ChordProParser {
   applyTag(tag) {
     switch (tag.name) {
       case START_OF_CHORUS:
-        this.sectionType = CHORUS;
+        this.startSection(CHORUS, tag);
         break;
 
       case END_OF_CHORUS:
-        this.sectionType = NONE;
-        this.song.setCurrentLineType(this.sectionType);
+        this.endSection(CHORUS, tag);
         break;
 
       case START_OF_VERSE:
-        this.sectionType = VERSE;
+        this.startSection(VERSE, tag);
         break;
 
       case END_OF_VERSE:
-        this.sectionType = NONE;
-        this.song.setCurrentLineType(this.sectionType);
+        this.endSection(VERSE, tag);
+        break;
+
+      default:
         break;
     }
+  }
+
+  startSection(sectionType, tag) {
+    this.checkCurrentSectionType(NONE, tag);
+    this.sectionType = sectionType;
+  }
+
+  endSection(sectionType, tag) {
+    this.checkCurrentSectionType(sectionType, tag);
+    this.sectionType = NONE;
+    this.song.setCurrentLineType(this.sectionType);
+  }
+
+  checkCurrentSectionType(sectionType, tag) {
+    if (this.sectionType !== sectionType) {
+      this.addWarning(`Unexpected tag {${tag.originalName}, current section is: ${this.sectionType}`);
+    }
+  }
+
+  addWarning(message) {
+    const warning = new ParserWarning(message, this.lineNumber);
+    this.warnings.push(warning);
   }
 }

--- a/src/parser/chord_pro_parser.js
+++ b/src/parser/chord_pro_parser.js
@@ -1,6 +1,6 @@
 import Song from '../chord_sheet/song';
 import { END_OF_CHORUS, END_OF_VERSE, START_OF_CHORUS, START_OF_VERSE } from '../chord_sheet/tag';
-import { CHORUS, VERSE } from '../constants';
+import { CHORUS, NONE, VERSE } from '../constants';
 
 const NEW_LINE = '\n';
 const SQUARE_START = '[';
@@ -12,7 +12,7 @@ const SHARP_SIGN = '#';
 export default class ChordProParser {
   parse(document) {
     this.song = new Song();
-    this.sectionType = null;
+    this.sectionType = NONE;
     this.resetTag();
     this.processor = this.readLyrics;
     this.parseDocument(document);
@@ -99,7 +99,7 @@ export default class ChordProParser {
         break;
 
       case END_OF_CHORUS:
-        this.sectionType = null;
+        this.sectionType = NONE;
         this.song.setCurrentLineType(this.sectionType);
         break;
 
@@ -108,7 +108,7 @@ export default class ChordProParser {
         break;
 
       case END_OF_VERSE:
-        this.sectionType = null;
+        this.sectionType = NONE;
         this.song.setCurrentLineType(this.sectionType);
         break;
     }

--- a/src/parser/chord_pro_parser.js
+++ b/src/parser/chord_pro_parser.js
@@ -1,4 +1,6 @@
 import Song from '../chord_sheet/song';
+import { END_OF_CHORUS, END_OF_VERSE, START_OF_CHORUS, START_OF_VERSE } from '../chord_sheet/tag';
+import { CHORUS, VERSE } from '../constants';
 
 const NEW_LINE = '\n';
 const SQUARE_START = '[';
@@ -10,6 +12,7 @@ const SHARP_SIGN = '#';
 export default class ChordProParser {
   parse(document) {
     this.song = new Song();
+    this.sectionType = null;
     this.resetTag();
     this.processor = this.readLyrics;
     this.parseDocument(document);
@@ -30,6 +33,7 @@ export default class ChordProParser {
         break;
       case NEW_LINE:
         this.song.addLine();
+        this.song.setCurrentLineType(this.sectionType);
         break;
       case SQUARE_START:
         this.song.addChordLyricsPair();
@@ -79,11 +83,34 @@ export default class ChordProParser {
   }
 
   finishTag() {
-    this.song.addTag(this.tag);
+    const parsedTag = this.song.addTag(this.tag);
+    this.applyTag(parsedTag);
     this.resetTag();
   }
 
   resetTag() {
     this.tag = '';
+  }
+
+  applyTag(tag) {
+    switch (tag.name) {
+      case START_OF_CHORUS:
+        this.sectionType = CHORUS;
+        break;
+
+      case END_OF_CHORUS:
+        this.sectionType = null;
+        this.song.setCurrentLineType(this.sectionType);
+        break;
+
+      case START_OF_VERSE:
+        this.sectionType = VERSE;
+        break;
+
+      case END_OF_VERSE:
+        this.sectionType = null;
+        this.song.setCurrentLineType(this.sectionType);
+        break;
+    }
   }
 }

--- a/src/parser/parser_warning.js
+++ b/src/parser/parser_warning.js
@@ -1,0 +1,12 @@
+class ParserWarning {
+  constructor(message, lineNumber) {
+    this._message = message;
+    this._lineNumber = lineNumber;
+  }
+
+  toString() {
+    return `Warning: ${this._message} on line ${this._lineNumber}`;
+  }
+}
+
+export default ParserWarning;

--- a/test/chord_sheet/line.js
+++ b/test/chord_sheet/line.js
@@ -35,6 +35,46 @@ describe('Line', () => {
     });
   });
 
+  describe('#isVerse', () => {
+    context('when the line type is "verse"', () => {
+      it('returns true', () => {
+        const line = new Line();
+        line.type = 'verse';
+
+        expect(line.isVerse()).to.be.true;
+      });
+    });
+
+    context('when the line type is not "verse"', () => {
+      it('returns false', () => {
+        const line = new Line();
+        line.type = 'chorus';
+
+        expect(line.isVerse()).to.be.false;
+      });
+    });
+  });
+
+  describe('#isChorus', () => {
+    context('when the line type is "chorus"', () => {
+      it('returns true', () => {
+        const line = new Line();
+        line.type = 'chorus';
+
+        expect(line.isChorus()).to.be.true;
+      });
+    });
+
+    context('when the line type is not "chorus"', () => {
+      it('returns false', () => {
+        const line = new Line();
+        line.type = 'verse';
+
+        expect(line.isChorus()).to.be.false;
+      });
+    });
+  });
+
   describe('#hasRenderableItems', () => {
     context('when the line has renderable items', () => {
       it('returns true', () => {

--- a/test/chord_sheet/line.js
+++ b/test/chord_sheet/line.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import Line from '../../src/chord_sheet/line';
 import ItemStub from '../cloneable_stub';
-import { createLine } from '../utilities';
+import { createChordLyricsPair, createLine, createTag } from '../utilities';
 
 describe('Line', () => {
   describe('#clone', () => {
@@ -71,6 +71,30 @@ describe('Line', () => {
         line.type = 'verse';
 
         expect(line.isChorus()).to.be.false;
+      });
+    });
+  });
+
+  describe('#hasContent', () => {
+    context('when the line contains chord-lyric pairs', () => {
+      it('returns true', () => {
+        const line = createLine([
+          createTag('foo', 'bar'),
+          createChordLyricsPair('C', 'Let it be'),
+        ]);
+
+        expect(line.hasContent()).to.be.true;
+      });
+    });
+
+    context('when the line contains no chord-lyric pairs', () => {
+      it('returns false', () => {
+        const line = createLine([
+          createTag('foo', 'bar'),
+          createTag('bar', 'baz'),
+        ]);
+
+        expect(line.hasContent()).to.be.false;
       });
     });
   });

--- a/test/chord_sheet/paragraph.js
+++ b/test/chord_sheet/paragraph.js
@@ -8,10 +8,8 @@ describe('Paragraph', () => {
     context('when all line types are equal or none', () => {
       it('returns the common type', () => {
         const paragraph = createParagraph([
-          createLine([], NONE),
           createLine([], VERSE),
           createLine([], VERSE),
-          createLine([], NONE),
         ]);
 
         expect(paragraph.type).to.equal(VERSE);
@@ -21,8 +19,6 @@ describe('Paragraph', () => {
     context('when the line types vary', () => {
       it('returns indeterminate', () => {
         const paragraph = createParagraph([
-          createLine([], NONE),
-          createLine([], VERSE),
           createLine([], VERSE),
           createLine([], CHORUS),
         ]);

--- a/test/chord_sheet/paragraph.js
+++ b/test/chord_sheet/paragraph.js
@@ -1,0 +1,34 @@
+import { expect } from 'chai';
+
+import { createLine, createParagraph } from '../utilities';
+import { CHORUS, INDETERMINATE, VERSE } from '../../src/constants';
+
+describe('Paragraph', () => {
+  describe('#type', () => {
+    context('when all line types are equal or none', () => {
+      it('returns the common type', () => {
+        const paragraph = createParagraph([
+          createLine([], NONE),
+          createLine([], VERSE),
+          createLine([], VERSE),
+          createLine([], NONE),
+        ]);
+
+        expect(paragraph.type).to.equal(VERSE);
+      });
+    });
+
+    context('when the line types vary', () => {
+      it('returns indeterminate', () => {
+        const paragraph = createParagraph([
+          createLine([], NONE),
+          createLine([], VERSE),
+          createLine([], VERSE),
+          createLine([], CHORUS),
+        ]);
+
+        expect(paragraph.type).to.equal(INDETERMINATE);
+      });
+    });
+  });
+});

--- a/test/chord_sheet/song.js
+++ b/test/chord_sheet/song.js
@@ -10,6 +10,10 @@ const createLineStub = ({ renderable }) => (
       return renderable;
     },
 
+    hasContent() {
+      return renderable;
+    },
+
     isEmpty() {
       return false;
     },

--- a/test/parser/chord_pro_parser.js
+++ b/test/parser/chord_pro_parser.js
@@ -112,5 +112,54 @@ Let it [F]be [C]
     const lineTypes = song.lines.map(line => line.type);
 
     expect(lineTypes).to.eql([NONE, VERSE, NONE, NONE, NONE, CHORUS, NONE]);
+    expect(parser.warnings).to.be.empty;
+  });
+
+  context('when encountering {end_of_chorus} while the current section type is not chorus', () => {
+    it('adds a parser warning', () => {
+      const invalidChordSheet = '{end_of_chorus}';
+
+      const parser = new ChordProParser();
+      parser.parse(invalidChordSheet);
+
+      expect(parser.warnings).to.have.lengthOf(1);
+      expect(parser.warnings[0].toString()).to.match(/unexpected.+end_of_chorus.+current.+none.+line 1/i);
+    });
+  });
+
+  context('when encountering {end_of_verse} while the current section type is not verse', () => {
+    it('adds a parser warning', () => {
+      const invalidChordSheet = '{end_of_verse}';
+
+      const parser = new ChordProParser();
+      parser.parse(invalidChordSheet);
+
+      expect(parser.warnings).to.have.lengthOf(1);
+      expect(parser.warnings[0].toString()).to.match(/unexpected.+end_of_verse.+current.+none.+line 1/i);
+    });
+  });
+
+  context('when encountering {start_of_chorus} while the current section type is not none', () => {
+    it('adds a parser warning', () => {
+      const invalidChordSheet = '{start_of_verse}\n{start_of_chorus}';
+
+      const parser = new ChordProParser();
+      parser.parse(invalidChordSheet);
+
+      expect(parser.warnings).to.have.lengthOf(1);
+      expect(parser.warnings[0].toString()).to.match(/unexpected.+start_of_chorus.+current.+verse.+line 2/i);
+    });
+  });
+
+  context('when encountering {start_of_chorus} while the current section type is not none', () => {
+    it('adds a parser warning', () => {
+      const invalidChordSheet = '{start_of_chorus}\n{start_of_verse}';
+
+      const parser = new ChordProParser();
+      parser.parse(invalidChordSheet);
+
+      expect(parser.warnings).to.have.lengthOf(1);
+      expect(parser.warnings[0].toString()).to.match(/unexpected.+start_of_verse.+current.+chorus.+line 2/i);
+    });
   });
 });

--- a/test/parser/chord_pro_parser.js
+++ b/test/parser/chord_pro_parser.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import '../matchers';
 import ChordProParser from '../../src/parser/chord_pro_parser';
-import { CHORUS, VERSE } from '../../src/constants';
+import { CHORUS, NONE, VERSE } from '../../src/constants';
 
 const chordSheet = `
 {title: Let it be}
@@ -111,6 +111,6 @@ Let it [F]be [C]
     const song = parser.parse(markedChordSheet);
     const lineTypes = song.lines.map(line => line.type);
 
-    expect(lineTypes).to.eql([null, VERSE, null, null, null, CHORUS, null]);
+    expect(lineTypes).to.eql([NONE, VERSE, NONE, NONE, NONE, CHORUS, NONE]);
   });
 });

--- a/test/parser/chord_pro_parser.js
+++ b/test/parser/chord_pro_parser.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 
 import '../matchers';
 import ChordProParser from '../../src/parser/chord_pro_parser';
+import { CHORUS, VERSE } from '../../src/constants';
 
 const chordSheet = `
 {title: Let it be}
@@ -94,5 +95,22 @@ Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be
     expect(paragraph1Line0Items[1]).to.be.chordLyricsPair('Bb', 'wisdom, let it ');
     expect(paragraph1Line0Items[2]).to.be.chordLyricsPair('F', 'be ');
     expect(paragraph1Line0Items[3]).to.be.chordLyricsPair('C', '');
+  });
+
+  it('adds the type to lines', () => {
+    const markedChordSheet = `
+{start_of_verse}
+Let it [Am]be
+{end_of_verse}
+C]Whisper words of [F]wis[G]dom
+{start_of_chorus}
+Let it [F]be [C]
+{end_of_chorus}`.substring(1);
+
+    const parser = new ChordProParser();
+    const song = parser.parse(markedChordSheet);
+    const lineTypes = song.lines.map(line => line.type);
+
+    expect(lineTypes).to.eql([null, VERSE, null, null, null, CHORUS, null]);
   });
 });

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -2,6 +2,8 @@ import ChordLyricsPair from '../src/chord_sheet/chord_lyrics_pair';
 import Line from '../src/chord_sheet/line';
 import Tag from '../src/chord_sheet/tag';
 import SongStub from './song_stub';
+import { NONE } from '../src/constants';
+import Paragraph from '../src/chord_sheet/paragraph';
 
 export function createSong(lines, metaData) {
   const song = new SongStub(metaData);
@@ -10,10 +12,17 @@ export function createSong(lines, metaData) {
   return song;
 }
 
-export function createLine(items) {
+export function createLine(items, type = NONE) {
   const line = new Line();
   line.items = items;
+  line.type = type;
   return line;
+}
+
+export function createParagraph(lines) {
+  const paragraph = new Paragraph();
+  lines.forEach(line => paragraph.addLine(line));
+  return paragraph;
 }
 
 export function createChordLyricsPair(chords, lyrics) {


### PR DESCRIPTION
This PR is a preparation for #17 (grouping the lines of a paragraph in a tag and adding the paragraph type, such as verse, chorus etc., as a CSS class). It makes sure the paragraph type is recognised and added as `type` property on `Line`s and `Paragraph`s. Currently the tags `start_of_chorus` (`soc`), `end_of_chorus` (`eoc`), `start_of_verse` and `end_of_verse` are used to determine the paragraph type.