### PR TITLE
Clean up dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1973,11 +1973,6 @@
         "os-tmpdir": "^1.0.1"
       }
     },
-    "html-entities": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
-      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -449,6 +449,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-handlebars-inline-precompile/-/babel-plugin-handlebars-inline-precompile-2.1.1.tgz",
       "integrity": "sha1-C1rLGyccxics+4+6F5ZKGnbQ6u4=",
+      "dev": true,
       "requires": {
         "handlebars": "^4.0.5",
         "resolve-cwd": "^1.0.0"
@@ -2533,6 +2534,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-1.0.0.tgz",
       "integrity": "sha1-Tq7qQe0EDRcCRX32SkKysH0kb58=",
+      "dev": true,
       "requires": {
         "resolve-from": "^2.0.0"
       }
@@ -2540,7 +2542,8 @@
     "resolve-from": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+      "dev": true
     },
     "right-align": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "homepage": "https://github.com/martijnversluis/ChordSheetJS",
   "devDependencies": {
     "babel-cli": "^6.26.0",
+    "babel-plugin-handlebars-inline-precompile": "^2.1.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-register": "^6.26.0",
@@ -27,7 +28,6 @@
     "prepublishOnly": "npm install && npm test && npm run build"
   },
   "dependencies": {
-    "babel-plugin-handlebars-inline-precompile": "^2.1.1",
     "handlebars": "^4.0.5",
     "html-entities": "^1.2.1"
   }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "prepublishOnly": "npm install && npm test && npm run build"
   },
   "dependencies": {
-    "handlebars": "^4.0.5",
-    "html-entities": "^1.2.1"
+    "handlebars": "^4.0.5"
   }
 }

--- a/src/formatter/html_entities_encode.js
+++ b/src/formatter/html_entities_encode.js
@@ -1,6 +1,0 @@
-const Html5Entities = require('html-entities').Html5Entities;
-
-export default function htmlEntitiesEncode(data) {
-  const encoder = new Html5Entities();
-  return encoder.encode(data);
-}

--- a/test/formatter/html_div_formatter.js
+++ b/test/formatter/html_div_formatter.js
@@ -2,7 +2,6 @@ import chai, { expect } from 'chai';
 
 import '../matchers';
 import HtmlDivFormatter from '../../src/formatter/html_div_formatter';
-import htmlEntitiesEncode from '../../src/formatter/html_entities_encode';
 import song from '../fixtures/song';
 import { createChordLyricsPair, createLine, createSong } from '../utilities';
 
@@ -94,28 +93,6 @@ describe('HtmlDivFormatter', () => {
       '</div>';
 
     expect(formatter.format(song)).to.equalText(expectedChordSheet);
-  });
-
-  it('encodes HTML entities', () => {
-    const formatter = new HtmlDivFormatter();
-
-    const songWithHtmlEntities = createSong([
-      createLine([
-        createChordLyricsPair('Am', '<h1>Let it</h1>'),
-      ]),
-    ]);
-
-    const expectedChordSheet =
-      '<div class="chord-sheet">' +
-        '<div class="row">' +
-          '<div class="column">' +
-            '<div class="chord">Am</div>' +
-            `<div class="lyrics">${htmlEntitiesEncode('<h1>Let it</h1>')}</div>` +
-          '</div>' +
-        '</div>' +
-      '</div>';
-
-    expect(formatter.format(songWithHtmlEntities)).to.equalText(expectedChordSheet);
   });
 
   context('with option renderBlankLines:false', () => {

--- a/test/formatter/html_table_formatter.js
+++ b/test/formatter/html_table_formatter.js
@@ -2,7 +2,6 @@ import chai, { expect } from 'chai';
 
 import '../matchers';
 import HtmlTableFormatter from '../../src/formatter/html_table_formatter';
-import htmlEntitiesEncode from '../../src/formatter/html_entities_encode';
 import song from '../fixtures/song';
 import { createChordLyricsPair, createLine, createSong } from '../utilities';
 
@@ -76,30 +75,6 @@ describe('HtmlTableFormatter', () => {
       '</div>';
 
     expect(formatter.format(song)).to.equalText(expectedChordSheet);
-  });
-
-  it('encodes HTML entities', () => {
-    const formatter = new HtmlTableFormatter();
-
-    const songWithHtmlEntities = createSong([
-      createLine([
-        createChordLyricsPair('Am', '<h1>Let it</h1>'),
-      ]),
-    ]);
-
-    const expectedChordSheet =
-      '<div class="chord-sheet">' +
-        '<table class="row">' +
-          '<tr>' +
-            '<td class="chord">Am</td>' +
-          '</tr>' +
-          '<tr>' +
-            `<td class="lyrics">${htmlEntitiesEncode('<h1>Let it</h1>')}</td>` +
-          '</tr>' +
-        '</table>' +
-      '</div>';
-
-    expect(formatter.format(songWithHtmlEntities)).to.equalText(expectedChordSheet);
   });
 
   context('with option renderBlankLines:false', () => {


### PR DESCRIPTION
When moving to Handlebars for chord sheet rendering I forgot to check for obsolete dependencies. 

- `html-entities` is no longer needed because `handlebars` takes care of HTML entity encoding, only the tests were using it
- the `babel-plugin-handlebars-inline-precompile` package is only used during build, so it can be a development dependency.