### PR TITLE
Implement Song#setCapo and Song#setKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ChordSheetJS [![Build Status](https://travis-ci.org/martijnversluis/ChordSheetJS.svg?branch=master)](https://travis-ci.org/martijnversluis/ChordSheetJS) [![npm version](https://badge.fury.io/js/chordsheetjs.svg)](https://badge.fury.io/js/chordsheetjs) [![Code Climate](https://codeclimate.com/github/martijnversluis/ChordSheetJS/badges/gpa.svg)](https://codeclimate.com/github/martijnversluis/ChordSheetJS)
+# ChordChartJS [![Code Climate](https://codeclimate.com/github/PraiseCharts/ChordChartJS/badges/gpa.svg)](https://codeclimate.com/github/PraiseCharts/ChordChartJS)
 
 A JavaScript library for parsing and formatting chord sheets
 
@@ -756,6 +756,8 @@ Represents a song in a chord sheet. Currently a chord sheet can only have one so
     * [.bodyParagraphs](#Song+bodyParagraphs) ⇒ [<code>Array.&lt;Paragraph&gt;</code>](#Paragraph)
     * ~~[.metaData](#Song+metaData) ⇒~~
     * [.clone()](#Song+clone) ⇒ [<code>Song</code>](#Song)
+    * [.setCapo(capo)](#Song+setCapo) ⇒ [<code>Song</code>](#Song)
+    * [.setKey(key)](#Song+setKey) ⇒ [<code>Song</code>](#Song)
 
 <a name="new_Song_new"></a>
 
@@ -818,6 +820,35 @@ Returns a deep clone of the song
 
 **Kind**: instance method of [<code>Song</code>](#Song)  
 **Returns**: [<code>Song</code>](#Song) - The cloned song  
+<a name="Song+setCapo"></a>
+
+### song.setCapo(capo) ⇒ [<code>Song</code>](#Song)
+Returns a copy of the song with the capo value set to the specified capo. It changes:
+- the value for `capo` in the `metadata` set
+- any existing `capo` directive)
+
+**Kind**: instance method of [<code>Song</code>](#Song)  
+**Returns**: [<code>Song</code>](#Song) - The changed song  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| capo | <code>number</code> \| <code>null</code> | the capo. Passing `null` will: - remove the current key from `metadata` - remove any `capo` directive |
+
+<a name="Song+setKey"></a>
+
+### song.setKey(key) ⇒ [<code>Song</code>](#Song)
+Returns a copy of the song with the key set to the specified key. It changes:
+- the value for `key` in the `metadata` set
+- any existing `key` directive
+- all chords, those are transposed according to the distance between the current and the new key
+
+**Kind**: instance method of [<code>Song</code>](#Song)  
+**Returns**: [<code>Song</code>](#Song) - The changed song  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| key | <code>string</code> | The new key. |
+
 <a name="Tag"></a>
 
 ## Tag

--- a/doc/README.hbs
+++ b/doc/README.hbs
@@ -1,4 +1,4 @@
-# ChordSheetJS [![Build Status](https://travis-ci.org/martijnversluis/ChordSheetJS.svg?branch=master)](https://travis-ci.org/martijnversluis/ChordSheetJS) [![npm version](https://badge.fury.io/js/chordsheetjs.svg)](https://badge.fury.io/js/chordsheetjs) [![Code Climate](https://codeclimate.com/github/martijnversluis/ChordSheetJS/badges/gpa.svg)](https://codeclimate.com/github/martijnversluis/ChordSheetJS)
+# ChordChartJS [![Code Climate](https://codeclimate.com/github/PraiseCharts/ChordChartJS/badges/gpa.svg)](https://codeclimate.com/github/PraiseCharts/ChordChartJS)
 
 A JavaScript library for parsing and formatting chord sheets
 

--- a/src/chord_sheet/chord_lyrics_pair.js
+++ b/src/chord_sheet/chord_lyrics_pair.js
@@ -42,6 +42,13 @@ class ChordLyricsPair {
   toString() {
     return `ChordLyricsPair(chords=${this.chords}, lyrics=${this.lyrics})`;
   }
+
+  set(properties) {
+    return new this.constructor(
+      properties.chords || this.chords,
+      properties.lyrics || this.lyrics,
+    );
+  }
 }
 
 export default ChordLyricsPair;

--- a/src/chord_sheet/line.js
+++ b/src/chord_sheet/line.js
@@ -63,8 +63,19 @@ class Line {
    * @returns {Line}
    */
   clone() {
+    return this.mapItems(null);
+  }
+
+  mapItems(func) {
     const clonedLine = new Line();
-    clonedLine.items = this.items.map((item) => item.clone());
+
+    clonedLine.items = this.items
+      .map((item) => {
+        const clonedItem = item.clone();
+        return func ? func(clonedItem) : clonedItem;
+      })
+      .filter((item) => item);
+
     clonedLine.type = this.type;
     return clonedLine;
   }
@@ -131,6 +142,16 @@ class Line {
     const comment = (content instanceof Comment) ? content : new Comment(content);
     this.items.push(comment);
     return comment;
+  }
+
+  set(properties) {
+    return new this.constructor(
+      {
+        type: this.type,
+        items: this.items,
+        ...properties,
+      },
+    );
   }
 }
 

--- a/src/chord_sheet/metadata.js
+++ b/src/chord_sheet/metadata.js
@@ -37,6 +37,10 @@ class Metadata {
       });
   }
 
+  contains(key) {
+    return key in this;
+  }
+
   add(key, value) {
     if (isReadonlyTag(key)) {
       return;
@@ -59,6 +63,14 @@ class Metadata {
     }
 
     this[key] = [currentValue, value];
+  }
+
+  set(key, value) {
+    if (value) {
+      this[key] = value;
+    } else {
+      delete this[key];
+    }
   }
 
   /**

--- a/src/chord_sheet/song.js
+++ b/src/chord_sheet/song.js
@@ -1,5 +1,8 @@
 import Line from './line';
 import Paragraph from './paragraph';
+import Key from '../key';
+import Chord from '../chord';
+import ChordLyricsPair from './chord_lyrics_pair';
 import { deprecate, pushNew } from '../utilities';
 import Metadata from './metadata';
 import ParserWarning from '../parser/parser_warning';
@@ -9,7 +12,17 @@ import {
 } from '../constants';
 
 import Tag, {
-  END_OF_CHORUS, END_OF_TAB, END_OF_VERSE, META_TAGS, START_OF_CHORUS, START_OF_TAB, START_OF_VERSE, TRANSPOSE,
+  END_OF_CHORUS,
+  END_OF_TAB,
+  END_OF_VERSE,
+  META_TAGS,
+  START_OF_CHORUS,
+  START_OF_TAB,
+  START_OF_VERSE,
+  TRANSPOSE,
+  NEW_KEY,
+  CAPO,
+  KEY,
 } from './tag';
 
 /**
@@ -23,15 +36,13 @@ class Song {
   constructor(metadata = {}) {
     /**
      * The {@link Line} items of which the song consists
-     * @member
-     * @type {Array<Line>}
+     * @member {Array<Line>}
      */
     this.lines = [];
 
     /**
      * The {@link Paragraph} items of which the song consists
-     * @member
-     * @type {Paragraph[]}
+     * @member {Paragraph[]}
      */
     this.paragraphs = [];
 
@@ -47,6 +58,7 @@ class Song {
     this.warnings = [];
     this.sectionType = NONE;
     this.currentKey = null;
+    this.transposeKey = null;
   }
 
   get previousLine() {
@@ -105,7 +117,8 @@ class Song {
     this.flushLine();
     this.currentLine = pushNew(this.lines, Line);
     this.setCurrentLineType(this.sectionType);
-    this.currentLine.key = this.currentKey;
+    this.currentLine.transposeKey = this.transposeKey ?? this.currentKey;
+    this.currentLine.key = this.currentKey || this.key;
     return this.currentLine;
   }
 
@@ -155,6 +168,8 @@ class Song {
     if (tag.isMetaTag()) {
       this.setMetaData(tag.name, tag.value);
     } else if (tag.name === TRANSPOSE) {
+      this.transposeKey = tag.value;
+    } else if (tag.name === NEW_KEY) {
       this.currentKey = tag.value;
     } else {
       this.setSectionTypeFromTag(tag);
@@ -238,10 +253,7 @@ class Song {
    * @returns {Song} The cloned song
    */
   clone() {
-    const clonedSong = new Song();
-    clonedSong.lines = this.lines.map((line) => line.clone());
-    clonedSong.metadata = this.metadata.clone();
-    return clonedSong;
+    return this.#mapItems(null);
   }
 
   setMetaData(name, value) {
@@ -260,6 +272,134 @@ class Song {
 
   getMetaData(name) {
     return this.metadata[name] || null;
+  }
+
+  /**
+   * Returns a copy of the song with the capo value set to the specified capo. It changes:
+   * - the value for `capo` in the `metadata` set
+   * - any existing `capo` directive)
+   * @param {number|null} capo the capo. Passing `null` will:
+   * - remove the current key from `metadata`
+   * - remove any `capo` directive
+   * @returns {Song} The changed song
+   */
+  setCapo(capo) {
+    let updatedSong;
+
+    if (capo === null) {
+      updatedSong = this.#removeItem((item) => item instanceof Tag && item.name === CAPO);
+    } else {
+      updatedSong = this.#updateItem(
+        (item) => item instanceof Tag && item.name === CAPO,
+        (item) => item.set({ value: capo }),
+        (song) => song.#insertDirective(CAPO, capo),
+      );
+    }
+
+    updatedSong.metadata.set('capo', capo);
+    return updatedSong;
+  }
+
+  /**
+   * Returns a copy of the song with the key set to the specified key. It changes:
+   * - the value for `key` in the `metadata` set
+   * - any existing `key` directive
+   * - all chords, those are transposed according to the distance between the current and the new key
+   * @param {string} key The new key.
+   * @returns {Song} The changed song
+   */
+  setKey(key) {
+    const transpose = Key.distance(this.key, key);
+
+    const updatedSong = this.#mapItems((item) => {
+      if (item instanceof Tag && item.name === KEY) {
+        return item.set({ value: key });
+      }
+
+      if (item instanceof ChordLyricsPair) {
+        const chordObj = Chord.parse(item.chords);
+
+        if (chordObj) {
+          return item.set({ chords: chordObj.transpose(transpose).normalize(key) });
+        }
+      }
+
+      return item;
+    });
+
+    updatedSong.metadata.set('key', key);
+    return updatedSong;
+  }
+
+  #insertDirective(name, value, { after = null } = {}) {
+    const insertIndex = this.lines.findIndex((line) => (
+      line.items.some((item) => (
+        !(item instanceof Tag) || (after && item instanceof Tag && item.name === after)
+      ))
+    ));
+
+    const newLine = new Line();
+    newLine.addTag(name, value);
+
+    const clonedSong = this.clone();
+    const { lines } = clonedSong;
+    clonedSong.lines = [...lines.slice(0, insertIndex), newLine, ...lines.slice(insertIndex)];
+
+    return clonedSong;
+  }
+
+  #mapItems(func) {
+    const clonedSong = new Song();
+    clonedSong.lines = this.lines.map((line) => line.mapItems(func));
+    clonedSong.metadata = this.metadata.clone();
+    return clonedSong;
+  }
+
+  #mapLines(func) {
+    const clonedSong = new Song();
+    clonedSong.lines = this.lines
+      .map((line) => func(line.clone()))
+      .filter((line) => line);
+    clonedSong.metadata = this.metadata.clone();
+    return clonedSong;
+  }
+
+  #updateItem(findCallback, updateCallback, notFoundCallback) {
+    let found = false;
+
+    const updatedSong = this.#mapItems((item) => {
+      if (findCallback(item)) {
+        found = true;
+        return updateCallback(item);
+      }
+
+      return item;
+    });
+
+    if (!found) {
+      return notFoundCallback(updatedSong);
+    }
+
+    return updatedSong;
+  }
+
+  #removeItem(callback) {
+    return this.#mapLines((line) => {
+      const { items } = line;
+      const index = items.findIndex(callback);
+
+      if (index === -1) {
+        return line;
+      }
+
+      if (items.length === 1) {
+        return null;
+      }
+
+      return line.set({
+        items: [...items.slice(0, index), ...items.slice(index + 1)],
+      });
+    });
   }
 }
 

--- a/src/chord_sheet/tag.js
+++ b/src/chord_sheet/tag.js
@@ -123,6 +123,11 @@ export const TITLE = 'title';
  * @type {string}
  */
 export const TRANSPOSE = 'transpose';
+/**
+ * New Key meta directive. See: https://github.com/PraiseCharts/ChordChartJS/issues/53
+ * @type {string}
+ */
+export const NEW_KEY = 'new_key';
 
 /**
  * Year meta directive. See https://www.chordpro.org/chordpro/directives-year/
@@ -137,6 +142,7 @@ const START_OF_CHORUS_SHORT = 'soc';
 const END_OF_CHORUS_SHORT = 'eoc';
 const START_OF_TAB_SHORT = 'sot';
 const END_OF_TAB_SHORT = 'eot';
+const NEW_KEY_SHORT = 'nk';
 
 const RENDERABLE_TAGS = [COMMENT];
 
@@ -166,6 +172,7 @@ const ALIASES = {
   [END_OF_CHORUS_SHORT]: END_OF_CHORUS,
   [START_OF_TAB_SHORT]: START_OF_TAB,
   [END_OF_TAB_SHORT]: END_OF_TAB,
+  [NEW_KEY_SHORT]: NEW_KEY,
 };
 
 const META_TAG_REGEX = /^meta:\s*([^:\s]+)(\s*(.+))?$/;
@@ -254,7 +261,7 @@ class Tag {
    */
   get value() {
     if (this._value) {
-      return this._value.trim();
+      return `${this._value}`.trim();
     }
 
     return this._value || null;
@@ -289,11 +296,15 @@ class Tag {
    * @returns {Tag} The cloned tag
    */
   clone() {
-    return new Tag(this.name, this.value);
+    return new Tag(this._originalName, this.value);
   }
 
   toString() {
     return `Tag(name=${this.name}, value=${this.name})`;
+  }
+
+  set({ value }) {
+    return new Tag(this._originalName, value);
   }
 }
 

--- a/src/formatter/templates/html_div_formatter.handlebars
+++ b/src/formatter/templates/html_div_formatter.handlebars
@@ -15,7 +15,7 @@
             <div class="{{lineClasses line}}">
               {{~#each items as |item|~}}
                 {{~#if (isChordLyricsPair item)~}}
-                  <div class="column"><div class="chord">{{renderChord chords line.key @root.song.key}}</div><div class="lyrics">{{lyrics}}</div></div>
+                  <div class="column"><div class="chord">{{renderChord chords line.key line.transposeKey @root.song}}</div><div class="lyrics">{{lyrics}}</div></div>
                 {{~/if~}}
 
                 {{~#if (isTag item)~}}

--- a/src/formatter/templates/html_table_formatter.handlebars
+++ b/src/formatter/templates/html_table_formatter.handlebars
@@ -18,7 +18,7 @@
                   <tr>
                     {{~#each items as |item|~}}
                       {{~#if (isChordLyricsPair item)~}}
-                        <td class="chord">{{renderChord chords line.key @root.song.key}}</td>
+                        <td class="chord">{{renderChord chords line.key line.transposeKey @root.song}}</td>
                       {{~/if~}}
                     {{~/each~}}
                   </tr>

--- a/src/formatter/text_formatter.js
+++ b/src/formatter/text_formatter.js
@@ -89,7 +89,7 @@ class TextFormatter {
   }
 
   chordLyricsPairLength(chordLyricsPair, line) {
-    const chords = renderChord(chordLyricsPair.chords, line.key, this.song.key);
+    const chords = renderChord(chordLyricsPair.chords, line.key, line.transposeKey, this.song);
     const { lyrics } = chordLyricsPair;
     const chordsLength = (chords || '').length;
     const lyricsLength = (lyrics || '').length;
@@ -107,7 +107,7 @@ class TextFormatter {
     }
 
     if (item instanceof ChordLyricsPair) {
-      const chords = renderChord(item.chords, line.key, this.song.key);
+      const chords = renderChord(item.chords, line.key, line.transposeKey, this.song);
       return padLeft(chords, this.chordLyricsPairLength(item, line));
     }
 

--- a/test/integration/changing_capo.test.js
+++ b/test/integration/changing_capo.test.js
@@ -1,0 +1,64 @@
+import { ChordProFormatter, ChordProParser } from '../../src';
+
+describe('changing the capo of an existing song', () => {
+  it('updates the capo directive', () => {
+    const chordpro = `
+{capo: 7}
+Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be`.substring(1);
+
+    const changedSheet = `
+{capo: 3}
+Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be`.substring(1);
+
+    const song = new ChordProParser().parse(chordpro);
+    const updatedSong = song.setCapo(3);
+
+    expect(new ChordProFormatter().format(updatedSong)).toEqual(changedSheet);
+  });
+
+  it('adds the capo directive', () => {
+    const chordpro = `
+Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be`.substring(1);
+
+    const changedSheet = `
+{capo: 3}
+Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be`.substring(1);
+
+    const song = new ChordProParser().parse(chordpro);
+    const updatedSong = song.setCapo(3);
+
+    expect(new ChordProFormatter().format(updatedSong)).toEqual(changedSheet);
+  });
+
+  it('adds the capo directive after the key directive', () => {
+    const chordpro = `
+{key: C}
+Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be`.substring(1);
+
+    const changedSheet = `
+{key: C}
+{capo: 3}
+Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be`.substring(1);
+
+    const song = new ChordProParser().parse(chordpro);
+    const updatedSong = song.setCapo(3);
+
+    expect(new ChordProFormatter().format(updatedSong)).toEqual(changedSheet);
+  });
+
+  it('removes the capo directive', () => {
+    const chordpro = `
+{key: C}
+{capo: 3}
+Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be`.substring(1);
+
+    const changedSheet = `
+{key: C}
+Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be`.substring(1);
+
+    const song = new ChordProParser().parse(chordpro);
+    const updatedSong = song.setCapo(null);
+
+    expect(new ChordProFormatter().format(updatedSong)).toEqual(changedSheet);
+  });
+});

--- a/test/integration/changing_key.test.js
+++ b/test/integration/changing_key.test.js
@@ -1,0 +1,18 @@
+import { ChordProFormatter, ChordProParser } from '../../src';
+
+describe('changing the key of an existing song', () => {
+  it('updates the key directive', () => {
+    const chordpro = `
+{key: C}
+Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be`.substring(1);
+
+    const changedSheet = `
+{key: D}
+Let it [Bm]be, let it [D/A]be, let it [G]be, let it [D]be`.substring(1);
+
+    const song = new ChordProParser().parse(chordpro);
+    const updatedSong = song.setKey('D');
+
+    expect(new ChordProFormatter().format(updatedSong)).toEqual(changedSheet);
+  });
+});

--- a/test/parser/chord_pro_parser.test.js
+++ b/test/parser/chord_pro_parser.test.js
@@ -174,7 +174,7 @@ Let it [F]be [C]
     expect(parser.warnings).toHaveLength(0);
   });
 
-  it('adds the key to lines', () => {
+  it('adds the transposeKey to lines', () => {
     const chordSheetWithTranspose = `
 {key: A}
 
@@ -189,11 +189,60 @@ This part is [D]key
 
     const parser = new ChordProParser();
     const song = parser.parse(chordSheetWithTranspose);
-    const keys = song.bodyParagraphs.map((paragraph) => paragraph.lines[0].key);
+    const keys = song.bodyParagraphs.map((paragraph) => paragraph.lines[0].transposeKey);
 
     expect(keys[0]).toBe(null);
     expect(keys[1]).toEqual('4');
     expect(keys[2]).toEqual('D');
+  });
+
+  it('adds the key to lines', () => {
+    const chordSheetWithTranspose = `
+{key: A}
+
+This part is [A]key
+
+{new_key: D}
+This part is [D]key
+
+{nk: G}
+This part is [G]key
+`.trim();
+
+    const parser = new ChordProParser();
+    const song = parser.parse(chordSheetWithTranspose);
+    const keys = song.bodyParagraphs.map((paragraph) => paragraph.lines[0].key);
+
+    expect(keys[0]).toBe('A');
+    expect(keys[1]).toEqual('D');
+    expect(keys[2]).toEqual('G');
+  });
+
+  it('adds the key & transposeKey to the same to lines', () => {
+    const chordSheetWithTranspose = `
+{key: A}
+
+This part is [A]key
+
+{transpose: 4}
+{new_key: D}
+This part is [D]key
+
+{transpose: D}
+{nk: G}
+This part is [G]key
+`.trim();
+
+    const parser = new ChordProParser();
+    const song = parser.parse(chordSheetWithTranspose);
+    const keys = song.bodyParagraphs.map((paragraph) => paragraph.lines[0].key);
+    const transposeKeys = song.bodyParagraphs.map((paragraph) => paragraph.lines[0].transposeKey);
+
+    expect(keys[0]).toBe('A');
+    expect(transposeKeys[1]).toEqual('4');
+    expect(keys[1]).toEqual('D');
+    expect(transposeKeys[2]).toEqual('D');
+    expect(keys[2]).toEqual('G');
   });
 
   it('allows escaped special characters in tags', () => {


### PR DESCRIPTION
`setCapo` changes the song capo, both in `metadata` and the `capo` directive.
`setKey` changes the song key in `metadata` and the `key` directive, and transposes all chords according to the distance between the current key and the new key.

Co-authored-by: isaiah dahl <isaiahdahl@me.com>