### PR TITLE
Add more metadata directives

### DIFF
--- a/src/chord_sheet/song.js
+++ b/src/chord_sheet/song.js
@@ -1,23 +1,9 @@
 import Line from './line';
-import Tag, {
-  ALBUM,
-  ARTIST,
-  CAPO,
-  COMPOSER,
-  COPYRIGHT,
-  DURATION,
-  KEY,
-  LYRICIST,
-  SUBTITLE,
-  TEMPO,
-  TIME,
-  TITLE,
-  YEAR,
-} from './tag';
+import Tag, { META_TAGS } from './tag';
 import Paragraph from './paragraph';
 import { pushNew } from '../utilities';
 
-export default class Song {
+class Song {
   constructor(metaData = {}) {
     this.lines = [];
     this.currentLine = null;
@@ -116,59 +102,20 @@ export default class Song {
     return clonedSong;
   }
 
-  get album() {
-    return this.getMetaData(ALBUM);
-  }
-
-  get artist() {
-    return this.getMetaData(ARTIST);
-  }
-
-  get capo() {
-    return this.getMetaData(CAPO);
-  }
-
-  get composer() {
-    return this.getMetaData(COMPOSER);
-  }
-
-  get copyright() {
-    return this.getMetaData(COPYRIGHT);
-  }
-
-  get duration() {
-    return this.getMetaData(DURATION);
-  }
-
-  get key() {
-    return this.getMetaData(KEY);
-  }
-
-  get lyricist() {
-    return this.getMetaData(LYRICIST);
-  }
-
-  get tempo() {
-    return this.getMetaData(TEMPO);
-  }
-
-  get time() {
-    return this.getMetaData(TIME);
-  }
-
-  get title() {
-    return this.getMetaData(TITLE);
-  }
-
-  get subtitle() {
-    return this.getMetaData(SUBTITLE);
-  }
-
-  get year() {
-    return this.getMetaData(YEAR);
-  }
-
   getMetaData(name) {
     return this.metaData[name] || null;
   }
 }
+
+const defineProperty = Object.defineProperty;
+const songPrototype = Song.prototype;
+
+META_TAGS.forEach((tagName) => {
+  defineProperty(songPrototype, tagName, {
+    get() {
+      return this.getMetaData(tagName);
+    },
+  });
+});
+
+export default Song;

--- a/src/chord_sheet/song.js
+++ b/src/chord_sheet/song.js
@@ -1,10 +1,21 @@
 import Line from './line';
-import Tag from './tag';
+import Tag, {
+  ALBUM,
+  ARTIST,
+  CAPO,
+  COMPOSER,
+  COPYRIGHT,
+  DURATION,
+  KEY,
+  LYRICIST,
+  SUBTITLE,
+  TEMPO,
+  TIME,
+  TITLE,
+  YEAR,
+} from './tag';
 import Paragraph from './paragraph';
 import { pushNew } from '../utilities';
-
-const TITLE = 'title';
-const SUBTITLE = 'subtitle';
 
 export default class Song {
   constructor(metaData = {}) {
@@ -98,18 +109,66 @@ export default class Song {
     return tag;
   }
 
-  get title() {
-    return this.metaData[TITLE] || '';
-  }
-
-  get subtitle() {
-    return this.metaData[SUBTITLE] || '';
-  }
-
   clone() {
     const clonedSong = new Song();
     clonedSong.lines = this.lines.map(line => line.clone());
     clonedSong.metaData = { ...this.metaData };
     return clonedSong;
+  }
+
+  get album() {
+    return this.getMetaData(ALBUM);
+  }
+
+  get artist() {
+    return this.getMetaData(ARTIST);
+  }
+
+  get capo() {
+    return this.getMetaData(CAPO);
+  }
+
+  get composer() {
+    return this.getMetaData(COMPOSER);
+  }
+
+  get copyright() {
+    return this.getMetaData(COPYRIGHT);
+  }
+
+  get duration() {
+    return this.getMetaData(DURATION);
+  }
+
+  get key() {
+    return this.getMetaData(KEY);
+  }
+
+  get lyricist() {
+    return this.getMetaData(LYRICIST);
+  }
+
+  get tempo() {
+    return this.getMetaData(TEMPO);
+  }
+
+  get time() {
+    return this.getMetaData(TIME);
+  }
+
+  get title() {
+    return this.getMetaData(TITLE);
+  }
+
+  get subtitle() {
+    return this.getMetaData(SUBTITLE);
+  }
+
+  get year() {
+    return this.getMetaData(YEAR);
+  }
+
+  getMetaData(name) {
+    return this.metaData[name] || null;
   }
 }

--- a/src/chord_sheet/tag.js
+++ b/src/chord_sheet/tag.js
@@ -25,7 +25,7 @@ const END_OF_CHORUS_SHORT = 'eoc';
 
 const RENDERABLE_TAGS = [COMMENT];
 
-const META_TAGS = [
+export const META_TAGS = [
   ALBUM,
   ARTIST,
   CAPO,

--- a/src/chord_sheet/tag.js
+++ b/src/chord_sheet/tag.js
@@ -1,10 +1,21 @@
-export const TITLE = 'title';
-export const SUBTITLE = 'subtitle';
+export const ALBUM = 'album';
+export const ARTIST = 'artist';
+export const CAPO = 'capo';
 export const COMMENT = 'comment';
-export const START_OF_CHORUS = 'start_of_chorus';
+export const COMPOSER = 'composer';
+export const COPYRIGHT = 'copyright';
+export const DURATION = 'duration';
 export const END_OF_CHORUS = 'end_of_chorus';
-export const START_OF_VERSE = 'start_of_verse';
 export const END_OF_VERSE = 'end_of_verse';
+export const KEY = 'key';
+export const LYRICIST = 'lyricist';
+export const START_OF_CHORUS = 'start_of_chorus';
+export const START_OF_VERSE = 'start_of_verse';
+export const SUBTITLE = 'subtitle';
+export const TEMPO = 'tempo';
+export const TIME = 'time';
+export const TITLE = 'title';
+export const YEAR = 'year';
 
 const TITLE_SHORT = 't';
 const SUBTITLE_SHORT = 'st';
@@ -12,8 +23,23 @@ const COMMENT_SHORT = 'c';
 const START_OF_CHORUS_SHORT = 'soc';
 const END_OF_CHORUS_SHORT = 'eoc';
 
-const META_TAGS = [TITLE, SUBTITLE];
 const RENDERABLE_TAGS = [COMMENT];
+
+const META_TAGS = [
+  ALBUM,
+  ARTIST,
+  CAPO,
+  COMPOSER,
+  COPYRIGHT,
+  DURATION,
+  KEY,
+  LYRICIST,
+  TEMPO,
+  TIME,
+  TITLE,
+  SUBTITLE,
+  YEAR,
+];
 
 const ALIASES = {
   [TITLE_SHORT]: TITLE,

--- a/test/chord_sheet/song.js
+++ b/test/chord_sheet/song.js
@@ -33,6 +33,72 @@ describe('Song', () => {
     expect(song.subtitle).to.eq('Song subtitle');
   });
 
+  it('can have an artist', () => {
+    const song = new Song({ artist: 'Song artist' });
+
+    expect(song.artist).to.eq('Song artist');
+  });
+
+  it('can have a composer', () => {
+    const song = new Song({ composer: 'Song composer' });
+
+    expect(song.composer).to.eq('Song composer');
+  });
+
+  it('can have a lyricist', () => {
+    const song = new Song({ lyricist: 'Song lyricist' });
+
+    expect(song.lyricist).to.eq('Song lyricist');
+  });
+
+  it('can have a copyright', () => {
+    const song = new Song({ copyright: 'Song copyright' });
+
+    expect(song.copyright).to.eq('Song copyright');
+  });
+
+  it('can have an album', () => {
+    const song = new Song({ album: 'Song album' });
+
+    expect(song.album).to.eq('Song album');
+  });
+
+  it('can have a year', () => {
+    const song = new Song({ year: 'Song year' });
+
+    expect(song.year).to.eq('Song year');
+  });
+
+  it('can have a key', () => {
+    const song = new Song({ key: 'Song key' });
+
+    expect(song.key).to.eq('Song key');
+  });
+
+  it('can have a time', () => {
+    const song = new Song({ time: 'Song time' });
+
+    expect(song.time).to.eq('Song time');
+  });
+
+  it('can have a tempo', () => {
+    const song = new Song({ tempo: 'Song tempo' });
+
+    expect(song.tempo).to.eq('Song tempo');
+  });
+
+  it('can have a duration', () => {
+    const song = new Song({ duration: 'Song duration' });
+
+    expect(song.duration).to.eq('Song duration');
+  });
+
+  it('can have a capo', () => {
+    const song = new Song({ capo: 'Song capo' });
+
+    expect(song.capo).to.eq('Song capo');
+  });
+
   describe('#clone', () => {
     it('returns a clone of the song', () => {
       const song = new Song();

--- a/test/chord_sheet/song.js
+++ b/test/chord_sheet/song.js
@@ -21,6 +21,18 @@ const createLineStub = ({ renderable }) => (
 );
 
 describe('Song', () => {
+  it('can have a title', () => {
+    const song = new Song({ title: 'Song title' });
+
+    expect(song.title).to.eq('Song title');
+  });
+
+  it('can have a subtitle', () => {
+    const song = new Song({ subtitle: 'Song subtitle' });
+
+    expect(song.subtitle).to.eq('Song subtitle');
+  });
+
   describe('#clone', () => {
     it('returns a clone of the song', () => {
       const song = new Song();


### PR DESCRIPTION
When using the `ChordProParser`, all official meta data directives are parsed and accessible as properties on the parsed song. For example:

```js
const chordSheet = `
{title: Let it be}
{artist: The Beatles}

Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be
[C]Whisper words of [G]wisdom, let it [F]be [C/E] [Dm] [C]`.substring(1);

const parser = new ChordSheetJS.ChordProParser();
const song = parser.parse(chordSheet);

console.log(song.title);  // Prints "Let it be"
console.log(song.artist); // Prints "The Beatles"
```

Support is added for:

- artist
- composer
- lyricist
- copyright
- album
- year
- key
- time
- tempo
- duration
- capo

See: https://www.chordpro.org/chordpro/ChordPro-Directives.html#meta-data-directives

Fixes #15 