### PR TITLE
Allow metadata arrray item lookup with negative index

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,12 @@ metadata.get('author')   // => ['John', 'Mary']
 metadata.get('author.1') // => 'John'
 metadata.get('author.2') // => 'Mary'
 
+Using a negative index will start counting at the end of the list:
+
+const metadata = new Metadata({ lyricist: 'Pete', author: ['John', 'Mary'] });
+metadata.get('author.-1') // => 'Mary'
+metadata.get('author.-2') // => 'John'
+
 **Kind**: instance method of [<code>Metadata</code>](#Metadata)  
 **Returns**: <code>Array.&lt;String&gt;</code> \| <code>String</code> - the metadata value(s). If there is only one value, it will return a String,
 else it returns an array of strings.  

--- a/src/chord_sheet/metadata.js
+++ b/src/chord_sheet/metadata.js
@@ -58,6 +58,12 @@ class Metadata {
    * metadata.get('author.1') // => 'John'
    * metadata.get('author.2') // => 'Mary'
    *
+   * Using a negative index will start counting at the end of the list:
+   *
+   * const metadata = new Metadata({ lyricist: 'Pete', author: ['John', 'Mary'] });
+   * metadata.get('author.-1') // => 'Mary'
+   * metadata.get('author.-2') // => 'John'
+   *
    * @param prop the property name
    * @returns {Array<String>|String} the metadata value(s). If there is only one value, it will return a String,
    * else it returns an array of strings.
@@ -67,18 +73,33 @@ class Metadata {
       return this[prop];
     }
 
-    const match = prop.match(/(.+)\.(\d+)$/);
+    const match = prop.match(/(.+)\.(-?\d+)$/);
 
-    if (match) {
-      const key = match[1];
-      const index = parseInt(match[2], 10);
-
-      if (key in this) {
-        return (this[key] || [])[index - 1];
-      }
+    if (!match) {
+      return undefined;
     }
 
-    return undefined;
+    const key = match[1];
+
+    if (!(key in this)) {
+      return undefined;
+    }
+
+    const index = parseInt(match[2], 10);
+    return this.getArrayItem(key, index);
+  }
+
+  getArrayItem(key, index) {
+    const arrayValue = (this[key] || []);
+    let itemIndex = index;
+
+    if (itemIndex < 0) {
+      itemIndex = arrayValue.length + itemIndex;
+    } else if (itemIndex > 0) {
+      itemIndex -= 1;
+    }
+
+    return arrayValue[itemIndex];
   }
 
   /**

--- a/test/chord_sheet/metadata.test.js
+++ b/test/chord_sheet/metadata.test.js
@@ -54,6 +54,12 @@ describe('Metadata', () => {
       expect(metadata.get('author.2')).toEqual('Mary');
     });
 
+    it('reads a single counting from the end', () => {
+      const metadata = new Metadata({ author: ['John', 'Mary'] });
+      expect(metadata.get('author.-1')).toEqual('Mary');
+      expect(metadata.get('author.-2')).toEqual('John');
+    });
+
     describe('when a single value does not exist', () => {
       it('returns undefined', () => {
         const metadata = new Metadata({});


### PR DESCRIPTION
Using a negative index will start counting at the end of the list:

```js
const metadata = new Metadata({ lyricist: 'Pete', author: ['John', 'Mary'] });
metadata.get('author.-1') // => 'Mary'
metadata.get('author.-2') // => 'John'
```