### PR TITLE
Fix deprecation warning from chordjs

### DIFF
--- a/src/chord_sheet/metadata.js
+++ b/src/chord_sheet/metadata.js
@@ -1,4 +1,4 @@
-import Chord from 'chordjs';
+import { parse } from 'chordjs';
 
 import {
   _KEY,
@@ -140,7 +140,7 @@ class Metadata {
     const key = this.get(KEY);
 
     if (capo && key) {
-      return Chord.parse(key).transpose(parseInt(capo, 10)).toString();
+      return parse(key).transpose(parseInt(capo, 10)).toString();
     }
 
     return undefined;


### PR DESCRIPTION
Fixes this deprecation warning:

```
Error: DEPRECATION: Chord.parse is deprecated, please use: import { parse } from 'chordjs'; const chord = parse('Esus');
```