### PR TITLE
Allow directive with empty value and trailing space

### DIFF
--- a/src/parser/chord_pro_grammar.pegjs
+++ b/src/parser/chord_pro_grammar.pegjs
@@ -12,7 +12,7 @@ LineWithNewline
 }
 
 Line
-  = lyrics:Lyrics? tokens:Token* chords:Chord? comment:Comment? {
+  = lyrics:Lyrics? tokens:Token* chords:Chord? comment:Comment? Space* {
   return {
     type: "line",
     items: [

--- a/src/parser/chord_pro_grammar.pegjs
+++ b/src/parser/chord_pro_grammar.pegjs
@@ -136,7 +136,7 @@ TagName
   = [a-zA-Z-_]+
 
 TagValue
-  = TagValueChar+
+  = TagValueChar*
 
 TagValueChar
   = [^}\\\r\n]

--- a/test/parser/chord_pro_parser.test.js
+++ b/test/parser/chord_pro_parser.test.js
@@ -66,6 +66,11 @@ Let it [Am]be, let it [C/A][C/G#]be, let it [F]be, let it [C]be
     expect(song.lines[0].items[0]).toBeTag('comment', 'Some {comment}');
   });
 
+  it('parses directive with empty value', () => {
+    const song = new ChordProParser().parse('{c: }');
+    expect(song.lines[0].items[0]).toBeTag('comment', null);
+  });
+
   it('parses meta data', () => {
     const chordSheet = `
 {title: Let it be}

--- a/test/parser/chord_pro_parser.test.js
+++ b/test/parser/chord_pro_parser.test.js
@@ -71,6 +71,11 @@ Let it [Am]be, let it [C/A][C/G#]be, let it [F]be, let it [C]be
     expect(song.lines[0].items[0]).toBeTag('comment', null);
   });
 
+  it('parses directive with trailing space', () => {
+    const song = new ChordProParser().parse('{key: C}   ');
+    expect(song.lines[0].items[0]).toBeTag('key', 'C');
+  });
+
   it('parses meta data', () => {
     const chordSheet = `
 {title: Let it be}


### PR DESCRIPTION
Prior to to this change, the parser raises an error on directive with empty value (e.g. `{c: }`) or directive with trailing space (e.g. `{key: C}  `. I know it doesn't really make sense to have a directive with a colon and empty value, but I found this often while trying to parse ~4000 chordpro files found in the wild.

```
  ● ChordProParser › parses directive with empty value

    SyntaxError: Expected "\\" or [^}\\\r\n] but "}" found.

      390 |
      391 |   function peg$buildStructuredError(expected, found, location) {
    > 392 |     return new peg$SyntaxError(
          |            ^
      393 |       peg$SyntaxError.buildMessage(expected, found),
      394 |       expected,
      395 |       found,

      at peg$buildStructuredError (src/parser/chord_pro_peg_parser.js:392:12)
      at Object.parse (src/parser/chord_pro_peg_parser.js:1684:11)
      at ChordProParser.parse (src/parser/chord_pro_parser.js:19:35)
      at Object.<anonymous> (test/parser/chord_pro_parser.test.js:70:39)

  ● ChordProParser › parses directive with trailing space

    SyntaxError: Expected "#" but end of input found.

      390 |
      391 |   function peg$buildStructuredError(expected, found, location) {
    > 392 |     return new peg$SyntaxError(
          |            ^
      393 |       peg$SyntaxError.buildMessage(expected, found),
      394 |       expected,
      395 |       found,

      at peg$buildStructuredError (src/parser/chord_pro_peg_parser.js:392:12)
      at Object.parse (src/parser/chord_pro_peg_parser.js:1684:11)
      at ChordProParser.parse (src/parser/chord_pro_parser.js:19:35)
      at Object.<anonymous> (test/parser/chord_pro_parser.test.js:75:39)
```

Fixes #450
Fixes #451
