### PR TITLE
Allow unescaped pipe char outside meta expression

### DIFF
--- a/src/parser/chord_pro_grammar.pegjs
+++ b/src/parser/chord_pro_grammar.pegjs
@@ -99,6 +99,7 @@ MetaExpression
 LyricsChar
   = Char
   / "]" { return {type: "char", char: "]"}; }
+  / "|" { return {type: "char", char: "|"}; }
   / "}" { return {type: "char", char: "\x7d"}; }
 
 Char

--- a/test/parser/chord_pro_parser.test.js
+++ b/test/parser/chord_pro_parser.test.js
@@ -240,6 +240,13 @@ Let it [F]be [C]
     expect(expression.falseExpression[0]).toBeLiteral('title is unset');
   });
 
+  it('Allows unescaped pipe characters outside of meta expressions', () => {
+    const chordSheet = '|: Let it be :|';
+    const song = new ChordProParser().parse(chordSheet);
+
+    expect(song.lines[0].items[0]).toBeChordLyricsPair('', '|: Let it be :|');
+  });
+
   describe('it is forgiving to syntax errors', () => {
     it('allows dangling ]', () => {
       const chordSheetWithError = `


### PR DESCRIPTION
This allows lyrics/instructions like:

    |: Let it be :|

Resolves #297