### PR TITLE
:sparkles: Add basic ultimate guitar parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1715,7 +1715,6 @@
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1911,8 +1910,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2002,8 +2000,7 @@
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/src/chordsheet.js
+++ b/src/chordsheet.js
@@ -1,5 +1,6 @@
 import ChordProParser from './parser/chord_pro_parser';
 import ChordSheetParser from './parser/chord_sheet_parser';
+import UltimateGuitarParser from './parser/ultimate_guitar_parser';
 import TextFormatter from './formatter/text_formatter';
 import HtmlTableFormatter from './formatter/html_table_formatter';
 import HtmlDivFormatter from './formatter/html_div_formatter';
@@ -12,6 +13,7 @@ import Tag from './chord_sheet/tag';
 export default {
   ChordProParser,
   ChordSheetParser,
+  UltimateGuitarParser,
   TextFormatter,
   HtmlTableFormatter,
   HtmlDivFormatter,

--- a/src/parser/ultimate_guitar_parser.js
+++ b/src/parser/ultimate_guitar_parser.js
@@ -1,0 +1,96 @@
+import ChordSheetParser from './chord_sheet_parser';
+import { CHORUS, NONE, VERSE } from '../constants';
+import { END_OF_CHORUS, END_OF_VERSE, START_OF_CHORUS, START_OF_VERSE } from '../chord_sheet/tag';
+
+const logger = {
+  debug: console.debug,
+  error: console.error,
+  info: console.info,
+};
+
+const VERSE_LINE_REGEX = /^\[Verse.*\]/;
+const CHORUS_LINE_REGEX = /^\[Chorus\]/;
+const OTHER_METADATA_LINE_REGEX = /^\[([^\]]+)\]/;
+
+const sectionTypeToStartTag = new Map(Object.entries({
+  [CHORUS]: START_OF_CHORUS,
+  [VERSE]: START_OF_VERSE,
+}));
+
+const sectionTypeToEndTag = new Map(Object.entries({
+  [CHORUS]: END_OF_CHORUS,
+  [VERSE]: END_OF_VERSE,
+}));
+
+/**
+ * Parses an Ultimate Guitar chord sheet with metadata
+ */
+export default class UltimateGuitarParser extends ChordSheetParser {
+  parse(ultimateGuitarChordSheet) {
+    this.currentSectionType = NONE;
+    const song = super.parse(ultimateGuitarChordSheet);
+    this.endCurrentSection();
+    return song;
+  }
+
+  startSection(type) {
+    this.endCurrentSection();
+
+    logger.debug(`Starting ${type} section`);
+
+    if (sectionTypeToStartTag.has(type)) {
+      const startTag = sectionTypeToStartTag.get(type);
+      logger.debug(`Adding section start tag ${startTag}`);
+      this.song.addTag(startTag);
+    } else {
+      logger.debug(`Unknown start tag for ${type} section, adding as comment`);
+      this.song.addTag(`comment: ${type}`);
+    }
+
+    this.currentSectionType = type;
+  }
+
+  endSection(type) {
+    logger.debug(`Ending ${type} section`);
+
+    if (sectionTypeToEndTag.has(type)) {
+      const endTag = sectionTypeToEndTag.get(type);
+      logger.debug(`Adding section end tag ${endTag}`);
+      this.song.addLine();
+      this.song.addTag(endTag);
+    } else {
+      logger.debug(`Unknown end tag for ${type} section, ignoring`);
+    }
+
+    this.currentSectionType = NONE;
+  }
+
+  endCurrentSection() {
+    if (this.currentSectionType === NONE) {
+      logger.debug('No current section to end');
+      return;
+    }
+
+    this.endSection(this.currentSectionType);
+  }
+
+  parseLine(line) {
+    if (line.trim().length === 0) {
+      this.endCurrentSection();
+    }
+
+    return super.parseLine(line);
+  }
+
+  parseNonEmptyLine(line) {
+    if (VERSE_LINE_REGEX.test(line)) {
+      this.startSection(VERSE);
+    } else if (CHORUS_LINE_REGEX.test(line)) {
+      this.startSection(CHORUS);
+    } else if (OTHER_METADATA_LINE_REGEX.test(line)) {
+      this.startSection(line.match(OTHER_METADATA_LINE_REGEX)[1]);
+    } else {
+      super.parseNonEmptyLine(line);
+    }
+  }
+}

--- a/src/parser/ultimate_guitar_parser.js
+++ b/src/parser/ultimate_guitar_parser.js
@@ -1,26 +1,35 @@
 import ChordSheetParser from './chord_sheet_parser';
 import { CHORUS, NONE, VERSE } from '../constants';
