### PR TITLE
Allow multiple values for meta data directives

### DIFF
--- a/src/chord_sheet/song.js
+++ b/src/chord_sheet/song.js
@@ -9,7 +9,15 @@ class Song {
     this.currentLine = null;
     this.paragraphs = [];
     this.currentParagraph = null;
-    this.metaData = metaData;
+    this.assignMetaData(metaData);
+  }
+
+  assignMetaData(metaData) {
+    this.metaData = {};
+
+    Object.keys(metaData).forEach((key) => {
+      this.setMetaData(key, metaData[key]);
+    });
   }
 
   get bodyLines() {
@@ -86,7 +94,7 @@ class Song {
     const tag = Tag.parse(tagContents);
 
     if (tag.isMetaTag()) {
-      this.metaData[tag.name] = tag.value;
+      this.setMetaData(tag.name, tag.value);
     }
 
     this.ensureLine();
@@ -102,8 +110,28 @@ class Song {
     return clonedSong;
   }
 
+  setMetaData(name, value) {
+    if (!(name in this.metaData)) {
+      this.metaData[name] = new Set();
+    }
+
+    this.metaData[name].add(value);
+  }
+
   getMetaData(name) {
-    return this.metaData[name] || null;
+    const valueSet = this.metaData[name];
+
+    if (valueSet === undefined) {
+      return null;
+    }
+
+    const values = [...valueSet];
+
+    if (values.length === 1) {
+      return values[0];
+    }
+
+    return values;
   }
 }
 

--- a/test/parser/chord_pro_parser.js
+++ b/test/parser/chord_pro_parser.js
@@ -54,6 +54,17 @@ describe('ChordProParser', () => {
     expect(song.subtitle).to.equal('ChordSheetJS example version');
   });
 
+  it('can have multiple values for a meta directive', () => {
+    const chordSheetWithMultipleComposers = `
+      {composer: John}
+      {composer: Jane}
+    `;
+
+    const song = new ChordProParser().parse(chordSheetWithMultipleComposers);
+
+    expect(song.composer).to.eql(['John', 'Jane']);
+  });
+
   it('ignores comments', () => {
     const chordSheetWithComment = '# this is a comment\nLet it [Am]be, let it [C/G]be';
     const song = new ChordProParser().parse(chordSheetWithComment);


### PR DESCRIPTION
For example, for a chord sheet:

{composer: John}
{composer: Jane}

`song.composer` will return `['John', 'Jane']`

Fixes #45 