### PR TITLE
Feature/Support several sections like Intro, Solo

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -25,3 +25,10 @@ export const NONE = 'none';
  * @type {string}
  */
 export const INDETERMINATE = 'indeterminate';
+
+/**
+ * Used to mark a paragraph as intro
+ * @constant
+ * @type {string}
+ */
+export const INTRO = 'intro';

--- a/src/formatter/html_div_formatter.js
+++ b/src/formatter/html_div_formatter.js
@@ -20,7 +20,7 @@ const template = hbs`
             <div class="{{lineClasses line}}">
               {{~#each items as |item|~}}
                 {{~#if (isChordLyricsPair item)~}}
-                  <div class="column"><div class="chord">{{chords}}</div><div class="lyrics">{{lyrics}}</div></div>
+                  <div class="column"><div class="chord">{{chords}}</div>{{~#if (hasTextContents line)~}}<div class="lyrics">{{lyrics}}</div>{{~/if~}}</div>
                 {{~/if~}}
 
                 {{~#if (isTag item)~}}

--- a/src/formatter/html_div_formatter.js
+++ b/src/formatter/html_div_formatter.js
@@ -20,7 +20,12 @@ const template = hbs`
             <div class="{{lineClasses line}}">
               {{~#each items as |item|~}}
                 {{~#if (isChordLyricsPair item)~}}
-                  <div class="column"><div class="chord">{{chords}}</div>{{~#if (hasTextContents line)~}}<div class="lyrics">{{lyrics}}</div>{{~/if~}}</div>
+                  <div class="column">
+                    <div class="chord">{{chords}}</div>
+                    {{~#if (hasTextContents line)~}}
+                      <div class="lyrics">{{lyrics}}</div>
+                    {{~/if~}}
+                  </div>
                 {{~/if~}}
 
                 {{~#if (isTag item)~}}

--- a/src/formatter/html_div_formatter.js
+++ b/src/formatter/html_div_formatter.js
@@ -20,8 +20,7 @@ const template = hbs`
             <div class="{{lineClasses line}}">
               {{~#each items as |item|~}}
                 {{~#if (isChordLyricsPair item)~}}
-                  <div class="column">
-                    <div class="chord">{{chords}}</div>
+                  <div class="column"><div class="chord">{{chords}}</div>
                     {{~#if (hasTextContents line)~}}
                       <div class="lyrics">{{lyrics}}</div>
                     {{~/if~}}

--- a/src/parser/chord_pro_parser.js
+++ b/src/parser/chord_pro_parser.js
@@ -1,6 +1,5 @@
 import Song from '../chord_sheet/song';
-import { END_OF_CHORUS, END_OF_VERSE, START_OF_CHORUS, START_OF_VERSE } from '../chord_sheet/tag';
-import { CHORUS, NONE, VERSE } from '../constants';
+import { NONE } from '../constants';
 import ParserWarning from './parser_warning';
 
 const NEW_LINE = '\n';
@@ -111,11 +110,11 @@ class ChordProParser {
   }
 
   applyTag(tag) {
-    if(tag.name.startsWith('start_of_')){
-      const sectionName = tag.name.replace('start_of_', '')
-      this.startSection(sectionName,tag);
-    } else if(tag.name.startsWith('end_of_')){
-      const sectionName = tag.name.replace('end_of_', '')
+    if (tag.name.startsWith('start_of_')) {
+      const sectionName = tag.name.replace('start_of_', '');
+      this.startSection(sectionName, tag);
+    } else if (tag.name.startsWith('end_of_')) {
+      const sectionName = tag.name.replace('end_of_', '');
       this.endSection(sectionName, tag);
     }
   }

--- a/src/parser/chord_pro_parser.js
+++ b/src/parser/chord_pro_parser.js
@@ -111,25 +111,12 @@ class ChordProParser {
   }
 
   applyTag(tag) {
-    switch (tag.name) {
-      case START_OF_CHORUS:
-        this.startSection(CHORUS, tag);
-        break;
-
-      case END_OF_CHORUS:
-        this.endSection(CHORUS, tag);
-        break;
-
-      case START_OF_VERSE:
-        this.startSection(VERSE, tag);
-        break;
-
-      case END_OF_VERSE:
-        this.endSection(VERSE, tag);
-        break;
-
-      default:
-        break;
+    if(tag.name.startsWith('start_of_')){
+      const sectionName = tag.name.replace('start_of_', '')
+      this.startSection(sectionName,tag);
+    } else if(tag.name.startsWith('end_of_')){
+      const sectionName = tag.name.replace('end_of_', '')
+      this.endSection(sectionName, tag);
     }
   }
 

--- a/test/fixtures/song.js
+++ b/test/fixtures/song.js
@@ -1,11 +1,15 @@
 import { createSong, createLine, createChordLyricsPair, createTag } from '../utilities';
-import { CHORUS, VERSE } from '../../src/constants';
+import { CHORUS, INTRO, VERSE } from '../../src/constants';
 
 // Mimic the following chord sheet:
 // {title: Let it be}
 // {subtitle: ChordSheetJS example version}
 // {x_some_setting: value}
 // {comment: Bridge}
+//
+// {start_of_intro}
+// [Am][C][F][G]
+// {end_of_intro}
 //
 // {start_of_verse}
 // Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be
@@ -31,6 +35,23 @@ export default createSong([
 
   createLine([
     createTag('comment', 'Bridge'),
+  ]),
+
+  createLine([]),
+
+  createLine([
+    createTag('start_of_intro'),
+  ]),
+
+  createLine([
+    createChordLyricsPair('Am', ''),
+    createChordLyricsPair('C', ''),
+    createChordLyricsPair('F', ''),
+    createChordLyricsPair('G', ''),
+  ], INTRO),
+
+  createLine([
+    createTag('end_of_intro'),
   ]),
 
   createLine([]),

--- a/test/formatter/chord_pro_formatter.js
+++ b/test/formatter/chord_pro_formatter.js
@@ -13,6 +13,10 @@ describe('ChordProFormatter', () => {
 {x_some_setting}
 {comment: Bridge}
 
+{start_of_intro}
+[Am][C][F][G]
+{end_of_intro}
+
 {start_of_verse}
 Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be
 [C]Whisper words of [F]wis[G]dom, let it [F]be [C/E] [Dm] [C] 

--- a/test/formatter/html_div_formatter.js
+++ b/test/formatter/html_div_formatter.js
@@ -24,19 +24,15 @@ describe('HtmlDivFormatter', () => {
           '<div class="row">' +
             '<div class="column">' +
               '<div class="chord">Am</div>' +
-              '<div class="lyrics"></div>' +
             '</div>' +
             '<div class="column">' +
               '<div class="chord">C</div>' +
-              '<div class="lyrics"></div>' +
             '</div>' +
             '<div class="column">' +
               '<div class="chord">F</div>' +
-              '<div class="lyrics"></div>' +
             '</div>' +
             '<div class="column">' +
               '<div class="chord">G</div>' +
-              '<div class="lyrics"></div>' +
             '</div>' +
           '</div>' +
         '</div>' +

--- a/test/formatter/html_div_formatter.js
+++ b/test/formatter/html_div_formatter.js
@@ -20,6 +20,26 @@ describe('HtmlDivFormatter', () => {
             '<div class="comment">Bridge</div>' +
           '</div>' +
         '</div>' +
+        '<div class="paragraph intro">' +
+          '<div class="row">' +
+            '<div class="column">' +
+              '<div class="chord">Am</div>' +
+              '<div class="lyrics"></div>' +
+            '</div>' +
+            '<div class="column">' +
+              '<div class="chord">C</div>' +
+              '<div class="lyrics"></div>' +
+            '</div>' +
+            '<div class="column">' +
+              '<div class="chord">F</div>' +
+              '<div class="lyrics"></div>' +
+            '</div>' +
+            '<div class="column">' +
+              '<div class="chord">G</div>' +
+              '<div class="lyrics"></div>' +
+            '</div>' +
+          '</div>' +
+        '</div>' +
         '<div class="paragraph verse">' +
           '<div class="row">' +
             '<div class="column">' +

--- a/test/formatter/html_table_formatter.js
+++ b/test/formatter/html_table_formatter.js
@@ -22,6 +22,16 @@ describe('HtmlTableFormatter', () => {
             '</tr>' +
           '</table>' +
         '</div>' +
+        '<div class="paragraph intro">' +
+          '<table class="row">' +
+            '<tr>' +
+              '<td class="chord">Am</td>' +
+              '<td class="chord">C</td>' +
+              '<td class="chord">F</td>' +
+              '<td class="chord">G</td>' +
+            '</tr>' +
+          '</table>' +
+        '</div>' +
         '<div class="paragraph verse">' +
           '<table class="row">' +
             '<tr>' +

--- a/test/formatter/text_formatter.js
+++ b/test/formatter/text_formatter.js
@@ -15,6 +15,8 @@ ChordSheetJS example version
 
 Bridge
 
+Am C F G
+
        Am         C/G        F          C
 Let it be, let it be, let it be, let it be
 C                F  G           F  C/E Dm C

--- a/test/parser/chord_pro_parser.js
+++ b/test/parser/chord_pro_parser.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import '../matchers';
 import ChordProParser from '../../src/parser/chord_pro_parser';
-import { CHORUS, NONE, VERSE } from '../../src/constants';
+import { CHORUS, INTRO, NONE, VERSE } from '../../src/constants';
 
 const chordSheet = `
 {title: Let it be}
@@ -122,6 +122,9 @@ Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be
 
   it('adds the type to lines', () => {
     const markedChordSheet = `
+{start_of_intro}
+[Am] [C] [F] [G]
+{end_of_intro}
 {start_of_verse}
 Let it [Am]be
 {end_of_verse}
@@ -134,7 +137,7 @@ Let it [F]be [C]
     const song = parser.parse(markedChordSheet);
     const lineTypes = song.lines.map(line => line.type);
 
-    expect(lineTypes).to.eql([NONE, VERSE, NONE, NONE, NONE, CHORUS, NONE]);
+    expect(lineTypes).to.eql([NONE, INTRO, NONE, NONE, VERSE, NONE, NONE, NONE, CHORUS, NONE]);
     expect(parser.warnings).to.be.empty;
   });
 


### PR DESCRIPTION
I want to create a stylesheet for a html formatted song where sections like the song chorus, intro or solo are highlighted. Therefore it is necessary to have a wrapper element for those sections. 

This PR will make it possible to use tags like `{start_of_intro}` (where intro can be anything) to structure the song. 

Besides that, it fixed a bug where blank lyric lines are rendered using the html div formatter. Now these lines are not rendered like using the html table or text formatter.