### PR TITLE
Add api docs

### DIFF
--- a/README.hbs
+++ b/README.hbs
@@ -5,7 +5,7 @@ A JavaScript library for parsing and formatting chord sheets
 **Contents**
 
 - [Installation](#installation)
-- [How to ...?](#how-to)
+- [How to ...?](#how-to-)
 - [Supported ChordPro directives](#supported-chordpro-directives)
 - [API docs](#api-docs)
 

--- a/README.hbs
+++ b/README.hbs
@@ -1,0 +1,187 @@
+# ChordSheetJS [![Build Status](https://travis-ci.org/martijnversluis/ChordSheetJS.svg?branch=master)](https://travis-ci.org/martijnversluis/ChordSheetJS) [![npm version](https://badge.fury.io/js/chordsheetjs.svg)](https://badge.fury.io/js/chordsheetjs) [![Code Climate](https://codeclimate.com/github/martijnversluis/ChordSheetJS/badges/gpa.svg)](https://codeclimate.com/github/martijnversluis/ChordSheetJS)
+
+A JavaScript library for parsing and formatting chord sheets
+
+**Contents**
+
+- [Installation](#installation)
+- [How to ...?](#how-to)
+- [Supported ChordPro directives](#supported-chordpro-directives)
+- [API docs](#api-docs)
+
+## Installation
+
+`ChordSheetJS` is on npm, to install run:
+
+```bash
+npm install chordsheetjs
+```
+
+Load with `require()`:
+
+```javascript
+var ChordSheetJS = require('chordsheetjs');
+```
+
+or `import` (es2015):
+
+```javascript
+import ChordSheetJS from 'chordsheetjs';
+```
+
+## How to ...?
+
+### Parse chord sheet
+
+#### Regular chord sheets
+
+```javascript
+const chordSheet = `
+       Am         C/G        F          C
+Let it be, let it be, let it be, let it be
+C                G              F  C/E Dm C
+Whisper words of wisdom, let it be`.substring(1);
+
+const parser = new ChordSheetJS.ChordSheetParser();
+const song = parser.parse(chordSheet);
+```
+
+#### Chord pro format
+
+```javascript
+const chordSheet = `
+{title: Let it be}
+{subtitle: ChordSheetJS example version}
+{Chorus}
+
+Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be
+[C]Whisper words of [G]wisdom, let it [F]be [C/E] [Dm] [C]`.substring(1);
+
+const parser = new ChordSheetJS.ChordProParser();
+const song = parser.parse(chordSheet);
+```
+
+### Display a parsed sheet
+
+#### Plain text format
+
+```javascript
+const formatter = new ChordSheetJS.TextFormatter();
+const disp = formatter.format(song);
+```
+
+#### HTML format
+
+##### Table-based layout
+
+```javascript
+const formatter = new ChordSheetJS.HtmlTableFormatter();
+const disp = formatter.format(song);
+```
+
+##### Div-based layout
+
+```javascript
+const formatter = new ChordSheetJS.HtmlDivFormatter();
+const disp = formatter.format(song);
+```
+
+#### Chord pro format
+
+```javascript
+const formatter = new ChordSheetJS.ChordProFormatter();
+const disp = formatter.format(song);
+```
+
+## Supported ChordPro directives
+
+:heavy_check_mark: = supported
+
+:clock2: = will be supported in a future version
+
+:heavy_multiplication_x: = no plans to support it in the near future
+
+### Meta-data directives
+
+| Directive        | Support            |
+|:---------------- |:------------------:|
+| title (short: t) | :heavy_check_mark: |
+| subtitle         | :heavy_check_mark: |
+| artist           | :clock2:           |
+| composer         | :clock2:           |
+| lyricist         | :clock2:           |
+| copyright        | :clock2:           |
+| album            | :clock2:           |
+| year             | :clock2:           |
+| key              | :clock2:           |
+| time             | :clock2:           |
+| tempo            | :clock2:           |
+| duration         | :clock2:           |
+| capo             | :clock2:           |
+| meta             | :clock2:           |
+
+### Formatting directives
+
+| Directive                  | Support                  |
+|:-------------------------- |:------------------------:|
+| comment (short: c)         | :heavy_check_mark:       |
+| comment_italic (short: ci) | :heavy_multiplication_x: |
+| comment_box (short: cb)    | :heavy_multiplication_x: |
+| chorus                     | :heavy_multiplication_x: |
+| image                      | :heavy_multiplication_x: |
+
+### Environment directives
+
+| Directive                    | Support                  |
+|:---------------------------- |:------------------------:|
+| start_of_chorus (short: soc) | :heavy_check_mark:       |
+| end_of_chorus (short: eoc)   | :heavy_check_mark:       |
+| start_of_verse               | :heavy_check_mark:       |
+| end_of_verse                 | :heavy_check_mark:       |
+| start_of_tab (short: sot)    | :heavy_multiplication_x: |
+| end_of_tab (short: eot)      | :heavy_multiplication_x: |
+| start_of_grid                | :heavy_multiplication_x: |
+| end_of_grid                  | :heavy_multiplication_x: |
+
+### Chord diagrams
+
+| Directive | Support                  |
+|:--------- |:------------------------:|
+| define    | :heavy_multiplication_x: |
+| chord     | :heavy_multiplication_x: |
+
+### Fonts, sizes and colours
+
+| Directive   | Support                  |
+|:----------- |:------------------------:|
+| textfont    | :clock2:                 |
+| textsize    | :clock2:                 |
+| textcolour  | :clock2:                 |
+| chordfont   | :clock2:                 |
+| chordsize   | :clock2:                 |
+| chordcolour | :clock2:                 |
+| tabfont     | :heavy_multiplication_x: |
+| tabsize     | :heavy_multiplication_x: |
+| tabcolour   | :heavy_multiplication_x: |
+
+### Output related directives
+
+| Directive                      | Support                  |
+|:------------------------------ |:------------------------:|
+| new_page (short: np)           | :heavy_multiplication_x: | 
+| new_physical_page (short: npp) | :heavy_multiplication_x: |
+| column_break (short: cb)       | :heavy_multiplication_x: |
+| grid (short: g)                | :heavy_multiplication_x: |
+| no_grid (short: ng)            | :heavy_multiplication_x: |
+| titles                         | :heavy_multiplication_x: |
+| columns (short: col)           | :heavy_multiplication_x: |
+
+### Custom extensions
+
+| Directive | Support  |
+|:--------- |:--------:|
+| x_        | :clock2: |
+
+## API docs
+
+{{>main}}

--- a/README.hbs
+++ b/README.hbs
@@ -99,7 +99,7 @@ const disp = formatter.format(song);
 
 :clock2: = will be supported in a future version
 
-:heavy_multiplication_x: = no plans to support it in the near future
+:heavy_multiplication_x: = currently no plans to support it in the near future
 
 ### Meta-data directives
 
@@ -107,18 +107,18 @@ const disp = formatter.format(song);
 |:---------------- |:------------------:|
 | title (short: t) | :heavy_check_mark: |
 | subtitle         | :heavy_check_mark: |
-| artist           | :clock2:           |
-| composer         | :clock2:           |
-| lyricist         | :clock2:           |
-| copyright        | :clock2:           |
-| album            | :clock2:           |
-| year             | :clock2:           |
-| key              | :clock2:           |
-| time             | :clock2:           |
-| tempo            | :clock2:           |
-| duration         | :clock2:           |
-| capo             | :clock2:           |
-| meta             | :clock2:           |
+| artist           | :heavy_check_mark: |
+| composer         | :heavy_check_mark: |
+| lyricist         | :heavy_check_mark: |
+| copyright        | :heavy_check_mark: |
+| album            | :heavy_check_mark: |
+| year             | :heavy_check_mark: |
+| key              | :heavy_check_mark: |
+| time             | :heavy_check_mark: |
+| tempo            | :heavy_check_mark: |
+| duration         | :heavy_check_mark: |
+| capo             | :heavy_check_mark: |
+| meta             | :heavy_check_mark: |
 
 ### Formatting directives
 
@@ -178,9 +178,9 @@ const disp = formatter.format(song);
 
 ### Custom extensions
 
-| Directive | Support  |
-|:--------- |:--------:|
-| x_        | :clock2: |
+| Directive | Support            |
+|:--------- |:------------------:|
+| x_        | :heavy_check_mark: |
 
 ## API docs
 

--- a/README.hbs
+++ b/README.hbs
@@ -184,4 +184,7 @@ const disp = formatter.format(song);
 
 ## API docs
 
+Note: all classes, methods and constants that are documented here can be considered public API and will only be
+subject to breaking changes between major versions.
+
 {{>main}}

--- a/README.md
+++ b/README.md
@@ -174,3 +174,662 @@ const disp = formatter.format(song);
 | Directive | Support  |
 |:--------- |:--------:|
 | x_        | :clock2: |
+
+## API docs
+
+## Classes
+
+<dl>
+<dt><a href="#ChordLyricsPair">ChordLyricsPair</a></dt>
+<dd><p>Represents a chord with the corresponding (partial) lyrics</p>
+</dd>
+<dt><a href="#Line">Line</a></dt>
+<dd><p>Represents a line in a chord sheet, consisting of items of type ChordLyricsPair or Tag</p>
+</dd>
+<dt><a href="#Paragraph">Paragraph</a></dt>
+<dd><p>Represents a paragraph of lines in a chord sheet</p>
+</dd>
+<dt><a href="#Song">Song</a></dt>
+<dd><p>Represents a song in a chord sheet. Currently a chord sheet can only have one song.</p>
+</dd>
+<dt><a href="#Tag">Tag</a></dt>
+<dd><p>Represents a tag/directive. See <a href="https://www.chordpro.org/chordpro/ChordPro-Directives.html">https://www.chordpro.org/chordpro/ChordPro-Directives.html</a></p>
+</dd>
+<dt><a href="#ChordProFormatter">ChordProFormatter</a></dt>
+<dd><p>Formats a song into a ChordPro chord sheet</p>
+</dd>
+<dt><a href="#HtmlDivFormatter">HtmlDivFormatter</a></dt>
+<dd><p>Formats a song into HTML. It uses DIVs to align lyrics with chords, which makes it useful for responsive web pages.</p>
+</dd>
+<dt><a href="#HtmlTableFormatter">HtmlTableFormatter</a></dt>
+<dd><p>Formats a song into HTML. It uses TABLEs to align lyrics with chords, which makes the HTML for things like
+PDF conversion.</p>
+</dd>
+<dt><a href="#TextFormatter">TextFormatter</a></dt>
+<dd><p>Formats a sonf into a plain text chord sheet</p>
+</dd>
+<dt><a href="#ChordProParser">ChordProParser</a></dt>
+<dd><p>Parses a ChordPro chord sheet</p>
+</dd>
+<dt><a href="#ParserWarning">ParserWarning</a></dt>
+<dd><p>Represents a parser warning, currently only used by ChordProParser.</p>
+</dd>
+</dl>
+
+## Constants
+
+<dl>
+<dt><a href="#ALBUM">ALBUM</a> : <code>string</code></dt>
+<dd><p>Album meta directive. See <a href="https://www.chordpro.org/chordpro/Directives-album.html">https://www.chordpro.org/chordpro/Directives-album.html</a></p>
+</dd>
+<dt><a href="#ARTIST">ARTIST</a> : <code>string</code></dt>
+<dd><p>Artist meta directive. See <a href="https://www.chordpro.org/chordpro/Directives-artist.html">https://www.chordpro.org/chordpro/Directives-artist.html</a></p>
+</dd>
+<dt><a href="#CAPO">CAPO</a> : <code>string</code></dt>
+<dd><p>Capo meta directive. See <a href="https://www.chordpro.org/chordpro/Directives-capo.html">https://www.chordpro.org/chordpro/Directives-capo.html</a></p>
+</dd>
+<dt><a href="#COMMENT">COMMENT</a> : <code>string</code></dt>
+<dd><p>Comment directive. See <a href="https://www.chordpro.org/chordpro/Directives-comment.html">https://www.chordpro.org/chordpro/Directives-comment.html</a></p>
+</dd>
+<dt><a href="#COMPOSER">COMPOSER</a> : <code>string</code></dt>
+<dd><p>Composer meta directive. See <a href="https://www.chordpro.org/chordpro/Directives-composer.html">https://www.chordpro.org/chordpro/Directives-composer.html</a></p>
+</dd>
+<dt><a href="#COPYRIGHT">COPYRIGHT</a> : <code>string</code></dt>
+<dd><p>Copyright meta directive. See <a href="https://www.chordpro.org/chordpro/Directives-copyright.html">https://www.chordpro.org/chordpro/Directives-copyright.html</a></p>
+</dd>
+<dt><a href="#DURATION">DURATION</a> : <code>string</code></dt>
+<dd><p>Duration meta directive. See <a href="https://www.chordpro.org/chordpro/Directives-duration.html">https://www.chordpro.org/chordpro/Directives-duration.html</a></p>
+</dd>
+<dt><a href="#END_OF_CHORUS">END_OF_CHORUS</a> : <code>string</code></dt>
+<dd><p>End of chorus directive. See <a href="https://www.chordpro.org/chordpro/Directives-env_chorus.html">https://www.chordpro.org/chordpro/Directives-env_chorus.html</a></p>
+</dd>
+<dt><a href="#END_OF_VERSE">END_OF_VERSE</a> : <code>string</code></dt>
+<dd><p>End of verse directive. See <a href="https://www.chordpro.org/chordpro/Directives-env_verse.html">https://www.chordpro.org/chordpro/Directives-env_verse.html</a></p>
+</dd>
+<dt><a href="#KEY">KEY</a> : <code>string</code></dt>
+<dd><p>Key meta directive. See <a href="https://www.chordpro.org/chordpro/Directives-key.html">https://www.chordpro.org/chordpro/Directives-key.html</a></p>
+</dd>
+<dt><a href="#LYRICIST">LYRICIST</a> : <code>string</code></dt>
+<dd><p>Lyricist meta directive. See <a href="https://www.chordpro.org/chordpro/Directives-lyricist.html">https://www.chordpro.org/chordpro/Directives-lyricist.html</a></p>
+</dd>
+<dt><a href="#START_OF_CHORUS">START_OF_CHORUS</a> : <code>string</code></dt>
+<dd><p>Start of chorus directive. See <a href="https://www.chordpro.org/chordpro/Directives-env_chorus.html">https://www.chordpro.org/chordpro/Directives-env_chorus.html</a></p>
+</dd>
+<dt><a href="#START_OF_VERSE">START_OF_VERSE</a> : <code>string</code></dt>
+<dd><p>Start of verse directive. See <a href="https://www.chordpro.org/chordpro/Directives-env_verse.html">https://www.chordpro.org/chordpro/Directives-env_verse.html</a></p>
+</dd>
+<dt><a href="#SUBTITLE">SUBTITLE</a> : <code>string</code></dt>
+<dd><p>Subtitle meta directive. See <a href="https://www.chordpro.org/chordpro/Directives-subtitle.html">https://www.chordpro.org/chordpro/Directives-subtitle.html</a></p>
+</dd>
+<dt><a href="#TEMPO">TEMPO</a> : <code>string</code></dt>
+<dd><p>Tempo meta directive. See <a href="https://www.chordpro.org/chordpro/Directives-tempo.html">https://www.chordpro.org/chordpro/Directives-tempo.html</a></p>
+</dd>
+<dt><a href="#TIME">TIME</a> : <code>string</code></dt>
+<dd><p>Time meta directive. See <a href="https://www.chordpro.org/chordpro/Directives-time.html">https://www.chordpro.org/chordpro/Directives-time.html</a></p>
+</dd>
+<dt><a href="#TITLE">TITLE</a> : <code>string</code></dt>
+<dd><p>Title meta directive. See <a href="https://www.chordpro.org/chordpro/Directives-title.html">https://www.chordpro.org/chordpro/Directives-title.html</a></p>
+</dd>
+<dt><a href="#YEAR">YEAR</a> : <code>string</code></dt>
+<dd><p>Year meta directive. See <a href="https://www.chordpro.org/chordpro/Directives-year.html">https://www.chordpro.org/chordpro/Directives-year.html</a></p>
+</dd>
+<dt><a href="#VERSE">VERSE</a> : <code>string</code></dt>
+<dd><p>Used to mark a paragraph as verse</p>
+</dd>
+<dt><a href="#CHORUS">CHORUS</a> : <code>string</code></dt>
+<dd><p>Used to mark a paragraph as chorus</p>
+</dd>
+<dt><a href="#NONE">NONE</a> : <code>string</code></dt>
+<dd><p>Used to mark a paragraph as not containing a line marked with a type</p>
+</dd>
+<dt><a href="#INDETERMINATE">INDETERMINATE</a> : <code>string</code></dt>
+<dd><p>Used to mark a paragraph as containing lines with both verse and chorus type</p>
+</dd>
+</dl>
+
+## Functions
+
+<dl>
+<dt><a href="#parse">parse(chordSheet)</a> ⇒ <code><a href="#Song">Song</a></code></dt>
+<dd><p>Parses a chord sheet into a song</p>
+</dd>
+</dl>
+
+<a name="ChordLyricsPair"></a>
+
+## ChordLyricsPair
+Represents a chord with the corresponding (partial) lyrics
+
+**Kind**: global class  
+
+* [ChordLyricsPair](#ChordLyricsPair)
+    * [new ChordLyricsPair(chords, lyrics)](#new_ChordLyricsPair_new)
+    * [.chords](#ChordLyricsPair+chords) : <code>string</code>
+    * [.lyrics](#ChordLyricsPair+lyrics) : <code>string</code>
+    * [.isRenderable()](#ChordLyricsPair+isRenderable) ⇒ <code>boolean</code>
+    * [.clone()](#ChordLyricsPair+clone) ⇒ [<code>ChordLyricsPair</code>](#ChordLyricsPair)
+
+<a name="new_ChordLyricsPair_new"></a>
+
+### new ChordLyricsPair(chords, lyrics)
+Initialises a ChordLyricsPair
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chords | <code>string</code> | The chords |
+| lyrics | <code>string</code> | The lyrics |
+
+<a name="ChordLyricsPair+chords"></a>
+
+### chordLyricsPair.chords : <code>string</code>
+The chords
+
+**Kind**: instance property of [<code>ChordLyricsPair</code>](#ChordLyricsPair)  
+<a name="ChordLyricsPair+lyrics"></a>
+
+### chordLyricsPair.lyrics : <code>string</code>
+The lyrics
+
+**Kind**: instance property of [<code>ChordLyricsPair</code>](#ChordLyricsPair)  
+<a name="ChordLyricsPair+isRenderable"></a>
+
+### chordLyricsPair.isRenderable() ⇒ <code>boolean</code>
+Indicates whether a ChordLyricsPair should be visible in a formatted chord sheet (except for ChordPro sheets)
+
+**Kind**: instance method of [<code>ChordLyricsPair</code>](#ChordLyricsPair)  
+<a name="ChordLyricsPair+clone"></a>
+
+### chordLyricsPair.clone() ⇒ [<code>ChordLyricsPair</code>](#ChordLyricsPair)
+Returns a deep copy of the ChordLyricsPair, useful when programmatically transforming a song
+
+**Kind**: instance method of [<code>ChordLyricsPair</code>](#ChordLyricsPair)  
+<a name="Line"></a>
+
+## Line
+Represents a line in a chord sheet, consisting of items of type ChordLyricsPair or Tag
+
+**Kind**: global class  
+
+* [Line](#Line)
+    * [.items](#Line+items) : <code>Array.&lt;(ChordLyricsPair\|Tag)&gt;</code>
+    * [.type](#Line+type) : <code>string</code>
+    * [.isEmpty()](#Line+isEmpty) ⇒ <code>boolean</code>
+    * [.addItem(item)](#Line+addItem)
+    * [.hasRenderableItems()](#Line+hasRenderableItems) ⇒ <code>boolean</code>
+    * [.clone()](#Line+clone) ⇒ [<code>Line</code>](#Line)
+    * [.isVerse()](#Line+isVerse) ⇒ <code>boolean</code>
+    * [.isChorus()](#Line+isChorus) ⇒ <code>boolean</code>
+    * ~~[.hasContent()](#Line+hasContent) ⇒ <code>boolean</code>~~
+
+<a name="Line+items"></a>
+
+### line.items : <code>Array.&lt;(ChordLyricsPair\|Tag)&gt;</code>
+The items ([ChordLyricsPair](#ChordLyricsPair) or [Tag](#Tag)) of which the line consists
+
+**Kind**: instance property of [<code>Line</code>](#Line)  
+<a name="Line+type"></a>
+
+### line.type : <code>string</code>
+The line type, This is set by the ChordProParser when it read tags like {start_of_chorus} or {start_of_verse}
+Values can be [VERSE](#VERSE), [CHORUS](#CHORUS) or [NONE](#NONE)
+
+**Kind**: instance property of [<code>Line</code>](#Line)  
+<a name="Line+isEmpty"></a>
+
+### line.isEmpty() ⇒ <code>boolean</code>
+Indicates whether the line contains any items
+
+**Kind**: instance method of [<code>Line</code>](#Line)  
+<a name="Line+addItem"></a>
+
+### line.addItem(item)
+Adds an item ([ChordLyricsPair](#ChordLyricsPair) or [Tag](#Tag)) to the line
+
+**Kind**: instance method of [<code>Line</code>](#Line)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| item | [<code>ChordLyricsPair</code>](#ChordLyricsPair) \| [<code>Tag</code>](#Tag) | The item to be added |
+
+<a name="Line+hasRenderableItems"></a>
+
+### line.hasRenderableItems() ⇒ <code>boolean</code>
+Indicates whether the line contains items that are renderable
+
+**Kind**: instance method of [<code>Line</code>](#Line)  
+<a name="Line+clone"></a>
+
+### line.clone() ⇒ [<code>Line</code>](#Line)
+Returns a deep copy of the line and all of its items
+
+**Kind**: instance method of [<code>Line</code>](#Line)  
+<a name="Line+isVerse"></a>
+
+### line.isVerse() ⇒ <code>boolean</code>
+Indicates whether the line type is [VERSE](#VERSE)
+
+**Kind**: instance method of [<code>Line</code>](#Line)  
+<a name="Line+isChorus"></a>
+
+### line.isChorus() ⇒ <code>boolean</code>
+Indicates whether the line type is [CHORUS](#CHORUS)
+
+**Kind**: instance method of [<code>Line</code>](#Line)  
+<a name="Line+hasContent"></a>
+
+### ~~line.hasContent() ⇒ <code>boolean</code>~~
+***Deprecated***
+
+Indicates whether the line contains items that are renderable. Please use [hasRenderableItems](hasRenderableItems)
+
+**Kind**: instance method of [<code>Line</code>](#Line)  
+<a name="Paragraph"></a>
+
+## Paragraph
+Represents a paragraph of lines in a chord sheet
+
+**Kind**: global class  
+
+* [Paragraph](#Paragraph)
+    * [.lines](#Paragraph+lines) : [<code>Array.&lt;Line&gt;</code>](#Line)
+    * [.type](#Paragraph+type) ⇒ <code>string</code>
+
+<a name="Paragraph+lines"></a>
+
+### paragraph.lines : [<code>Array.&lt;Line&gt;</code>](#Line)
+The [Line](#Line) items of which the paragraph consists
+
+**Kind**: instance property of [<code>Paragraph</code>](#Paragraph)  
+<a name="Paragraph+type"></a>
+
+### paragraph.type ⇒ <code>string</code>
+Tries to determine the common type for all lines. If the types for all lines are equal, it returns that type.
+If not, it returns [INDETERMINATE](#INDETERMINATE)
+
+**Kind**: instance property of [<code>Paragraph</code>](#Paragraph)  
+<a name="Song"></a>
+
+## Song
+Represents a song in a chord sheet. Currently a chord sheet can only have one song.
+
+**Kind**: global class  
+
+* [Song](#Song)
+    * [.lines](#Song+lines) : [<code>Array.&lt;Line&gt;</code>](#Line)
+    * [.paragraphs](#Song+paragraphs) : [<code>Array.&lt;Line&gt;</code>](#Line)
+    * [.bodyLines](#Song+bodyLines) ⇒ [<code>Array.&lt;Line&gt;</code>](#Line)
+    * [.metaData](#Song+metaData) ⇒ <code>object</code>
+    * [.clone()](#Song+clone) ⇒ [<code>Song</code>](#Song)
+
+<a name="Song+lines"></a>
+
+### song.lines : [<code>Array.&lt;Line&gt;</code>](#Line)
+The [Line](#Line) items of which the song consists
+
+**Kind**: instance property of [<code>Song</code>](#Song)  
+<a name="Song+paragraphs"></a>
+
+### song.paragraphs : [<code>Array.&lt;Line&gt;</code>](#Line)
+The [Paragraph](#Paragraph) items of which the song consists
+
+**Kind**: instance property of [<code>Song</code>](#Song)  
+<a name="Song+bodyLines"></a>
+
+### song.bodyLines ⇒ [<code>Array.&lt;Line&gt;</code>](#Line)
+Returns the song lines, skipping the leading empty lines (empty as in not rendering any content). This is useful
+if you want to skip the "header lines": the lines that only contain meta data.
+
+**Kind**: instance property of [<code>Song</code>](#Song)  
+**Returns**: [<code>Array.&lt;Line&gt;</code>](#Line) - The song body lines  
+<a name="Song+metaData"></a>
+
+### song.metaData ⇒ <code>object</code>
+Returns the song metadata. When there is only one value for an entry, the value is a string. Else, the value is
+an array containing all unique values for the entry.
+
+**Kind**: instance property of [<code>Song</code>](#Song)  
+**Returns**: <code>object</code> - The metadata  
+<a name="Song+clone"></a>
+
+### song.clone() ⇒ [<code>Song</code>](#Song)
+Returns a deep clone of the song
+
+**Kind**: instance method of [<code>Song</code>](#Song)  
+**Returns**: [<code>Song</code>](#Song) - The cloned song  
+<a name="Tag"></a>
+
+## Tag
+Represents a tag/directive. See https://www.chordpro.org/chordpro/ChordPro-Directives.html
+
+**Kind**: global class  
+
+* [Tag](#Tag)
+    * [.name](#Tag+name) : <code>string</code>
+    * [.originalName](#Tag+originalName) : <code>string</code>
+    * [.value](#Tag+value) : <code>string</code> \| <code>null</code>
+    * [.hasValue()](#Tag+hasValue) ⇒ <code>boolean</code>
+    * [.isRenderable()](#Tag+isRenderable) ⇒ <code>boolean</code>
+    * [.isMetaTag()](#Tag+isMetaTag) ⇒ <code>boolean</code>
+    * [.clone()](#Tag+clone) ⇒ [<code>Tag</code>](#Tag)
+
+<a name="Tag+name"></a>
+
+### tag.name : <code>string</code>
+The tag full name. When the original tag used the short name, `name` will return the full name.
+
+**Kind**: instance property of [<code>Tag</code>](#Tag)  
+<a name="Tag+originalName"></a>
+
+### tag.originalName : <code>string</code>
+The original tag name that was used to construct the tag.
+
+**Kind**: instance property of [<code>Tag</code>](#Tag)  
+<a name="Tag+value"></a>
+
+### tag.value : <code>string</code> \| <code>null</code>
+The tag value
+
+**Kind**: instance property of [<code>Tag</code>](#Tag)  
+<a name="Tag+hasValue"></a>
+
+### tag.hasValue() ⇒ <code>boolean</code>
+Checks whether the tag value is a non-empty string.
+
+**Kind**: instance method of [<code>Tag</code>](#Tag)  
+<a name="Tag+isRenderable"></a>
+
+### tag.isRenderable() ⇒ <code>boolean</code>
+Checks whether the tag is usually rendered inline. It currently only applies to comment tags.
+
+**Kind**: instance method of [<code>Tag</code>](#Tag)  
+<a name="Tag+isMetaTag"></a>
+
+### tag.isMetaTag() ⇒ <code>boolean</code>
+Checks whether the tag is either a standard meta tag or a custom meta directive (`{x_some_name}`)
+
+**Kind**: instance method of [<code>Tag</code>](#Tag)  
+<a name="Tag+clone"></a>
+
+### tag.clone() ⇒ [<code>Tag</code>](#Tag)
+Returns a clone of the tag.
+
+**Kind**: instance method of [<code>Tag</code>](#Tag)  
+**Returns**: [<code>Tag</code>](#Tag) - The cloned tag  
+<a name="ChordProFormatter"></a>
+
+## ChordProFormatter
+Formats a song into a ChordPro chord sheet
+
+**Kind**: global class  
+<a name="ChordProFormatter+format"></a>
+
+### chordProFormatter.format(song) ⇒ <code>string</code>
+Formats a song into a ChordPro chord sheet.
+
+**Kind**: instance method of [<code>ChordProFormatter</code>](#ChordProFormatter)  
+**Returns**: <code>string</code> - The ChordPro string  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| song | [<code>Song</code>](#Song) | The song to be formatted |
+
+<a name="HtmlDivFormatter"></a>
+
+## HtmlDivFormatter
+Formats a song into HTML. It uses DIVs to align lyrics with chords, which makes it useful for responsive web pages.
+
+**Kind**: global class  
+<a name="HtmlDivFormatter+format"></a>
+
+### htmlDivFormatter.format(song) ⇒ <code>string</code>
+Formats a song into HTML.
+
+**Kind**: instance method of [<code>HtmlDivFormatter</code>](#HtmlDivFormatter)  
+**Returns**: <code>string</code> - The HTML string  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| song | [<code>Song</code>](#Song) | The song to be formatted |
+
+<a name="HtmlTableFormatter"></a>
+
+## HtmlTableFormatter
+Formats a song into HTML. It uses TABLEs to align lyrics with chords, which makes the HTML for things like
+PDF conversion.
+
+**Kind**: global class  
+<a name="HtmlTableFormatter+format"></a>
+
+### htmlTableFormatter.format(song) ⇒ <code>string</code>
+Formats a song into HTML.
+
+**Kind**: instance method of [<code>HtmlTableFormatter</code>](#HtmlTableFormatter)  
+**Returns**: <code>string</code> - The HTML string  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| song | [<code>Song</code>](#Song) | The song to be formatted |
+
+<a name="TextFormatter"></a>
+
+## TextFormatter
+Formats a sonf into a plain text chord sheet
+
+**Kind**: global class  
+<a name="TextFormatter+format"></a>
+
+### textFormatter.format(song) ⇒ <code>string</code>
+Formats a song into a plain text chord sheet
+
+**Kind**: instance method of [<code>TextFormatter</code>](#TextFormatter)  
+**Returns**: <code>string</code> - the chord sheet  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| song | [<code>Song</code>](#Song) | The song to be formatted |
+
+<a name="ChordProParser"></a>
+
+## ChordProParser
+Parses a ChordPro chord sheet
+
+**Kind**: global class  
+
+* [ChordProParser](#ChordProParser)
+    * [.warnings](#ChordProParser+warnings) : [<code>Array.&lt;ParserWarning&gt;</code>](#ParserWarning)
+    * [.parse(chordProChordSheet)](#ChordProParser+parse) ⇒ [<code>Song</code>](#Song)
+
+<a name="ChordProParser+warnings"></a>
+
+### chordProParser.warnings : [<code>Array.&lt;ParserWarning&gt;</code>](#ParserWarning)
+All warnings raised during parsing the ChordPro chord sheet
+
+**Kind**: instance property of [<code>ChordProParser</code>](#ChordProParser)  
+<a name="ChordProParser+parse"></a>
+
+### chordProParser.parse(chordProChordSheet) ⇒ [<code>Song</code>](#Song)
+Parses a ChordPro chord sheet into a song
+
+**Kind**: instance method of [<code>ChordProParser</code>](#ChordProParser)  
+**Returns**: [<code>Song</code>](#Song) - The parsed song  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chordProChordSheet | <code>string</code> | the ChordPro chord sheet |
+
+<a name="ParserWarning"></a>
+
+## ParserWarning
+Represents a parser warning, currently only used by ChordProParser.
+
+**Kind**: global class  
+
+* [ParserWarning](#ParserWarning)
+    * [.message](#ParserWarning+message) : <code>string</code>
+    * [.lineNumber](#ParserWarning+lineNumber) : <code>integer</code>
+    * [.toString()](#ParserWarning+toString) ⇒ <code>string</code>
+
+<a name="ParserWarning+message"></a>
+
+### parserWarning.message : <code>string</code>
+The warning message
+
+**Kind**: instance property of [<code>ParserWarning</code>](#ParserWarning)  
+<a name="ParserWarning+lineNumber"></a>
+
+### parserWarning.lineNumber : <code>integer</code>
+The chord sheet line number on which the warning occurred
+
+**Kind**: instance property of [<code>ParserWarning</code>](#ParserWarning)  
+<a name="ParserWarning+toString"></a>
+
+### parserWarning.toString() ⇒ <code>string</code>
+Returns a stringified version of the warning
+
+**Kind**: instance method of [<code>ParserWarning</code>](#ParserWarning)  
+**Returns**: <code>string</code> - The string warning  
+<a name="ALBUM"></a>
+
+## ALBUM : <code>string</code>
+Album meta directive. See https://www.chordpro.org/chordpro/Directives-album.html
+
+**Kind**: global constant  
+<a name="ARTIST"></a>
+
+## ARTIST : <code>string</code>
+Artist meta directive. See https://www.chordpro.org/chordpro/Directives-artist.html
+
+**Kind**: global constant  
+<a name="CAPO"></a>
+
+## CAPO : <code>string</code>
+Capo meta directive. See https://www.chordpro.org/chordpro/Directives-capo.html
+
+**Kind**: global constant  
+<a name="COMMENT"></a>
+
+## COMMENT : <code>string</code>
+Comment directive. See https://www.chordpro.org/chordpro/Directives-comment.html
+
+**Kind**: global constant  
+<a name="COMPOSER"></a>
+
+## COMPOSER : <code>string</code>
+Composer meta directive. See https://www.chordpro.org/chordpro/Directives-composer.html
+
+**Kind**: global constant  
+<a name="COPYRIGHT"></a>
+
+## COPYRIGHT : <code>string</code>
+Copyright meta directive. See https://www.chordpro.org/chordpro/Directives-copyright.html
+
+**Kind**: global constant  
+<a name="DURATION"></a>
+
+## DURATION : <code>string</code>
+Duration meta directive. See https://www.chordpro.org/chordpro/Directives-duration.html
+
+**Kind**: global constant  
+<a name="END_OF_CHORUS"></a>
+
+## END\_OF\_CHORUS : <code>string</code>
+End of chorus directive. See https://www.chordpro.org/chordpro/Directives-env_chorus.html
+
+**Kind**: global constant  
+<a name="END_OF_VERSE"></a>
+
+## END\_OF\_VERSE : <code>string</code>
+End of verse directive. See https://www.chordpro.org/chordpro/Directives-env_verse.html
+
+**Kind**: global constant  
+<a name="KEY"></a>
+
+## KEY : <code>string</code>
+Key meta directive. See https://www.chordpro.org/chordpro/Directives-key.html
+
+**Kind**: global constant  
+<a name="LYRICIST"></a>
+
+## LYRICIST : <code>string</code>
+Lyricist meta directive. See https://www.chordpro.org/chordpro/Directives-lyricist.html
+
+**Kind**: global constant  
+<a name="START_OF_CHORUS"></a>
+
+## START\_OF\_CHORUS : <code>string</code>
+Start of chorus directive. See https://www.chordpro.org/chordpro/Directives-env_chorus.html
+
+**Kind**: global constant  
+<a name="START_OF_VERSE"></a>
+
+## START\_OF\_VERSE : <code>string</code>
+Start of verse directive. See https://www.chordpro.org/chordpro/Directives-env_verse.html
+
+**Kind**: global constant  
+<a name="SUBTITLE"></a>
+
+## SUBTITLE : <code>string</code>
+Subtitle meta directive. See https://www.chordpro.org/chordpro/Directives-subtitle.html
+
+**Kind**: global constant  
+<a name="TEMPO"></a>
+
+## TEMPO : <code>string</code>
+Tempo meta directive. See https://www.chordpro.org/chordpro/Directives-tempo.html
+
+**Kind**: global constant  
+<a name="TIME"></a>
+
+## TIME : <code>string</code>
+Time meta directive. See https://www.chordpro.org/chordpro/Directives-time.html
+
+**Kind**: global constant  
+<a name="TITLE"></a>
+
+## TITLE : <code>string</code>
+Title meta directive. See https://www.chordpro.org/chordpro/Directives-title.html
+
+**Kind**: global constant  
+<a name="YEAR"></a>
+
+## YEAR : <code>string</code>
+Year meta directive. See https://www.chordpro.org/chordpro/Directives-year.html
+
+**Kind**: global constant  
+<a name="VERSE"></a>
+
+## VERSE : <code>string</code>
+Used to mark a paragraph as verse
+
+**Kind**: global constant  
+<a name="CHORUS"></a>
+
+## CHORUS : <code>string</code>
+Used to mark a paragraph as chorus
+
+**Kind**: global constant  
+<a name="NONE"></a>
+
+## NONE : <code>string</code>
+Used to mark a paragraph as not containing a line marked with a type
+
+**Kind**: global constant  
+<a name="INDETERMINATE"></a>
+
+## INDETERMINATE : <code>string</code>
+Used to mark a paragraph as containing lines with both verse and chorus type
+
+**Kind**: global constant  
+<a name="parse"></a>
+
+## parse(chordSheet) ⇒ [<code>Song</code>](#Song)
+Parses a chord sheet into a song
+
+**Kind**: global function  
+**Returns**: [<code>Song</code>](#Song) - The parsed song  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chordSheet | <code>string</code> | The ChordPro chord sheet |
+

--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ const disp = formatter.format(song);
 
 ## API docs
 
+Note: all classes, methods and constants that are documented here can be considered public API and will only be
+subject to breaking changes between major versions.
+
 ## Classes
 
 <dl>

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 A JavaScript library for parsing and formatting chord sheets
 
+**Contents**
+
+- [Installation](#installation)
+- [How to ...?](#how-to-)
+- [Supported ChordPro directives](#supported-chordpro-directives)
+- [API docs](#api-docs)
+
 ## Installation
 
 `ChordSheetJS` is on npm, to install run:
@@ -22,7 +29,7 @@ or `import` (es2015):
 import ChordSheetJS from 'chordsheetjs';
 ```
 
-## Functionalities
+## How to ...?
 
 ### Parse chord sheet
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ const disp = formatter.format(song);
 
 :clock2: = will be supported in a future version
 
-:heavy_multiplication_x: = no plans to support it in the near future
+:heavy_multiplication_x: = currently no plans to support it in the near future
 
 ### Meta-data directives
 
@@ -107,18 +107,18 @@ const disp = formatter.format(song);
 |:---------------- |:------------------:|
 | title (short: t) | :heavy_check_mark: |
 | subtitle         | :heavy_check_mark: |
-| artist           | :clock2:           |
-| composer         | :clock2:           |
-| lyricist         | :clock2:           |
-| copyright        | :clock2:           |
-| album            | :clock2:           |
-| year             | :clock2:           |
-| key              | :clock2:           |
-| time             | :clock2:           |
-| tempo            | :clock2:           |
-| duration         | :clock2:           |
-| capo             | :clock2:           |
-| meta             | :clock2:           |
+| artist           | :heavy_check_mark: |
+| composer         | :heavy_check_mark: |
+| lyricist         | :heavy_check_mark: |
+| copyright        | :heavy_check_mark: |
+| album            | :heavy_check_mark: |
+| year             | :heavy_check_mark: |
+| key              | :heavy_check_mark: |
+| time             | :heavy_check_mark: |
+| tempo            | :heavy_check_mark: |
+| duration         | :heavy_check_mark: |
+| capo             | :heavy_check_mark: |
+| meta             | :heavy_check_mark: |
 
 ### Formatting directives
 
@@ -178,9 +178,9 @@ const disp = formatter.format(song);
 
 ### Custom extensions
 
-| Directive | Support  |
-|:--------- |:--------:|
-| x_        | :clock2: |
+| Directive | Support            |
+|:--------- |:------------------:|
+| x_        | :heavy_check_mark: |
 
 ## API docs
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1374,9 +1374,9 @@
       "dev": true
     },
     "dmd": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/dmd/-/dmd-3.0.12.tgz",
-      "integrity": "sha512-79w644JdsB2TthYpVl2bDurX7i9Abaegg2E7X46Ajc135aASTMXxrHzJ9mOa5X5nbmnXwlBYiF68K+1baX+BzQ==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/dmd/-/dmd-3.0.13.tgz",
+      "integrity": "sha512-FV/417bH2c/CYpe8BjFEAHoaHaItcJnPlKELi/qyPZdmUom8joyuC78OhhfPUdyKD/WcouTQ2LxQT4M/RoiJ3w==",
       "dev": true,
       "requires": {
         "array-back": "^2.0.0",
@@ -1436,13 +1436,29 @@
       }
     },
     "file-set": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/file-set/-/file-set-2.0.0.tgz",
-      "integrity": "sha512-cCWXfw+nrYoIoUVmEF7Xsw91lGWuObtSnTEZ7AmdvZou1A/6Xx237HfxdQyC/ayKRvQSMbNOBwg62OjN5JxbXw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/file-set/-/file-set-2.0.1.tgz",
+      "integrity": "sha512-XgOUUpgR6FbbfYcniLw0qm1Am7PnNYIAkd+eXxRt42LiYhjaso0WiuQ+VmrNdtwotyM+cLCfZ56AZrySP3QnKA==",
       "dev": true,
       "requires": {
         "array-back": "^2.0.0",
-        "glob": "^7.1.2"
+        "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "filename-regex": {
@@ -2448,7 +2464,7 @@
     },
     "marked": {
       "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "resolved": "http://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
       "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,15 @@
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
+    "ansi-escape-sequences": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz",
+      "integrity": "sha512-v+0wW9Wezwsyb0uF4aBVCjmSqit3Ru7PZFziGF0o2KwTvN2zWfTi3BRLq9EkJFdg3eBbyERXGTntVpBxH1J68Q==",
+      "dev": true,
+      "requires": {
+        "array-back": "^2.0.0"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -42,6 +51,16 @@
         "normalize-path": "^2.0.0"
       }
     },
+    "argv-tools": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/argv-tools/-/argv-tools-0.1.1.tgz",
+      "integrity": "sha512-Cc0dBvx4dvrjjKpyDA6w8RlNAw8Su30NvZbWl/Tv9ZALEVlLVkWQiHMi84Q0xNfpVuSaiQbYkdmWK8g1PLGhKw==",
+      "dev": true,
+      "requires": {
+        "array-back": "^2.0.0",
+        "find-replace": "^2.0.1"
+      }
+    },
     "arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
@@ -58,6 +77,15 @@
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true,
       "optional": true
+    },
+    "array-back": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
+      "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
+      "dev": true,
+      "requires": {
+        "typical": "^2.6.1"
+      }
     },
     "array-unique": {
       "version": "0.2.1",
@@ -1041,6 +1069,12 @@
       "dev": true,
       "optional": true
     },
+    "bluebird": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
+      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1069,11 +1103,31 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "cache-point": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-0.4.1.tgz",
+      "integrity": "sha512-4TgWfe9SF+bUy5cCql8gWHqKNrviufNwSYxLjf2utB0pY4+bdcuFwMmY1hDB+67Gz/L1vmhFNhePAjJTFBtV+Q==",
+      "dev": true,
+      "requires": {
+        "array-back": "^2.0.0",
+        "fs-then-native": "^2.0.0",
+        "mkdirp2": "^1.0.3"
+      }
+    },
     "camelcase": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
       "optional": true
+    },
+    "catharsis": {
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
+      "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
+      "dev": true,
+      "requires": {
+        "underscore-contrib": "~0.3.0"
+      }
     },
     "center-align": {
       "version": "0.1.3",
@@ -1172,10 +1226,64 @@
         }
       }
     },
+    "collect-all": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
+      "integrity": "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==",
+      "dev": true,
+      "requires": {
+        "stream-connect": "^1.0.2",
+        "stream-via": "^1.0.4"
+      }
+    },
+    "command-line-args": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.0.2.tgz",
+      "integrity": "sha512-/qPcbL8zpqg53x4rAaqMFlRV4opN3pbla7I7k9x8kyOBMQoGT6WltjN6sXZuxOXw6DgdK7Ad+ijYS5gjcr7vlA==",
+      "dev": true,
+      "requires": {
+        "argv-tools": "^0.1.1",
+        "array-back": "^2.0.0",
+        "find-replace": "^2.0.1",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^2.6.1"
+      }
+    },
+    "command-line-tool": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.8.0.tgz",
+      "integrity": "sha512-Xw18HVx/QzQV3Sc5k1vy3kgtOeGmsKIqwtFFoyjI4bbcpSgnw2CWVULvtakyw4s6fhyAdI6soQQhXc2OzJy62g==",
+      "dev": true,
+      "requires": {
+        "ansi-escape-sequences": "^4.0.0",
+        "array-back": "^2.0.0",
+        "command-line-args": "^5.0.0",
+        "command-line-usage": "^4.1.0",
+        "typical": "^2.6.1"
+      }
+    },
+    "command-line-usage": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
+      "integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
+      "dev": true,
+      "requires": {
+        "ansi-escape-sequences": "^4.0.0",
+        "array-back": "^2.0.0",
+        "table-layout": "^0.4.2",
+        "typical": "^2.6.1"
+      }
+    },
     "commander": {
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "common-sequence": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-1.0.2.tgz",
+      "integrity": "sha1-MOB/P49vf5s97oVPILLTnu4Ibeg=",
       "dev": true
     },
     "concat-map": {
@@ -1183,6 +1291,23 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "config-master": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/config-master/-/config-master-3.1.0.tgz",
+      "integrity": "sha1-ZnZjWQUFooO/JqSE1oSJ10xUhdo=",
+      "dev": true,
+      "requires": {
+        "walk-back": "^2.0.1"
+      },
+      "dependencies": {
+        "walk-back": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz",
+          "integrity": "sha1-VU4qnYdPrEeoywBr9EwvDEmYoKQ=",
+          "dev": true
+        }
+      }
     },
     "convert-source-map": {
       "version": "1.5.1",
@@ -1227,6 +1352,12 @@
         "type-detect": "^4.0.0"
       }
     },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
+    },
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
@@ -1241,6 +1372,26 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
+    },
+    "dmd": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/dmd/-/dmd-3.0.12.tgz",
+      "integrity": "sha512-79w644JdsB2TthYpVl2bDurX7i9Abaegg2E7X46Ajc135aASTMXxrHzJ9mOa5X5nbmnXwlBYiF68K+1baX+BzQ==",
+      "dev": true,
+      "requires": {
+        "array-back": "^2.0.0",
+        "cache-point": "^0.4.1",
+        "common-sequence": "^1.0.2",
+        "file-set": "^2.0.0",
+        "handlebars": "^4.0.11",
+        "marked": "^0.3.16",
+        "object-get": "^2.1.0",
+        "reduce-flatten": "^1.0.1",
+        "reduce-unique": "^1.0.0",
+        "reduce-without": "^1.0.1",
+        "test-value": "^3.0.0",
+        "walk-back": "^3.0.0"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1284,6 +1435,16 @@
         "is-extglob": "^1.0.0"
       }
     },
+    "file-set": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-set/-/file-set-2.0.0.tgz",
+      "integrity": "sha512-cCWXfw+nrYoIoUVmEF7Xsw91lGWuObtSnTEZ7AmdvZou1A/6Xx237HfxdQyC/ayKRvQSMbNOBwg62OjN5JxbXw==",
+      "dev": true,
+      "requires": {
+        "array-back": "^2.0.0",
+        "glob": "^7.1.2"
+      }
+    },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -1303,6 +1464,16 @@
         "randomatic": "^3.0.0",
         "repeat-element": "^1.1.2",
         "repeat-string": "^1.5.2"
+      }
+    },
+    "find-replace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-2.0.1.tgz",
+      "integrity": "sha512-LzDo3Fpa30FLIBsh6DCDnMN1KW2g4QKkqKmejlImgWY67dDFPX/x9Kh/op/GK522DchQXEvDi/wD48HKW49XOQ==",
+      "dev": true,
+      "requires": {
+        "array-back": "^2.0.0",
+        "test-value": "^3.0.0"
       }
     },
     "for-in": {
@@ -1326,6 +1497,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
       "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true
+    },
+    "fs-then-native": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fs-then-native/-/fs-then-native-2.0.0.tgz",
+      "integrity": "sha1-GaEk2U2QwiyOBF8ujdbr6jbUjGc=",
       "dev": true
     },
     "fs.realpath": {
@@ -2107,6 +2284,89 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
+    "js2xmlparser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
+      "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
+      "dev": true,
+      "requires": {
+        "xmlcreate": "^1.0.1"
+      }
+    },
+    "jsdoc": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
+      "integrity": "sha512-6PxB65TAU4WO0Wzyr/4/YhlGovXl0EVYfpKbpSroSj0qBxT4/xod/l40Opkm38dRHRdQgdeY836M0uVnJQG7kg==",
+      "dev": true,
+      "requires": {
+        "babylon": "7.0.0-beta.19",
+        "bluebird": "~3.5.0",
+        "catharsis": "~0.8.9",
+        "escape-string-regexp": "~1.0.5",
+        "js2xmlparser": "~3.0.0",
+        "klaw": "~2.0.0",
+        "marked": "~0.3.6",
+        "mkdirp": "~0.5.1",
+        "requizzle": "~0.2.1",
+        "strip-json-comments": "~2.0.1",
+        "taffydb": "2.6.2",
+        "underscore": "~1.8.3"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.19",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
+          "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
+          "dev": true
+        }
+      }
+    },
+    "jsdoc-api": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-4.0.3.tgz",
+      "integrity": "sha512-dfYq9JgB+XahY0XfSEw93PmXmocjwYcvJ5aMuQUJ/OdDRGWamf2SSOk3W06Bsj8qdjp/UdefzqpP/mpwsvHuvA==",
+      "dev": true,
+      "requires": {
+        "array-back": "^2.0.0",
+        "cache-point": "^0.4.1",
+        "collect-all": "^1.0.3",
+        "file-set": "^2.0.0",
+        "fs-then-native": "^2.0.0",
+        "jsdoc": "~3.5.5",
+        "object-to-spawn-args": "^1.1.1",
+        "temp-path": "^1.0.0",
+        "walk-back": "^3.0.0"
+      }
+    },
+    "jsdoc-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-3.0.1.tgz",
+      "integrity": "sha512-btZLp4wYl90vcAfgk4hoGQbO17iBVrhh3LJRMKZNtZgniO3F8H2CjxXld0owBIB1XxN+j3bAcWZnZKMnSj3iMA==",
+      "dev": true,
+      "requires": {
+        "array-back": "^2.0.0",
+        "lodash.omit": "^4.5.0",
+        "lodash.pick": "^4.4.0",
+        "reduce-extract": "^1.0.0",
+        "sort-array": "^2.0.0",
+        "test-value": "^3.0.0"
+      }
+    },
+    "jsdoc-to-markdown": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-4.0.1.tgz",
+      "integrity": "sha512-LHJRoLoLyDdxNcColgkLoB/rFG5iRP+PNJjMILI0x+95IdEAtyjSt0wJ6ZlKxRpkhBYtQXTQQ119hMqPIUZzTQ==",
+      "dev": true,
+      "requires": {
+        "array-back": "^2.0.0",
+        "command-line-tool": "^0.8.0",
+        "config-master": "^3.1.0",
+        "dmd": "^3.0.10",
+        "jsdoc-api": "^4.0.1",
+        "jsdoc-parse": "^3.0.1",
+        "walk-back": "^3.0.0"
+      }
+    },
     "jsesc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
@@ -2127,6 +2387,15 @@
         "is-buffer": "^1.1.5"
       }
     },
+    "klaw": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
+      "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
     "lazy-cache": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
@@ -2137,6 +2406,30 @@
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "dev": true
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
+    "lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
+      "dev": true
+    },
+    "lodash.padend": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
+      "dev": true
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
       "dev": true
     },
     "longest": {
@@ -2152,6 +2445,12 @@
       "requires": {
         "js-tokens": "^3.0.0"
       }
+    },
+    "marked": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+      "dev": true
     },
     "math-random": {
       "version": "1.0.1",
@@ -2204,6 +2503,12 @@
       "requires": {
         "minimist": "0.0.8"
       }
+    },
+    "mkdirp2": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.4.tgz",
+      "integrity": "sha512-Q2PKB4ZR4UPtjLl76JfzlgSCUZhSV1AXQgAZa1qt5RiaALFjP/CDrGvFBrOz7Ck6McPcwMAxTsJvWOUjOU8XMw==",
+      "dev": true
     },
     "mocha": {
       "version": "5.2.0",
@@ -2276,6 +2581,18 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object-get": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/object-get/-/object-get-2.1.0.tgz",
+      "integrity": "sha1-ciu9tgA576R8rTxtws5RqFwCxa4=",
+      "dev": true
+    },
+    "object-to-spawn-args": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-1.1.1.tgz",
+      "integrity": "sha1-d9qIJ/Bz0BHJ4bFz+JV4FHAkZ4U=",
       "dev": true
     },
     "object.omit": {
@@ -2432,6 +2749,78 @@
         "set-immediate-shim": "^1.0.1"
       }
     },
+    "reduce-extract": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz",
+      "integrity": "sha1-Z/I4W+2mUGG19fQxJmLosIDKFSU=",
+      "dev": true,
+      "requires": {
+        "test-value": "^1.0.1"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "dev": true,
+          "requires": {
+            "typical": "^2.6.0"
+          }
+        },
+        "test-value": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
+          "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
+          "dev": true,
+          "requires": {
+            "array-back": "^1.0.2",
+            "typical": "^2.4.2"
+          }
+        }
+      }
+    },
+    "reduce-flatten": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
+      "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
+      "dev": true
+    },
+    "reduce-unique": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-unique/-/reduce-unique-1.0.0.tgz",
+      "integrity": "sha1-flhrz4ek4ytter2Cd/rWzeyfSAM=",
+      "dev": true
+    },
+    "reduce-without": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
+      "integrity": "sha1-aK0OrRGFXJo31OglbBW7+Hly/Iw=",
+      "dev": true,
+      "requires": {
+        "test-value": "^2.0.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "dev": true,
+          "requires": {
+            "typical": "^2.6.0"
+          }
+        },
+        "test-value": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
+          "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
+          "dev": true,
+          "requires": {
+            "array-back": "^1.0.3",
+            "typical": "^2.6.0"
+          }
+        }
+      }
+    },
     "regenerate": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
@@ -2525,6 +2914,23 @@
         "is-finite": "^1.0.0"
       }
     },
+    "requizzle": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
+      "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
+      "dev": true,
+      "requires": {
+        "underscore": "~1.6.0"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+          "dev": true
+        }
+      }
+    },
     "resolve-cwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-1.0.0.tgz",
@@ -2568,6 +2974,28 @@
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "dev": true
     },
+    "sort-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-2.0.0.tgz",
+      "integrity": "sha1-OKnG2if9fRR7QuYFVPKBGHtN9HI=",
+      "dev": true,
+      "requires": {
+        "array-back": "^1.0.4",
+        "object-get": "^2.1.0",
+        "typical": "^2.6.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "dev": true,
+          "requires": {
+            "typical": "^2.6.0"
+          }
+        }
+      }
+    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -2581,6 +3009,32 @@
       "requires": {
         "source-map": "^0.5.6"
       }
+    },
+    "stream-connect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
+      "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
+      "dev": true,
+      "requires": {
+        "array-back": "^1.0.2"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "dev": true,
+          "requires": {
+            "typical": "^2.6.0"
+          }
+        }
+      }
+    },
+    "stream-via": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
+      "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
+      "dev": true
     },
     "string_decoder": {
       "version": "1.1.1",
@@ -2601,11 +3055,52 @@
         "ansi-regex": "^2.0.0"
       }
     },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
+    },
+    "table-layout": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.4.tgz",
+      "integrity": "sha512-uNaR3SRMJwfdp9OUr36eyEi6LLsbcTqTO/hfTsNviKsNeyMBPICJCC7QXRF3+07bAP6FRwA8rczJPBqXDc0CkQ==",
+      "dev": true,
+      "requires": {
+        "array-back": "^2.0.0",
+        "deep-extend": "~0.6.0",
+        "lodash.padend": "^4.6.1",
+        "typical": "^2.6.1",
+        "wordwrapjs": "^3.0.0"
+      }
+    },
+    "taffydb": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
+      "dev": true
+    },
+    "temp-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
+      "integrity": "sha1-JLFUOXOrRCiW2a02fdnL2/r+kYs=",
+      "dev": true
+    },
+    "test-value": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
+      "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
+      "dev": true,
+      "requires": {
+        "array-back": "^2.0.0",
+        "typical": "^2.6.1"
+      }
     },
     "to-fast-properties": {
       "version": "1.0.3",
@@ -2625,6 +3120,12 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
+    "typical": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+      "dev": true
+    },
     "uglify-js": {
       "version": "2.8.29",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
@@ -2641,6 +3142,29 @@
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "optional": true
+    },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+      "dev": true
+    },
+    "underscore-contrib": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
+      "integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
+      "dev": true,
+      "requires": {
+        "underscore": "1.6.0"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+          "dev": true
+        }
+      }
     },
     "user-home": {
       "version": "1.1.1",
@@ -2664,6 +3188,12 @@
         "user-home": "^1.1.1"
       }
     },
+    "walk-back": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-3.0.0.tgz",
+      "integrity": "sha1-I1h4ejXakQMtrV6S+AsSNw2HlcU=",
+      "dev": true
+    },
     "window-size": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
@@ -2675,10 +3205,26 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
+    "wordwrapjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
+      "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
+      "dev": true,
+      "requires": {
+        "reduce-flatten": "^1.0.1",
+        "typical": "^2.6.1"
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xmlcreate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
+      "integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "babel-register": "^6.26.0",
     "chai": "^4.1.2",
     "chai-diff": "^1.0.1",
+    "jsdoc-to-markdown": "^4.0.1",
     "mocha": "^5.2.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "test": "mocha --recursive --compilers js:babel-register",
     "build": "babel src --out-dir lib",
+    "readme": "jsdoc2md -f src/**/*.js --template README.hbs > README.md",
     "prepublishOnly": "npm install && npm test && npm run build"
   },
   "dependencies": {

--- a/src/chord_sheet/chord_lyrics_pair.js
+++ b/src/chord_sheet/chord_lyrics_pair.js
@@ -1,13 +1,40 @@
-export default class ChordLyricsPair {
+/**
+ * Represents a chord with the corresponding (partial) lyrics
+ */
+class ChordLyricsPair {
+  /**
+   * Initialises a ChordLyricsPair
+   * @param {string} chords The chords
+   * @param {string} lyrics The lyrics
+   */
   constructor(chords = '', lyrics = '') {
+    /**
+     * The chords
+     * @member
+     * @type {string}
+     */
     this.chords = chords;
+
+    /**
+     * The lyrics
+     * @member
+     * @type {string}
+     */
     this.lyrics = lyrics;
   }
 
+  /**
+   * Indicates whether a ChordLyricsPair should be visible in a formatted chord sheet (except for ChordPro sheets)
+   * @returns {boolean}
+   */
   isRenderable() {
     return true;
   }
 
+  /**
+   * Returns a deep copy of the ChordLyricsPair, useful when programmatically transforming a song
+   * @returns {ChordLyricsPair}
+   */
   clone() {
     return new ChordLyricsPair(this.chords, this.lyrics);
   }
@@ -16,3 +43,5 @@ export default class ChordLyricsPair {
     return `ChordLyricsPair(chords=${this.chords}, lyrics=${this.lyrics})`;
   }
 }
+
+export default ChordLyricsPair;

--- a/src/chord_sheet/line.js
+++ b/src/chord_sheet/line.js
@@ -2,23 +2,91 @@ import ChordLyricsPair from './chord_lyrics_pair';
 import Tag from './tag';
 import { CHORUS, NONE, VERSE } from '../constants';
 
-export default class Line {
+/**
+ * Represents a line in a chord sheet, consisting of items of type ChordLyricsPair or Tag
+ */
+class Line {
   constructor() {
+    /**
+     * The items ({@link ChordLyricsPair} or {@link Tag}) of which the line consists
+     * @member
+     * @type {Array.<(ChordLyricsPair|Tag)>}
+     */
     this.items = [];
-    this.currentChordLyricsPair = null;
+
+    /**
+     * The line type, This is set by the ChordProParser when it read tags like {start_of_chorus} or {start_of_verse}
+     * Values can be {@link VERSE}, {@link CHORUS} or {@link NONE}
+     * @member
+     * @type {string}
+     */
     this.type = NONE;
+
+    this.currentChordLyricsPair = null;
   }
 
+  /**
+   * Indicates whether the line contains any items
+   * @returns {boolean}
+   */
   isEmpty() {
     return this.items.length === 0;
   }
 
+  /**
+   * Adds an item ({@link ChordLyricsPair} or {@link Tag}) to the line
+   * @param {ChordLyricsPair|Tag} item The item to be added
+   */
   addItem(item) {
     if (item instanceof Tag) {
       this.addTag(item);
     } else if (item instanceof ChordLyricsPair) {
       this.addChordLyricsPair(item);
     }
+  }
+
+  /**
+   * Indicates whether the line contains items that are renderable
+   * @returns {boolean}
+   */
+  hasRenderableItems() {
+    return this.items.some(item => item.isRenderable());
+  }
+
+  /**
+   * Returns a deep copy of the line and all of its items
+   * @returns {Line}
+   */
+  clone() {
+    const clonedLine = new Line();
+    clonedLine.items = this.items.map(item => item.clone());
+    clonedLine.type = this.type;
+    return clonedLine;
+  }
+
+  /**
+   * Indicates whether the line type is {@link VERSE}
+   * @returns {boolean}
+   */
+  isVerse() {
+    return this.type === VERSE;
+  }
+
+  /**
+   * Indicates whether the line type is {@link CHORUS}
+   * @returns {boolean}
+   */
+  isChorus() {
+    return this.type === CHORUS;
+  }
+
+  /**
+   * Indicates whether the line contains items that are renderable. Please use {@link hasRenderableItems}
+   * @deprecated
+   * @returns {boolean}
+   */
+  hasContent() {
+    return this.hasRenderableItems();
   }
 
   addChordLyricsPair(chords, lyrics) {
@@ -53,26 +121,6 @@ export default class Line {
     this.items.push(tag);
     return tag;
   }
-
-  hasRenderableItems() {
-    return this.items.some(item => item.isRenderable());
-  }
-
-  clone() {
-    const clonedLine = new Line();
-    clonedLine.items = this.items.map(item => item.clone());
-    return clonedLine;
-  }
-
-  isVerse() {
-    return this.type === VERSE;
-  }
-
-  isChorus() {
-    return this.type === CHORUS;
-  }
-
-  hasContent() {
-    return this.items.some(item => (item instanceof ChordLyricsPair) || (item instanceof Tag && item.isRenderable()));
-  }
 }
+
+export default Line;

--- a/src/chord_sheet/paragraph.js
+++ b/src/chord_sheet/paragraph.js
@@ -1,7 +1,15 @@
 import { INDETERMINATE } from '../constants';
 
-export default class Paragraph {
+/**
+ * Represents a paragraph of lines in a chord sheet
+ */
+class Paragraph {
   constructor() {
+    /**
+     * The {@link Line} items of which the paragraph consists
+     * @member
+     * @type {Array<Line>}
+     */
     this.lines = [];
   }
 
@@ -9,6 +17,11 @@ export default class Paragraph {
     this.lines.push(line);
   }
 
+  /**
+   * Tries to determine the common type for all lines. If the types for all lines are equal, it returns that type.
+   * If not, it returns {@link INDETERMINATE}
+   * @returns {string}
+   */
   get type() {
     const types = this.lines.map(line => line.type);
     const uniqueTypes = [...new Set(types)];
@@ -20,3 +33,5 @@ export default class Paragraph {
     return INDETERMINATE;
   }
 }
+
+export default Paragraph;

--- a/src/chord_sheet/song.js
+++ b/src/chord_sheet/song.js
@@ -3,11 +3,26 @@ import Tag, { META_TAGS } from './tag';
 import Paragraph from './paragraph';
 import { pushNew } from '../utilities';
 
+/**
+ * Represents a song in a chord sheet. Currently a chord sheet can only have one song.
+ */
 class Song {
   constructor(metaData = {}) {
+    /**
+     * The {@link Line} items of which the song consists
+     * @member
+     * @type {Array<Line>}
+     */
     this.lines = [];
-    this.currentLine = null;
+
+    /**
+     * The {@link Paragraph} items of which the song consists
+     * @member
+     * @type {Array<Line>}
+     */
     this.paragraphs = [];
+
+    this.currentLine = null;
     this.currentParagraph = null;
     this.assignMetaData(metaData);
   }
@@ -20,6 +35,11 @@ class Song {
     });
   }
 
+  /**
+   * Returns the song lines, skipping the leading empty lines (empty as in not rendering any content). This is useful
+   * if you want to skip the "header lines": the lines that only contain meta data.
+   * @returns {Array<Line>} The song body lines
+   */
   get bodyLines() {
     if (this._bodyLines === undefined) {
       this._bodyLines = [...this.lines];
@@ -103,6 +123,10 @@ class Song {
     return tag;
   }
 
+  /**
+   * Returns a deep clone of the song
+   * @returns {Song} The cloned song
+   */
   clone() {
     const clonedSong = new Song();
     clonedSong.lines = this.lines.map(line => line.clone());
@@ -120,6 +144,11 @@ class Song {
     this.rawMetaData[name].add(value);
   }
 
+  /**
+   * Returns the song metadata. When there is only one value for an entry, the value is a string. Else, the value is
+   * an array containing all unique values for the entry.
+   * @returns {object} The metadata
+   */
   get metaData() {
     if (!this.optimizedMetaData) {
       this.optimizedMetaData = this.getOptimizedMetaData();

--- a/src/chord_sheet/tag.js
+++ b/src/chord_sheet/tag.js
@@ -1,20 +1,109 @@
+/**
+ * Album meta directive. See https://www.chordpro.org/chordpro/Directives-album.html
+ * @type {string}
+ */
 export const ALBUM = 'album';
+
+/**
+ * Artist meta directive. See https://www.chordpro.org/chordpro/Directives-artist.html
+ * @type {string}
+ */
 export const ARTIST = 'artist';
+
+/**
+ * Capo meta directive. See https://www.chordpro.org/chordpro/Directives-capo.html
+ * @type {string}
+ */
 export const CAPO = 'capo';
+
+/**
+ * Comment directive. See https://www.chordpro.org/chordpro/Directives-comment.html
+ * @type {string}
+ */
 export const COMMENT = 'comment';
+
+/**
+ * Composer meta directive. See https://www.chordpro.org/chordpro/Directives-composer.html
+ * @type {string}
+ */
 export const COMPOSER = 'composer';
+
+/**
+ * Copyright meta directive. See https://www.chordpro.org/chordpro/Directives-copyright.html
+ * @type {string}
+ */
 export const COPYRIGHT = 'copyright';
+
+/**
+ * Duration meta directive. See https://www.chordpro.org/chordpro/Directives-duration.html
+ * @type {string}
+ */
 export const DURATION = 'duration';
+
+/**
+ * End of chorus directive. See https://www.chordpro.org/chordpro/Directives-env_chorus.html
+ * @type {string}
+ */
 export const END_OF_CHORUS = 'end_of_chorus';
+
+/**
+ * End of verse directive. See https://www.chordpro.org/chordpro/Directives-env_verse.html
+ * @type {string}
+ */
 export const END_OF_VERSE = 'end_of_verse';
+
+/**
+ * Key meta directive. See https://www.chordpro.org/chordpro/Directives-key.html
+ * @type {string}
+ */
 export const KEY = 'key';
+
+/**
+ * Lyricist meta directive. See https://www.chordpro.org/chordpro/Directives-lyricist.html
+ * @type {string}
+ */
 export const LYRICIST = 'lyricist';
+
+/**
+ * Start of chorus directive. See https://www.chordpro.org/chordpro/Directives-env_chorus.html
+ * @type {string}
+ */
 export const START_OF_CHORUS = 'start_of_chorus';
+
+/**
+ * Start of verse directive. See https://www.chordpro.org/chordpro/Directives-env_verse.html
+ * @type {string}
+ */
 export const START_OF_VERSE = 'start_of_verse';
+
+/**
+ * Subtitle meta directive. See https://www.chordpro.org/chordpro/Directives-subtitle.html
+ * @type {string}
+ */
 export const SUBTITLE = 'subtitle';
+
+/**
+ * Tempo meta directive. See https://www.chordpro.org/chordpro/Directives-tempo.html
+ * @type {string}
+ */
 export const TEMPO = 'tempo';
+
+/**
+ * Time meta directive. See https://www.chordpro.org/chordpro/Directives-time.html
+ * @type {string}
+ */
 export const TIME = 'time';
+
+/**
+ * Title meta directive. See https://www.chordpro.org/chordpro/Directives-title.html
+ * @type {string}
+ */
 export const TITLE = 'title';
+
+/**
+ * Year meta directive. See https://www.chordpro.org/chordpro/Directives-year.html
+ * @type {string}
+ */
 export const YEAR = 'year';
 
 const TITLE_SHORT = 't';
@@ -67,7 +156,10 @@ const translateTagNameAlias = (name) => {
   return sanitizedName;
 };
 
-export default class Tag {
+/**
+ * Represents a tag/directive. See https://www.chordpro.org/chordpro/ChordPro-Directives.html
+ */
+class Tag {
   constructor(name, value) {
     this.name = name;
     this.value = value;
@@ -92,10 +184,20 @@ export default class Tag {
     this._originalName = name;
   }
 
+  /**
+   * The tag full name. When the original tag used the short name, `name` will return the full name.
+   * @member
+   * @type {string}
+   */
   get name() {
     return this._name.trim();
   }
 
+  /**
+   * The original tag name that was used to construct the tag.
+   * @member
+   * @type {string}
+   */
   get originalName() {
     return this._originalName.trim();
   }
@@ -104,6 +206,12 @@ export default class Tag {
     this._value = value;
   }
 
+
+  /**
+   * The tag value
+   * @member
+   * @type {string|null}
+   */
   get value() {
     if (this._value) {
       return this._value.trim();
@@ -112,18 +220,34 @@ export default class Tag {
     return this._value || null;
   }
 
+  /**
+   * Checks whether the tag value is a non-empty string.
+   * @returns {boolean}
+   */
   hasValue() {
     return this.value !== null && this.value.trim().length > 0;
   }
 
+  /**
+   * Checks whether the tag is usually rendered inline. It currently only applies to comment tags.
+   * @returns {boolean}
+   */
   isRenderable() {
     return RENDERABLE_TAGS.indexOf(this.name) !== -1;
   }
 
+  /**
+   * Checks whether the tag is either a standard meta tag or a custom meta directive (`{x_some_name}`)
+   * @returns {boolean}
+   */
   isMetaTag() {
     return CUSTOM_META_TAG_NAME_REGEX.test(this.name) || META_TAGS.indexOf(this.name) !== -1;
   }
 
+  /**
+   * Returns a clone of the tag.
+   * @returns {Tag} The cloned tag
+   */
   clone() {
     return new Tag(this.name, this.value);
   }
@@ -132,3 +256,5 @@ export default class Tag {
     return `Tag(name=${this.name}, value=${this.name})`;
   }
 }
+
+export default Tag;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,27 @@
+/**
+ * Used to mark a paragraph as verse
+ * @constant
+ * @type {string}
+ */
 export const VERSE = 'verse';
+
+/**
+ * Used to mark a paragraph as chorus
+ * @constant
+ * @type {string}
+ */
 export const CHORUS = 'chorus';
+
+/**
+ * Used to mark a paragraph as not containing a line marked with a type
+ * @constant
+ * @type {string}
+ */
 export const NONE = 'none';
+
+/**
+ * Used to mark a paragraph as containing lines with both verse and chorus type
+ * @constant
+ * @type {string}
+ */
 export const INDETERMINATE = 'indeterminate';

--- a/src/formatter/chord_pro_formatter.js
+++ b/src/formatter/chord_pro_formatter.js
@@ -3,7 +3,15 @@ import ChordLyricsPair from '../chord_sheet/chord_lyrics_pair';
 
 const NEW_LINE = '\n';
 
-export default class ChordProFormatter {
+/**
+ * Formats a song into a ChordPro chord sheet
+ */
+class ChordProFormatter {
+  /**
+   * Formats a song into a ChordPro chord sheet.
+   * @param {Song} song The song to be formatted
+   * @returns {string} The ChordPro string
+   */
   format(song) {
     return song.lines.map(line => this.formatLine(line)).join(NEW_LINE);
   }
@@ -49,3 +57,5 @@ export default class ChordProFormatter {
     return chordLyricsPair.lyrics || '';
   }
 }
+
+export default ChordProFormatter;

--- a/src/formatter/html_div_formatter.js
+++ b/src/formatter/html_div_formatter.js
@@ -37,7 +37,16 @@ const template = hbs`
   </div>
 {{~/with~}}`;
 
+
+/**
+ * Formats a song into HTML. It uses DIVs to align lyrics with chords, which makes it useful for responsive web pages.
+ */
 class HtmlDivFormatter {
+  /**
+   * Formats a song into HTML.
+   * @param {Song} song The song to be formatted
+   * @returns {string} The HTML string
+   */
   format(song) {
     return template({ song });
   }

--- a/src/formatter/html_table_formatter.js
+++ b/src/formatter/html_table_formatter.js
@@ -54,7 +54,16 @@ const template = hbs`
 {{~/with~}}
 `;
 
+/**
+ * Formats a song into HTML. It uses TABLEs to align lyrics with chords, which makes the HTML for things like
+ * PDF conversion.
+ */
 class HtmlTableFormatter {
+  /**
+   * Formats a song into HTML.
+   * @param {Song} song The song to be formatted
+   * @returns {string} The HTML string
+   */
   format(song) {
     return template({ song });
   }

--- a/src/formatter/text_formatter.js
+++ b/src/formatter/text_formatter.js
@@ -2,7 +2,15 @@ import ChordLyricsPair from '../chord_sheet/chord_lyrics_pair';
 import Tag from '../chord_sheet/tag';
 import { hasChordContents, hasTextContents, padLeft } from '../utilities';
 
-export default class TextFormatter {
+/**
+ * Formats a sonf into a plain text chord sheet
+ */
+class TextFormatter {
+  /**
+   * Formats a song into a plain text chord sheet
+   * @param {Song} song The song to be formatted
+   * @returns {string} the chord sheet
+   */
   format(song) {
     return [
       this.formatHeader(song),
@@ -118,3 +126,5 @@ export default class TextFormatter {
     return '';
   }
 }
+
+export default TextFormatter;

--- a/src/parser/chord_pro_parser.js
+++ b/src/parser/chord_pro_parser.js
@@ -10,15 +10,29 @@ const CURLY_START = '{';
 const CURLY_END = '}';
 const SHARP_SIGN = '#';
 
-export default class ChordProParser {
-  parse(document) {
+/**
+ * Parses a ChordPro chord sheet
+ */
+class ChordProParser {
+  /**
+   * Parses a ChordPro chord sheet into a song
+   * @param {string} chordProChordSheet the ChordPro chord sheet
+   * @returns {Song} The parsed song
+   */
+  parse(chordProChordSheet) {
+    /**
+     * All warnings raised during parsing the ChordPro chord sheet
+     * @member
+     * @type {Array<ParserWarning>}
+     */
+    this.warnings = [];
+
     this.song = new Song();
     this.lineNumber = 1;
-    this.warnings = [];
     this.sectionType = NONE;
     this.resetTag();
     this.processor = this.readLyrics;
-    this.parseDocument(document);
+    this.parseDocument(chordProChordSheet);
     this.song.finish();
     return this.song;
   }
@@ -141,3 +155,5 @@ export default class ChordProParser {
     this.warnings.push(warning);
   }
 }
+
+export default ChordProParser;

--- a/src/parser/chord_sheet_parser.js
+++ b/src/parser/chord_sheet_parser.js
@@ -3,13 +3,21 @@ import Song from '../chord_sheet/song';
 const WHITE_SPACE = /\s/;
 const CHORD_LINE_REGEX = /^\s*((([A-G])(#|b)?([^/\s]*)(\/([A-G])(#|b)?)?)(\s|$)+)+(\s|$)+/;
 
+/**
+ * Parses a normal chord sheet
+ */
 export default class ChordSheetParser {
   constructor({ preserveWhitespace = true } = {}) {
     this.preserveWhitespace = (preserveWhitespace === true);
   }
 
-  parse(document) {
-    this.initialize(document);
+  /**
+   * Parses a chord sheet into a song
+   * @param {string} chordSheet The ChordPro chord sheet
+   * @returns {Song} The parsed song
+   */
+  parse(chordSheet) {
+    this.initialize(chordSheet);
 
     while (this.hasNextLine()) {
       const line = this.readLine();

--- a/src/parser/parser_warning.js
+++ b/src/parser/parser_warning.js
@@ -1,11 +1,32 @@
+/**
+ * Represents a parser warning, currently only used by ChordProParser.
+ */
 class ParserWarning {
+  /**
+   * @hideconstructor
+   */
   constructor(message, lineNumber) {
-    this._message = message;
-    this._lineNumber = lineNumber;
+    /**
+     * The warning message
+     * @member
+     * @type {string}
+     */
+    this.message = message;
+
+    /**
+     * The chord sheet line number on which the warning occurred
+     * @member
+     * @type {integer}
+     */
+    this.lineNumber = lineNumber;
   }
 
+  /**
+   * Returns a stringified version of the warning
+   * @returns {string} The string warning
+   */
   toString() {
-    return `Warning: ${this._message} on line ${this._lineNumber}`;
+    return `Warning: ${this.message} on line ${this.lineNumber}`;
   }
 }
 

--- a/test/chord_sheet/line.js
+++ b/test/chord_sheet/line.js
@@ -11,10 +11,12 @@ describe('Line', () => {
     it('returns a clone of the line', () => {
       const line = new Line();
       line.items = ['foo', 'bar'].map(value => new ItemStub(value));
+      line.type = 'test_type';
       const clonedLine = line.clone();
 
       const actualValues = clonedLine.items.map(item => item.value);
       expect(actualValues).to.eql(['foo', 'bar']);
+      expect(clonedLine.type).to.eql('test_type');
     });
   });
 


### PR DESCRIPTION
In order to better explain how to use ChordSheetJS, this PR adds API docs to the README. The docs are generated from Jsdoc comments inside the code. All classes, methods and constants that are documented can be considered public API and will only be subject to breaking changes between major versions.

Fixes #58 