### PR TITLE
Gh 196 support directives with curly braces

### DIFF
--- a/src/parser/chord_pro_grammar.pegjs
+++ b/src/parser/chord_pro_grammar.pegjs
@@ -116,8 +116,8 @@ Tag
 }
 
 TagColonWithValue
-  = ":" _ tagValue:$(TagValue) {
-  return tagValue;
+  = ":" _ tagValue:TagValue {
+  return tagValue.map(c => c.char || c).join('');
 }
 
 TagName
@@ -127,7 +127,7 @@ TagValue
   = TagValueChar+
 
 TagValueChar
-  = [^\}\r\n]
+  = [^}\\\r\n]
   / Escape
     sequence:(
         "\\" { return {type: "char", char: "\\"}; }

--- a/test/parser/chord_pro_parser.test.js
+++ b/test/parser/chord_pro_parser.test.js
@@ -53,6 +53,13 @@ Let it [Am]be, let it [C/A][C/G#]be, let it [F]be, let it [C]be
     expect(song.lines[0].items[0]).toBeTag('comment', 'Intro [Dm7] [F6/B] [Cmaj7]');
   });
 
+  it('correctly parses a directive containing curly brackets', () => {
+    const chordSheet = '{comment: Some {comment\\} }';
+    const song = new ChordProParser().parse(chordSheet);
+
+    expect(song.lines[0].items[0]).toBeTag('comment', 'Some {comment}');
+  });
+
   it('parses meta data', () => {
     const chordSheet = `
 {title: Let it be}


### PR DESCRIPTION
Allow curly braces in directive value

A directive is allowed to contain unescaped opening curly braces and escaped closing curly braces.

Example:

    {comment: Some {comment\} value}

Resolves #196