### PR TITLE
Implement `_key` metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "pretest": "yarn build:templates && yarn build:pegjs"
   },
   "dependencies": {
+    "chordjs": "^1.1.1",
     "handlebars": "^4.7.6"
   }
 }

--- a/src/chord_sheet/tag.js
+++ b/src/chord_sheet/tag.js
@@ -59,6 +59,12 @@ export const END_OF_VERSE = 'end_of_verse';
 export const KEY = 'key';
 
 /**
+ * Key meta directive. See https://www.chordpro.org/chordpro/directives-key/
+ * @type {string}
+ */
+export const _KEY = '_key';
+
+/**
  * Lyricist meta directive. See https://www.chordpro.org/chordpro/directives-lyricist/
  * @type {string}
  */
@@ -130,6 +136,8 @@ export const META_TAGS = [
   YEAR,
 ];
 
+export const READ_ONLY_TAGS = [_KEY];
+
 const ALIASES = {
   [TITLE_SHORT]: TITLE,
   [SUBTITLE_SHORT]: SUBTITLE,
@@ -141,6 +149,10 @@ const ALIASES = {
 const META_TAG_REGEX = /^meta:\s*([^:\s]+)(\s*(.+))?$/;
 const TAG_REGEX = /^([^:\s]+)(:?\s*(.+))?$/;
 const CUSTOM_META_TAG_NAME_REGEX = /^x_(.+)$/;
+
+export function isReadonlyTag(tagName) {
+  return READ_ONLY_TAGS.includes(tagName);
+}
 
 const translateTagNameAlias = (name) => {
   if (!name) {

--- a/test/chord_sheet/metadata.test.js
+++ b/test/chord_sheet/metadata.test.js
@@ -74,5 +74,30 @@ describe('Metadata', () => {
         expect(metadata.get('author.5')).toBeUndefined();
       });
     });
+
+    describe('_key', () => {
+      it('is calculated when when key and capo are defined', () => {
+        const metadata = new Metadata({ key: 'Bb', capo: '2' });
+        expect(metadata.get('_key')).toEqual('C');
+      });
+
+      it('returns undefined when when key or capo is undefined', () => {
+        const metadata = new Metadata({ key: 'Bb' });
+        expect(metadata.get('_key')).toBe(undefined);
+      });
+
+      it('is readonly on initialisation', () => {
+        const metadata = new Metadata({ _key: 'E' });
+        expect(metadata.get('_key')).toBe(undefined);
+      });
+
+      it('is readonly', () => {
+        const emptyMetadata = new Metadata();
+        const metadata = new Metadata();
+        metadata.add('_key', 'G');
+        expect(metadata.get('_key')).toBe(undefined);
+        expect(metadata).toEqual(emptyMetadata);
+      });
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1877,6 +1877,11 @@ chokidar@^3.4.0:
   optionalDependencies:
     fsevents "~2.1.2"
 
+chordjs@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/chordjs/-/chordjs-1.1.1.tgz#4daf47f5f0a42de968600a8c9e091a9156cfd814"
+  integrity sha512-jWGJ8Vs2HZn1nJKGnlxpQ8vRjOo/b6EVWo5sxYlVVEZSzO+tr8IvpiUf2tEiXqNUwRugXC8Vr2HDLCV3xzjQTA==
+
 ci-info@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.1.1.tgz#9a32fcefdf7bcdb6f0a7e1c0f8098ec57897b80a"


### PR DESCRIPTION
When `key` and `capo` are present, `_key` will contain the value of
`key`, transposed by the `capo` value.

For example, when `key` is B♭ and capo is 2, `_key` will be `'C'`.

Resolves #312