### PR TITLE
Gh 252 allow chords without spacing in between

### DIFF
--- a/src/parser/chord_pro_grammar.pegjs
+++ b/src/parser/chord_pro_grammar.pegjs
@@ -33,7 +33,7 @@ Comment
 }
 
 ChordLyricsPair
-  = chord: Chord lyrics: Lyrics {
+  = chord: Chord lyrics:$(Lyrics*) {
   return { type: "chordLyricsPair", chord, lyrics }
 }
 

--- a/test/matchers.js
+++ b/test/matchers.js
@@ -26,8 +26,15 @@ function toBeClassInstanceWithProperties(received, klass, properties) {
         errors.push(`it was a instance of ${received.constructor.name}`);
       } else {
         propertyNames.forEach((name) => {
-          if (received[name] !== properties[name]) {
-            errors.push(`its ${name} were: "${received[name]}"`);
+          const actualProperty = received[name];
+          const expectedProperty = properties[name];
+          const actualType = typeof actualProperty;
+          const expectedType = typeof expectedProperty;
+
+          if (actualType !== expectedType) {
+            errors.push(`expected ${name} to be a ${expectedType} but it was a ${actualType}`);
+          } else if (actualProperty !== expectedProperty) {
+            errors.push(`its ${name} were: "${actualProperty}" vs "${expectedProperty}"`);
           }
         });
       }

--- a/test/parser/chord_pro_parser.test.js
+++ b/test/parser/chord_pro_parser.test.js
@@ -7,7 +7,7 @@ const chordSheet = `
 {subtitle: ChordSheetJS example version}
 {Chorus}
 
-Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be
+Let it [Am]be, let it [C/A][C/G]be, let it [F]be, let it [C]be
 [C]Whisper words of [F]wis[G]dom, let it [F]be [C/E] [Dm] [C]`.substring(1);
 
 describe('ChordProParser', () => {
@@ -31,9 +31,10 @@ describe('ChordProParser', () => {
     const line4Pairs = lines[4].items;
     expect(line4Pairs[0]).toBeChordLyricsPair('', 'Let it ');
     expect(line4Pairs[1]).toBeChordLyricsPair('Am', 'be, let it ');
-    expect(line4Pairs[2]).toBeChordLyricsPair('C/G', 'be, let it ');
-    expect(line4Pairs[3]).toBeChordLyricsPair('F', 'be, let it ');
-    expect(line4Pairs[4]).toBeChordLyricsPair('C', 'be');
+    expect(line4Pairs[2]).toBeChordLyricsPair('C/A', '');
+    expect(line4Pairs[3]).toBeChordLyricsPair('C/G', 'be, let it ');
+    expect(line4Pairs[4]).toBeChordLyricsPair('F', 'be, let it ');
+    expect(line4Pairs[5]).toBeChordLyricsPair('C', 'be');
 
     const lines5Pairs = lines[5].items;
     expect(lines5Pairs[0]).toBeChordLyricsPair('C', 'Whisper words of ');


### PR DESCRIPTION
Allow chords without spacing in between

    Eg.:

        [F#][C]

    is a valid Chordpro sheet

    Resolves #252