### PR TITLE
Do not rely on contructor name

### DIFF
--- a/src/formatter/html_div_formatter.js
+++ b/src/formatter/html_div_formatter.js
@@ -1,6 +1,6 @@
 import Handlebars from 'handlebars';
 
-import '../handlebars_helpers';
+import '../template_helpers';
 import HtmlFormatter from './html_formatter';
 import './templates/html_div_formatter';
 import { scopeCss } from '../utilities';

--- a/src/formatter/html_table_formatter.js
+++ b/src/formatter/html_table_formatter.js
@@ -1,6 +1,6 @@
 import Handlebars from 'handlebars';
 
-import '../handlebars_helpers';
+import '../template_helpers';
 import HtmlFormatter from './html_formatter';
 import './templates/html_table_formatter';
 import { scopeCss } from '../utilities';

--- a/src/formatter/text_formatter.js
+++ b/src/formatter/text_formatter.js
@@ -1,10 +1,10 @@
 import ChordLyricsPair from '../chord_sheet/chord_lyrics_pair';
 import Tag from '../chord_sheet/tag';
 import { renderChord } from '../helpers';
+import { hasTextContents } from '../template_helpers';
 
 import {
   hasChordContents,
-  hasTextContents,
   padLeft,
 } from '../utilities';
 

--- a/src/template_helpers.js
+++ b/src/template_helpers.js
@@ -7,11 +7,19 @@ import { renderChord } from './helpers';
 
 import {
   hasChordContents,
-  hasTextContents,
   isEvaluatable,
 } from './utilities';
 
 const lineHasContents = (line) => line.items.some((item) => item.isRenderable());
+
+/* eslint import/prefer-default-export: 0 */
+export const hasTextContents = (line) => (
+  line.items.some((item) => (
+    (item instanceof ChordLyricsPair && item.lyrics)
+    || (item instanceof Tag && item.isRenderable())
+    || isEvaluatable(item)
+  ))
+);
 
 HandleBars.registerHelper('isChordLyricsPair', (item) => item instanceof ChordLyricsPair);
 

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -8,18 +8,6 @@ export const hasChordContents = (line) => line.items.some((item) => !!item.chord
 
 export const isEvaluatable = (item) => typeof item.evaluate === 'function';
 
-function isInstanceOf(object, constructorName) {
-  return object?.constructor?.name === constructorName;
-}
-
-export const hasTextContents = (line) => (
-  line.items.some((item) => (
-    (isInstanceOf(item, 'ChordLyricsPair') && item.lyrics)
-      || (isInstanceOf(item, 'Tag') && item.isRenderable())
-      || isEvaluatable(item)
-  ))
-);
-
 export const padLeft = (str, length) => {
   let paddedString = str;
   for (let l = str.length; l < length; l += 1, paddedString += ' ');


### PR DESCRIPTION
Due to build tools scrambling constructor names, we can not rely on those
for type checking. Thus we have to use `instanceof`. This change removes
usages of `constructor.name` and solves the cyclic dependency by moving around
some functions.

Resolves #421