### PR TITLE
Wrap paragraphs in tags

### DIFF
--- a/src/chord_sheet/line.js
+++ b/src/chord_sheet/line.js
@@ -1,6 +1,5 @@
 import ChordLyricsPair from './chord_lyrics_pair';
 import Tag from './tag';
-import { pushNew } from '../utilities';
 import { CHORUS, NONE, VERSE } from '../constants';
 
 export default class Line {
@@ -14,8 +13,22 @@ export default class Line {
     return this.items.length === 0;
   }
 
-  addChordLyricsPair() {
-    this.currentChordLyricsPair = pushNew(this.items, ChordLyricsPair);
+  addItem(item) {
+    if (item instanceof Tag) {
+      this.addTag(item);
+    } else if (item instanceof ChordLyricsPair) {
+      this.addChordLyricsPair(item);
+    }
+  }
+
+  addChordLyricsPair(chords, lyrics) {
+    if (chords instanceof ChordLyricsPair) {
+      this.currentChordLyricsPair = chords;
+    } else {
+      this.currentChordLyricsPair = new ChordLyricsPair(chords, lyrics);
+    }
+
+    this.items.push(this.currentChordLyricsPair);
     return this.currentChordLyricsPair;
   }
 

--- a/src/chord_sheet/song.js
+++ b/src/chord_sheet/song.js
@@ -53,7 +53,7 @@ export default class Song {
     if (this.currentLine !== null) {
       if (this.currentLine.isEmpty()) {
         this.addParagraph();
-      } else if (this.currentLine.hasContent()) {
+      } else if (this.currentLine.hasRenderableItems()) {
         this.currentParagraph.addLine(this.currentLine);
       }
     }

--- a/src/formatter/html_div_formatter.js
+++ b/src/formatter/html_div_formatter.js
@@ -14,22 +14,26 @@ const template = hbs`
   {{~/if~}}
 
   <div class="chord-sheet">
-    {{~#each bodyLines as |line|~}}
-      {{~#if (shouldRenderLine line)~}}
-        <div class="{{lineClasses line}}">
-          {{~#each items as |item|~}}
-            {{~#if (isChordLyricsPair item)~}}
-              <div class="column"><div class="chord">{{chords}}</div><div class="lyrics">{{lyrics}}</div></div>
-            {{~/if~}}
-    
-            {{~#if (isTag item)~}}
-              {{~#if (isComment item)~}}
-                <div class="comment">{{value}}</div>
-              {{~/if~}}
-            {{~/if~}}
-          {{~/each~}}
-        </div>
-      {{~/if~}}
+    {{~#each paragraphs as |paragraph|~}}
+      <div class="{{paragraphClasses paragraph}}">
+        {{~#each lines as |line|~}}
+          {{~#if (shouldRenderLine line)~}}
+            <div class="{{lineClasses line}}">
+              {{~#each items as |item|~}}
+                {{~#if (isChordLyricsPair item)~}}
+                  <div class="column"><div class="chord">{{chords}}</div><div class="lyrics">{{lyrics}}</div></div>
+                {{~/if~}}
+        
+                {{~#if (isTag item)~}}
+                  {{~#if (isComment item)~}}
+                    <div class="comment">{{value}}</div>
+                  {{~/if~}}
+                {{~/if~}}
+              {{~/each~}}
+            </div>
+          {{~/if~}}
+        {{~/each~}}
+      </div>
     {{~/each~}}
   </div>
 {{~/with~}}`;

--- a/src/formatter/html_table_formatter.js
+++ b/src/formatter/html_table_formatter.js
@@ -15,36 +15,40 @@ const template = hbs`
 
   {{~#if bodyLines~}}
     <div class="chord-sheet">
-      {{~#each bodyLines as |line|~}}
-        {{~#if (shouldRenderLine line)~}}
-          <table class="{{lineClasses line}}">
-            {{~#if (hasChordContents line)~}}
-              <tr>
-                {{~#each items as |item|~}}
-                  {{~#if (isChordLyricsPair item)~}}
-                    <td class="chord">{{chords}}</td>
-                  {{~/if~}}
-                {{~/each~}}
-              </tr>
-            {{~/if~}}
+      {{~#each paragraphs as |paragraph|~}}
+        <div class="{{paragraphClasses paragraph}}">
+          {{~#each lines as |line|~}}
+            {{~#if (shouldRenderLine line)~}}
+              <table class="{{lineClasses line}}">
+                {{~#if (hasChordContents line)~}}
+                  <tr>
+                    {{~#each items as |item|~}}
+                      {{~#if (isChordLyricsPair item)~}}
+                        <td class="chord">{{chords}}</td>
+                      {{~/if~}}
+                    {{~/each~}}
+                  </tr>
+                {{~/if~}}
+                  
+                {{~#if (hasTextContents line)~}}
+                  <tr>
+                    {{~#each items as |item|~}}
+                      {{~#if (isChordLyricsPair item)~}}
+                        <td class="lyrics">{{lyrics}}</td>
+                      {{~/if~}}
               
-            {{~#if (hasTextContents line)~}}
-              <tr>
-                {{~#each items as |item|~}}
-                  {{~#if (isChordLyricsPair item)~}}
-                    <td class="lyrics">{{lyrics}}</td>
-                  {{~/if~}}
-          
-                  {{~#if (isTag item)~}}
-                    {{~#if (isComment item)~}}
-                      <td class="comment">{{value}}</td>
-                    {{~/if~}}
-                  {{~/if~}}
-                {{~/each~}}
-              </tr>
+                      {{~#if (isTag item)~}}
+                        {{~#if (isComment item)~}}
+                          <td class="comment">{{value}}</td>
+                        {{~/if~}}
+                      {{~/if~}}
+                    {{~/each~}}
+                  </tr>
+                {{~/if~}}
+              </table>
             {{~/if~}}
-          </table>
-        {{~/if~}}
+          {{~/each~}}
+        </div>
       {{~/each~}}
     </div>
   {{~/if~}}

--- a/src/handlebars_helpers.js
+++ b/src/handlebars_helpers.js
@@ -2,6 +2,7 @@ import HandleBars from 'handlebars/runtime';
 
 import ChordLyricsPair from './chord_sheet/chord_lyrics_pair';
 import Tag from './chord_sheet/tag';
+import { INDETERMINATE, NONE } from './constants';
 import { hasChordContents, hasTextContents } from './utilities';
 
 const lineHasContents = line => line.items.some(item => item.isRenderable());
@@ -37,3 +38,13 @@ HandleBars.registerHelper('lineClasses', (line) => {
 });
 
 HandleBars.registerHelper('toUpperCase', line => line.toUpperCase());
+
+HandleBars.registerHelper('paragraphClasses', (paragraph) => {
+  const classes = ['paragraph'];
+
+  if (paragraph.type !== INDETERMINATE && paragraph.type !== NONE) {
+    classes.push(paragraph.type);
+  }
+
+  return classes.join(' ');
+});

--- a/test/chord_sheet/line.js
+++ b/test/chord_sheet/line.js
@@ -3,6 +3,8 @@ import { expect } from 'chai';
 import Line from '../../src/chord_sheet/line';
 import ItemStub from '../cloneable_stub';
 import { createChordLyricsPair, createLine, createTag } from '../utilities';
+import ChordLyricsPair from '../../src/chord_sheet/chord_lyrics_pair';
+import Tag from '../../src/chord_sheet/tag';
 
 describe('Line', () => {
   describe('#clone', () => {
@@ -19,7 +21,7 @@ describe('Line', () => {
   describe('#isEmpty', () => {
     context('when the line has items', () => {
       it('returns false', () => {
-        const item = new ItemStub();
+        const item = new ChordLyricsPair('C', 'Let it be');
         const line = createLine([item]);
 
         expect(line.isEmpty()).to.be.false;
@@ -103,11 +105,7 @@ describe('Line', () => {
     context('when the line has renderable items', () => {
       it('returns true', () => {
         const line = createLine([
-          {
-            isRenderable() {
-              return true;
-            },
-          },
+          new ChordLyricsPair('C', 'Let it'),
         ]);
 
         expect(line.hasRenderableItems()).to.be.true;
@@ -117,11 +115,7 @@ describe('Line', () => {
     context('when the line has no renderable items', () => {
       it('returns false', () => {
         const line = createLine([
-          {
-            isRenderable() {
-              return false;
-            },
-          },
+          new Tag('x_foo', 'bar'),
         ]);
 
         expect(line.hasRenderableItems()).to.be.false;

--- a/test/fixtures/song.js
+++ b/test/fixtures/song.js
@@ -1,4 +1,5 @@
 import { createSong, createLine, createChordLyricsPair, createTag } from '../utilities';
+import { CHORUS, VERSE } from '../../src/constants';
 
 // Mimic the following chord sheet:
 // {title: Let it be}
@@ -6,10 +7,14 @@ import { createSong, createLine, createChordLyricsPair, createTag } from '../uti
 // {x_some_setting: value}
 // {comment: Bridge}
 //
+// {start_of_verse}
 // Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be
 // [C]Whisper words of [F]wis[G]dom, let it [F]be [C/E] [Dm] [C]
+// {end_of_verse}
 //
+// {start_of_chorus}
 // [Am]Whisper words of [Bb]wisdom, let it [F]be [C]
+// {end_of_chorus}
 
 export default createSong([
   createLine([
@@ -31,12 +36,16 @@ export default createSong([
   createLine([]),
 
   createLine([
+    createTag('start_of_verse'),
+  ]),
+
+  createLine([
     createChordLyricsPair('', 'Let it '),
     createChordLyricsPair('Am', 'be, let it '),
     createChordLyricsPair('C/G', 'be, let it '),
     createChordLyricsPair('F', 'be, let it '),
     createChordLyricsPair('C', 'be'),
-  ]),
+  ], VERSE),
 
   createLine([
     createChordLyricsPair('C', 'Whisper words of '),
@@ -46,15 +55,27 @@ export default createSong([
     createChordLyricsPair('C/E', ' '),
     createChordLyricsPair('Dm', ' '),
     createChordLyricsPair('C', ' '),
+  ], VERSE),
+
+  createLine([
+    createTag('end_of_verse'),
   ]),
 
   createLine([]),
+
+  createLine([
+    createTag('start_of_chorus'),
+  ]),
 
   createLine([
     createChordLyricsPair('Am', 'Whisper words of '),
     createChordLyricsPair('Bb', 'wisdom, let it '),
     createChordLyricsPair('F', 'be '),
     createChordLyricsPair('C', ''),
+  ], CHORUS),
+
+  createLine([
+    createTag('end_of_chorus'),
   ]),
 ], {
   title: 'Let it be',

--- a/test/formatter/chord_pro_formatter.js
+++ b/test/formatter/chord_pro_formatter.js
@@ -13,10 +13,14 @@ describe('ChordProFormatter', () => {
 {x_some_setting}
 {comment: Bridge}
 
+{start_of_verse}
 Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be
 [C]Whisper words of [F]wis[G]dom, let it [F]be [C/E] [Dm] [C] 
+{end_of_verse}
 
-[Am]Whisper words of [Bb]wisdom, let it [F]be [C]`.substring(1);
+{start_of_chorus}
+[Am]Whisper words of [Bb]wisdom, let it [F]be [C]
+{end_of_chorus}`.substring(1);
 
     expect(formatter.format(song)).to.equal(expectedChordSheet);
   });

--- a/test/formatter/html_div_formatter.js
+++ b/test/formatter/html_div_formatter.js
@@ -15,79 +15,83 @@ describe('HtmlDivFormatter', () => {
       '<h1>Let it be</h1>' +
       '<h2>ChordSheetJS example version</h2>' +
       '<div class="chord-sheet">' +
-        '<div class="row">' +
-          '<div class="comment">Bridge</div>' +
-        '</div>' +
-        '<div class="row empty-line"></div>' +
-        '<div class="row">' +
-          '<div class="column">' +
-            '<div class="chord"></div>' +
-            '<div class="lyrics">Let it </div>' +
-          '</div>' +
-          '<div class="column">' +
-            '<div class="chord">Am</div>' +
-            '<div class="lyrics">be, let it </div>' +
-          '</div>' +
-          '<div class="column">' +
-            '<div class="chord">C/G</div>' +
-            '<div class="lyrics">be, let it </div>' +
-          '</div>' +
-          '<div class="column">' +
-            '<div class="chord">F</div>' +
-            '<div class="lyrics">be, let it </div>' +
-          '</div>' +
-          '<div class="column">' +
-            '<div class="chord">C</div>' +
-            '<div class="lyrics">be</div>' +
+        '<div class="paragraph">' +
+          '<div class="row">' +
+            '<div class="comment">Bridge</div>' +
           '</div>' +
         '</div>' +
-        '<div class="row">' +
-          '<div class="column">' +
-            '<div class="chord">C</div>' +
-            '<div class="lyrics">Whisper words of </div>' +
+        '<div class="paragraph verse">' +
+          '<div class="row">' +
+            '<div class="column">' +
+              '<div class="chord"></div>' +
+              '<div class="lyrics">Let it </div>' +
+            '</div>' +
+            '<div class="column">' +
+              '<div class="chord">Am</div>' +
+              '<div class="lyrics">be, let it </div>' +
+            '</div>' +
+            '<div class="column">' +
+              '<div class="chord">C/G</div>' +
+              '<div class="lyrics">be, let it </div>' +
+            '</div>' +
+            '<div class="column">' +
+              '<div class="chord">F</div>' +
+              '<div class="lyrics">be, let it </div>' +
+            '</div>' +
+            '<div class="column">' +
+              '<div class="chord">C</div>' +
+              '<div class="lyrics">be</div>' +
+            '</div>' +
           '</div>' +
-          '<div class="column">' +
-            '<div class="chord">F</div>' +
-            '<div class="lyrics">wis</div>' +
-          '</div>' +
-          '<div class="column">' +
-            '<div class="chord">G</div>' +
-            '<div class="lyrics">dom, let it </div>' +
-          '</div>' +
-          '<div class="column">' +
-            '<div class="chord">F</div>' +
-            '<div class="lyrics">be </div>' +
-          '</div>' +
-          '<div class="column">' +
-            '<div class="chord">C/E</div>' +
-            '<div class="lyrics"> </div>' +
-          '</div>' +
-          '<div class="column">' +
-            '<div class="chord">Dm</div>' +
-            '<div class="lyrics"> </div>' +
-          '</div>' +
-          '<div class="column">' +
-            '<div class="chord">C</div>' +
-            '<div class="lyrics"> </div>' +
+          '<div class="row">' +
+            '<div class="column">' +
+              '<div class="chord">C</div>' +
+              '<div class="lyrics">Whisper words of </div>' +
+            '</div>' +
+            '<div class="column">' +
+              '<div class="chord">F</div>' +
+              '<div class="lyrics">wis</div>' +
+            '</div>' +
+            '<div class="column">' +
+              '<div class="chord">G</div>' +
+              '<div class="lyrics">dom, let it </div>' +
+            '</div>' +
+            '<div class="column">' +
+              '<div class="chord">F</div>' +
+              '<div class="lyrics">be </div>' +
+            '</div>' +
+            '<div class="column">' +
+              '<div class="chord">C/E</div>' +
+              '<div class="lyrics"> </div>' +
+            '</div>' +
+            '<div class="column">' +
+              '<div class="chord">Dm</div>' +
+              '<div class="lyrics"> </div>' +
+            '</div>' +
+            '<div class="column">' +
+              '<div class="chord">C</div>' +
+              '<div class="lyrics"> </div>' +
+            '</div>' +
           '</div>' +
         '</div>' +
-        '<div class="row empty-line"></div>' +
-        '<div class="row">' +
-          '<div class="column">' +
-            '<div class="chord">Am</div>' +
-            '<div class="lyrics">Whisper words of </div>' +
-          '</div>' +
-          '<div class="column">' +
-            '<div class="chord">Bb</div>' +
-            '<div class="lyrics">wisdom, let it </div>' +
-          '</div>' +
-          '<div class="column">' +
-            '<div class="chord">F</div>' +
-            '<div class="lyrics">be </div>' +
-          '</div>' +
-          '<div class="column">' +
-            '<div class="chord">C</div>' +
-            '<div class="lyrics"></div>' +
+        '<div class="paragraph chorus">' +
+          '<div class="row">' +
+            '<div class="column">' +
+              '<div class="chord">Am</div>' +
+              '<div class="lyrics">Whisper words of </div>' +
+            '</div>' +
+            '<div class="column">' +
+              '<div class="chord">Bb</div>' +
+              '<div class="lyrics">wisdom, let it </div>' +
+            '</div>' +
+            '<div class="column">' +
+              '<div class="chord">F</div>' +
+              '<div class="lyrics">be </div>' +
+            '</div>' +
+            '<div class="column">' +
+              '<div class="chord">C</div>' +
+              '<div class="lyrics"></div>' +
+            '</div>' +
           '</div>' +
         '</div>' +
       '</div>';
@@ -111,16 +115,20 @@ describe('HtmlDivFormatter', () => {
 
       const expectedChordSheet =
         '<div class="chord-sheet">' +
-          '<div class="row">' +
-            '<div class="column">' +
-              '<div class="chord">C</div>' +
-              '<div class="lyrics">Whisper words of wisdom</div>' +
+          '<div class="paragraph">' +
+            '<div class="row">' +
+              '<div class="column">' +
+                '<div class="chord">C</div>' +
+                '<div class="lyrics">Whisper words of wisdom</div>' +
+              '</div>' +
             '</div>' +
           '</div>' +
-          '<div class="row">' +
-            '<div class="column">' +
-              '<div class="chord">Am</div>' +
-              '<div class="lyrics">Whisper words of wisdom</div>' +
+          '<div class="paragraph">' +
+            '<div class="row">' +
+              '<div class="column">' +
+                '<div class="chord">Am</div>' +
+                '<div class="lyrics">Whisper words of wisdom</div>' +
+              '</div>' +
             '</div>' +
           '</div>' +
         '</div>';

--- a/test/formatter/html_table_formatter.js
+++ b/test/formatter/html_table_formatter.js
@@ -15,63 +15,67 @@ describe('HtmlTableFormatter', () => {
       '<h1>Let it be</h1>' +
       '<h2>ChordSheetJS example version</h2>' +
       '<div class="chord-sheet">' +
-        '<table class="row">' +
-          '<tr>' +
-            '<td class="comment">Bridge</td>' +
-          '</tr>' +
-        '</table>' +
-        '<table class="row empty-line"></table>' +
-        '<table class="row">' +
-          '<tr>' +
-            '<td class="chord"></td>' +
-            '<td class="chord">Am</td>' +
-            '<td class="chord">C/G</td>' +
-            '<td class="chord">F</td>' +
-            '<td class="chord">C</td>' +
-          '</tr>' +
-          '<tr>' +
-            '<td class="lyrics">Let it </td>' +
-            '<td class="lyrics">be, let it </td>' +
-            '<td class="lyrics">be, let it </td>' +
-            '<td class="lyrics">be, let it </td>' +
-            '<td class="lyrics">be</td>' +
-          '</tr>' +
-        '</table>' +
-        '<table class="row">' +
-          '<tr>' +
-            '<td class="chord">C</td>' +
-            '<td class="chord">F</td>' +
-            '<td class="chord">G</td>' +
-            '<td class="chord">F</td>' +
-            '<td class="chord">C/E</td>' +
-            '<td class="chord">Dm</td>' +
-            '<td class="chord">C</td>' +
-          '</tr>' +
-          '<tr>' +
-            '<td class="lyrics">Whisper words of </td>' +
-            '<td class="lyrics">wis</td>' +
-            '<td class="lyrics">dom, let it </td>' +
-            '<td class="lyrics">be </td>' +
-            '<td class="lyrics"> </td>' +
-            '<td class="lyrics"> </td>' +
-            '<td class="lyrics"> </td>' +
-          '</tr>' +
-        '</table>' +
-        '<table class="row empty-line"></table>' +
-        '<table class="row">' +
-          '<tr>' +
-            '<td class="chord">Am</td>' +
-            '<td class="chord">Bb</td>' +
-            '<td class="chord">F</td>' +
-            '<td class="chord">C</td>' +
-          '</tr>' +
-          '<tr>' +
-            '<td class="lyrics">Whisper words of </td>' +
-            '<td class="lyrics">wisdom, let it </td>' +
-            '<td class="lyrics">be </td>' +
-            '<td class="lyrics"></td>' +
-          '</tr>' +
-        '</table>' +
+        '<div class="paragraph">' +
+          '<table class="row">' +
+            '<tr>' +
+              '<td class="comment">Bridge</td>' +
+            '</tr>' +
+          '</table>' +
+        '</div>' +
+        '<div class="paragraph verse">' +
+          '<table class="row">' +
+            '<tr>' +
+              '<td class="chord"></td>' +
+              '<td class="chord">Am</td>' +
+              '<td class="chord">C/G</td>' +
+              '<td class="chord">F</td>' +
+              '<td class="chord">C</td>' +
+            '</tr>' +
+            '<tr>' +
+              '<td class="lyrics">Let it </td>' +
+              '<td class="lyrics">be, let it </td>' +
+              '<td class="lyrics">be, let it </td>' +
+              '<td class="lyrics">be, let it </td>' +
+              '<td class="lyrics">be</td>' +
+            '</tr>' +
+          '</table>' +
+          '<table class="row">' +
+            '<tr>' +
+              '<td class="chord">C</td>' +
+              '<td class="chord">F</td>' +
+              '<td class="chord">G</td>' +
+              '<td class="chord">F</td>' +
+              '<td class="chord">C/E</td>' +
+              '<td class="chord">Dm</td>' +
+              '<td class="chord">C</td>' +
+            '</tr>' +
+            '<tr>' +
+              '<td class="lyrics">Whisper words of </td>' +
+              '<td class="lyrics">wis</td>' +
+              '<td class="lyrics">dom, let it </td>' +
+              '<td class="lyrics">be </td>' +
+              '<td class="lyrics"> </td>' +
+              '<td class="lyrics"> </td>' +
+              '<td class="lyrics"> </td>' +
+            '</tr>' +
+          '</table>' +
+        '</div>' +
+        '<div class="paragraph chorus">' +
+          '<table class="row">' +
+            '<tr>' +
+              '<td class="chord">Am</td>' +
+              '<td class="chord">Bb</td>' +
+              '<td class="chord">F</td>' +
+              '<td class="chord">C</td>' +
+            '</tr>' +
+            '<tr>' +
+              '<td class="lyrics">Whisper words of </td>' +
+              '<td class="lyrics">wisdom, let it </td>' +
+              '<td class="lyrics">be </td>' +
+              '<td class="lyrics"></td>' +
+            '</tr>' +
+          '</table>' +
+        '</div>' +
       '</div>';
 
     expect(formatter.format(song)).to.equalText(expectedChordSheet);
@@ -93,22 +97,26 @@ describe('HtmlTableFormatter', () => {
 
       const expectedChordSheet =
         '<div class="chord-sheet">' +
-          '<table class="row">' +
-            '<tr>' +
-              '<td class="chord">C</td>' +
-            '</tr>' +
-            '<tr>' +
-              '<td class="lyrics">Whisper words of wisdom</td>' +
-            '</tr>' +
-          '</table>' +
-          '<table class="row">' +
-            '<tr>' +
-              '<td class="chord">Am</td>' +
-            '</tr>' +
-            '<tr>' +
-              '<td class="lyrics">Whisper words of wisdom</td>' +
-            '</tr>' +
-          '</table>' +
+        '<div class="paragraph">' +
+            '<table class="row">' +
+              '<tr>' +
+                '<td class="chord">C</td>' +
+              '</tr>' +
+              '<tr>' +
+                '<td class="lyrics">Whisper words of wisdom</td>' +
+              '</tr>' +
+            '</table>' +
+          '</div>' +
+        '<div class="paragraph">' +
+            '<table class="row">' +
+              '<tr>' +
+                '<td class="chord">Am</td>' +
+              '</tr>' +
+              '<tr>' +
+                '<td class="lyrics">Whisper words of wisdom</td>' +
+              '</tr>' +
+            '</table>' +
+          '</div>' +
         '</div>';
 
       const formatter = new HtmlTableFormatter({ renderBlankLines: false });

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -14,7 +14,7 @@ export function createSong(lines, metaData) {
 
 export function createLine(items, type = NONE) {
   const line = new Line();
-  line.items = items;
+  items.forEach(item => line.addItem(item));
   line.type = type;
   return line;
 }


### PR DESCRIPTION
# Use paragraph type in html formatters

 This changes the HTML formatters to render per paragraph. It adds a CSS
class when the paragraph type can be determined from usage of
`{start_of_verse}`, `{end_of_verse}`, `{start_of_chorus}` or `{end_of_chorus}`.

Fixes #17 