### PR TITLE
Correctly handle custom meta data

### DIFF
--- a/src/chord_sheet/song.js
+++ b/src/chord_sheet/song.js
@@ -13,7 +13,7 @@ class Song {
   }
 
   assignMetaData(metaData) {
-    this.metaData = {};
+    this.rawMetaData = {};
 
     Object.keys(metaData).forEach((key) => {
       this.setMetaData(key, metaData[key]);
@@ -106,21 +106,40 @@ class Song {
   clone() {
     const clonedSong = new Song();
     clonedSong.lines = this.lines.map(line => line.clone());
-    clonedSong.metaData = { ...this.metaData };
+    clonedSong.rawMetaData = { ...this.rawMetaData };
     return clonedSong;
   }
 
   setMetaData(name, value) {
-    if (!(name in this.metaData)) {
-      this.metaData[name] = new Set();
+    this.optimizedMetaData = null;
+
+    if (!(name in this.rawMetaData)) {
+      this.rawMetaData[name] = new Set();
     }
 
-    this.metaData[name].add(value);
+    this.rawMetaData[name].add(value);
   }
 
-  getMetaData(name) {
-    const valueSet = this.metaData[name];
+  get metaData() {
+    if (!this.optimizedMetaData) {
+      this.optimizedMetaData = this.getOptimizedMetaData();
+    }
 
+    return this.optimizedMetaData;
+  }
+
+  getOptimizedMetaData() {
+    const optimizedMetaData = {};
+
+    Object.keys(this.rawMetaData).forEach((key) => {
+      const valueSet = this.rawMetaData[key];
+      optimizedMetaData[key] = this.optimizeMetaDataValue(valueSet);
+    });
+
+    return optimizedMetaData;
+  }
+
+  optimizeMetaDataValue(valueSet) {
     if (valueSet === undefined) {
       return null;
     }
@@ -132,6 +151,10 @@ class Song {
     }
 
     return values;
+  }
+
+  getMetaData(name) {
+    return this.metaData[name] || null;
   }
 }
 

--- a/src/chord_sheet/tag.js
+++ b/src/chord_sheet/tag.js
@@ -51,6 +51,7 @@ const ALIASES = {
 
 const META_TAG_REGEX = /^meta:\s*([^:\s]+)(\s*(.+))?$/;
 const TAG_REGEX = /^([^:\s]+)(:?\s*(.+))?$/;
+const CUSTOM_META_TAG_NAME_REGEX = /^x_(.+)$/;
 
 const translateTagNameAlias = (name) => {
   if (!name) {
@@ -120,7 +121,7 @@ export default class Tag {
   }
 
   isMetaTag() {
-    return META_TAGS.indexOf(this.name) !== -1;
+    return CUSTOM_META_TAG_NAME_REGEX.test(this.name) || META_TAGS.indexOf(this.name) !== -1;
   }
 
   clone() {

--- a/test/chord_sheet/song.js
+++ b/test/chord_sheet/song.js
@@ -103,7 +103,7 @@ describe('Song', () => {
     it('returns a clone of the song', () => {
       const song = new Song();
       song.lines = ['foo', 'bar'].map(value => new LineStub(value));
-      song.metaData = { foo: 'bar' };
+      song.assignMetaData({ foo: 'bar' });
       const clonedSong = song.clone();
 
       const actualValues = clonedSong.lines.map(line => line.value);

--- a/test/parser/chord_pro_parser.js
+++ b/test/parser/chord_pro_parser.js
@@ -54,6 +54,18 @@ describe('ChordProParser', () => {
     expect(song.subtitle).to.equal('ChordSheetJS example version');
   });
 
+  it('parses custom meta data', () => {
+    const chordSheetWithCustomMetaData = `
+      {x_one_directive: Foo}
+      {x_other_directive: Bar}
+    `;
+
+    const song = new ChordProParser().parse(chordSheetWithCustomMetaData);
+
+    expect(song.metaData.x_one_directive).to.equal('Foo');
+    expect(song.metaData.x_other_directive).to.equal('Bar');
+  });
+
   it('can have multiple values for a meta directive', () => {
     const chordSheetWithMultipleComposers = `
       {composer: John}


### PR DESCRIPTION
All meta data directives with a name starting with `x_` are stored in
`song.metaData`

See https://www.chordpro.org/chordpro/ChordPro-Directives.html#custom-extensions.

Fixes #21 