-import { END_OF_CHORUS, END_OF_VERSE, START_OF_CHORUS, START_OF_VERSE } from '../chord_sheet/tag';
+import {
+  END_OF_CHORUS,
+  END_OF_VERSE,
+  START_OF_CHORUS,
+  START_OF_VERSE,
+} from '../chord_sheet/tag';
 
-const logger = {
-  debug: console.debug,
-  error: console.error,
-  info: console.info,
-};
+const noop = () => {};
+const logger =
+  process && process.env === 'development'
+    ? console
+    : {
+      debug: noop,
+      error: noop,
+      info: noop,
+    };
 
 const VERSE_LINE_REGEX = /^\[Verse.*\]/;
 const CHORUS_LINE_REGEX = /^\[Chorus\]/;
 const OTHER_METADATA_LINE_REGEX = /^\[([^\]]+)\]/;
 
-const sectionTypeToStartTag = new Map(Object.entries({
+const sectionTypeToStartTag = {
   [CHORUS]: START_OF_CHORUS,
   [VERSE]: START_OF_VERSE,
-}));
+};
 
-const sectionTypeToEndTag = new Map(Object.entries({
+const sectionTypeToEndTag = {
   [CHORUS]: END_OF_CHORUS,
   [VERSE]: END_OF_VERSE,
-}));
+};
 
 /**
  * Parses an Ultimate Guitar chord sheet with metadata
@@ -38,8 +47,8 @@ export default class UltimateGuitarParser extends ChordSheetParser {
 
     logger.debug(`Starting ${type} section`);
 
-    if (sectionTypeToStartTag.has(type)) {
-      const startTag = sectionTypeToStartTag.get(type);
+    if (type in sectionTypeToStartTag) {
+      const startTag = sectionTypeToStartTag[type];
       logger.debug(`Adding section start tag ${startTag}`);
       this.song.addTag(startTag);
     } else {
@@ -53,8 +62,8 @@ export default class UltimateGuitarParser extends ChordSheetParser {
   endSection(type) {
     logger.debug(`Ending ${type} section`);
 
-    if (sectionTypeToEndTag.has(type)) {
-      const endTag = sectionTypeToEndTag.get(type);
+    if (type in sectionTypeToEndTag) {
+      const endTag = sectionTypeToEndTag[type];
       logger.debug(`Adding section end tag ${endTag}`);
       this.song.addLine();
       this.song.addTag(endTag);

--- a/test/parser/ultimate_guitar_chordsheet.txt
+++ b/test/parser/ultimate_guitar_chordsheet.txt
@@ -1,0 +1,45 @@
+[Verse 1]
+C     G               Am
+Lorem ipsum dolor sit amet,
+C           G          F
+consectetur adipiscing elit.
+
+
+[Chorus]
+        Am      C     F                        C
+ Tortor posuere ac ut consequat semper viverra nam.
+C            G                  F
+Non nisi est sit amet facilisis magna etiam tempor orci.
+
+
+[Verse 2]
+C         G               Am
+Habitasse platea dictumst vestibulum rhoncus.
+C            G            F
+Tristique et egestas quis ipsum.
+
+
+[Chorus]
+        Am      C     F                        C
+ Tortor posuere ac ut consequat semper viverra nam.
+C            G                  F
+Non nisi est sit amet facilisis magna etiam tempor orci.
+
+
+[Instrumental]
+F  C Dm
+
+
+[Solo]
+C  G  Am
+
+
+[Chorus]
+        Am      C     F                        C
+ Tortor posuere ac ut consequat semper viverra nam.
+C            G                  F
+Non nisi est sit amet facilisis magna etiam tempor orci.
+
+
+[Outro]
+F C Dm

--- a/test/parser/ultimate_guitar_chordsheet_expected_chordpro_format.txt
+++ b/test/parser/ultimate_guitar_chordsheet_expected_chordpro_format.txt
@@ -1,0 +1,40 @@
+{start_of_verse}
+[C]Lorem [G]ipsum dolor sit [Am]amet,
+[C]consectetur [G]adipiscing [F]elit.
+{end_of_verse}
+
+
+{start_of_chorus}
+ Tortor [Am]posuere [C]ac ut [F]consequat semper viverra [C]nam.
+[C]Non nisi est [G]sit amet facilisis [F]magna etiam tempor orci.
+{end_of_chorus}
+
+
+{start_of_verse}
+[C]Habitasse [G]platea dictumst [Am]vestibulum rhoncus.
+[C]Tristique et [G]egestas quis [F]ipsum.
+{end_of_verse}
+
+
+{start_of_chorus}
+ Tortor [Am]posuere [C]ac ut [F]consequat semper viverra [C]nam.
+[C]Non nisi est [G]sit amet facilisis [F]magna etiam tempor orci.
+{end_of_chorus}
+
+
+{comment: Instrumental}
+[F][C][Dm]
+
+
+{comment: Solo}
+[C][G][Am]
+
+
+{start_of_chorus}
+ Tortor [Am]posuere [C]ac ut [F]consequat semper viverra [C]nam.
+[C]Non nisi est [G]sit amet facilisis [F]magna etiam tempor orci.
+{end_of_chorus}
+
+
+{comment: Outro}
+[F][C][Dm]

--- a/test/parser/utlimate_guitar_parser.js
+++ b/test/parser/utlimate_guitar_parser.js
@@ -1,0 +1,86 @@
+import { expect } from 'chai';
+import fs from 'fs';
+
+import '../matchers';
+import UltimateGuitarParser from '../../src/parser/ultimate_guitar_parser';
+import ChordProFormatter from '../../src/formatter/chord_pro_formatter';
+
+
+describe('UltimateGuitarParser', () => {
+  it('starts and ends a single verse tag correctly', () => {
+    const chordSheetVerseTag = `
+[Verse 1]`.substring(1);
+
+    const parser = new UltimateGuitarParser({ preserveWhitespace: false });
+    const song = parser.parse(chordSheetVerseTag);
+    const lines = song.lines;
+
+    expect(lines.length).to.equal(2);
+
+    const line0Items = lines[0].items;
+    expect(line0Items[0]).to.be.tag('start_of_verse', null);
+
+    const line1Items = lines[1].items;
+    expect(line1Items[0]).to.be.tag('end_of_verse', null);
+  });
+
+  it('parses a single verse correctly', () => {
+    const chordSheetVerse = `
+[Verse 1]
+C     G               Am
+Lorem ipsum dolor sit amet,
+C           G          F
+consectetur adipiscing elit.`.substring(1);
+
+    const parser = new UltimateGuitarParser({ preserveWhitespace: false });
+    const song = parser.parse(chordSheetVerse);
+    const lines = song.lines;
+
+    expect(lines.length).to.equal(4);
+
+    const line0Items = lines[0].items;
+    expect(line0Items[0]).to.be.tag('start_of_verse', null);
+
+    const line1Items = lines[1].items;
+    expect(line1Items).to.have.length(3);
+
+    const line2Items = lines[2].items;
+    expect(line2Items).to.have.length(3);
+
+    const line3Items = lines[3].items;
+    expect(line3Items[0]).to.be.tag('end_of_verse', null);
+  });
+
+  it('adds unknown sections as comments', () => {
+    const chordSheetInstrumental = `
+[Instrumental]
+F  C Dm
+`.substring(1); // TODO support chords-only line with no following lyrics or empty line
+
+    const parser = new UltimateGuitarParser({ preserveWhitespace: false });
+    const song = parser.parse(chordSheetInstrumental);
+    const lines = song.lines;
+
+    expect(lines.length).to.equal(3);
+
+    const line0Items = lines[0].items;
+    expect(line0Items[0]).to.be.tag('comment', 'Instrumental');
+
+    const line1Items = lines[1].items;
+    expect(line1Items).to.have.length(3);
+
+    const line2Items = lines[2].items;
+    expect(line2Items).to.have.length(0);
+  });
+
+  it('parses entire chordsheet with several sections correctly', () => {
+    const chordSheet = fs.readFileSync('./test/parser/ultimate_guitar_chordsheet.txt', 'utf8');
+    const expected = fs.readFileSync('./test/parser/ultimate_guitar_chordsheet_expected_chordpro_format.txt', 'utf8');
+
+    const parser = new UltimateGuitarParser({ preserveWhitespace: false });
+    const song = parser.parse(chordSheet);
+    const result = new ChordProFormatter().format(song);
+
+    expect(result).to.equal(expected);
+  });
+});

--- a/test/parser/utlimate_guitar_parser.js
+++ b/test/parser/utlimate_guitar_parser.js
@@ -55,7 +55,7 @@ consectetur adipiscing elit.`.substring(1);
     const chordSheetInstrumental = `
 [Instrumental]
 F  C Dm
-`.substring(1); // TODO support chords-only line with no following lyrics or empty line
+`.substring(1); // to do: support chords-only line with no following lyrics or empty line
 
     const parser = new UltimateGuitarParser({ preserveWhitespace: false });
     const song = parser.parse(chordSheetInstrumental);


### PR DESCRIPTION
Ultimate guitar chordsheets (e.g. [Let it be](https://tabs.ultimate-guitar.com/tab/the_beatles/let_it_be_chords_60690)) are very similar to the chord sheets already supported by this library.

They have special kind of meta tags. Example:
```
[Verse 1]
When I...
```
This MR provides a very basic `UltimateGuitarParser` parser by subclassing the `ChordSheetParser`.