### PR TITLE
Ensure song integrity on changing lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,10 +631,13 @@ If not, it returns [INDETERMINATE](#INDETERMINATE)</p>
     * [new Song(metadata)](#new_Song_new)
     * [.bodyLines](#Song+bodyLines) ⇒ <code>Array.&lt;Line&gt;</code>
     * [.bodyParagraphs](#Song+bodyParagraphs) ⇒ [<code>Array.&lt;Paragraph&gt;</code>](#Paragraph)
+    * [.paragraphs](#Song+paragraphs) : [<code>Array.&lt;Paragraph&gt;</code>](#Paragraph)
     * ~~[.metaData](#Song+metaData) ⇒~~
     * [.clone()](#Song+clone) ⇒ [<code>Song</code>](#Song)
     * [.setCapo(capo)](#Song+setCapo) ⇒ [<code>Song</code>](#Song)
     * [.setKey(key)](#Song+setKey) ⇒ [<code>Song</code>](#Song)
+    * [.mapItems(func)](#Song+mapItems) ⇒ [<code>Song</code>](#Song)
+    * [.mapLines(func)](#Song+mapLines) ⇒ [<code>Song</code>](#Song)
 
 <a name="new_Song_new"></a>
 
@@ -662,6 +665,12 @@ if you want to skip the &quot;header lines&quot;: the lines that only contain me
 
 **Kind**: instance property of [<code>Song</code>](#Song)  
 **See**: [bodyLines](bodyLines)  
+<a name="Song+paragraphs"></a>
+
+### song.paragraphs : [<code>Array.&lt;Paragraph&gt;</code>](#Paragraph)
+<p>The [Paragraph](#Paragraph) items of which the song consists</p>
+
+**Kind**: instance property of [<code>Song</code>](#Song)  
 <a name="Song+metaData"></a>
 
 ### ~~song.metaData ⇒~~
@@ -711,6 +720,52 @@ if you want to skip the &quot;header lines&quot;: the lines that only contain me
 | --- | --- | --- |
 | key | <code>string</code> | <p>The new key.</p> |
 
+<a name="Song+mapItems"></a>
+
+### song.mapItems(func) ⇒ [<code>Song</code>](#Song)
+<p>Change the song contents inline. Return a new [Item](Item) to replace it. Return <code>null</code> to remove it.</p>
+
+**Kind**: instance method of [<code>Song</code>](#Song)  
+**Returns**: [<code>Song</code>](#Song) - <p>the changed song</p>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| func | <code>MapItemsCallback</code> | <p>the callback function</p> |
+
+**Example**  
+```js
+// transpose all chords:
+song.mapItems((item) => {
+  if (item instanceof ChordLyricsPair) {
+    return item.transpose(2, 'D');
+  }
+
+  return item;
+});
+```
+<a name="Song+mapLines"></a>
+
+### song.mapLines(func) ⇒ [<code>Song</code>](#Song)
+<p>Change the song contents inline. Return a new [Line](Line) to replace it. Return <code>null</code> to remove it.</p>
+
+**Kind**: instance method of [<code>Song</code>](#Song)  
+**Returns**: [<code>Song</code>](#Song) - <p>the changed song</p>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| func | <code>MapLinesCallback</code> | <p>the callback function</p> |
+
+**Example**  
+```js
+// remove lines with only Tags:
+song.mapLines((line) => {
+  if (line.items.every(item => item instanceof Tag)) {
+    return null;
+  }
+
+  return line;
+});
+```
 <a name="Tag"></a>
 
 ## Tag

--- a/src/chord_sheet/chord_lyrics_pair.ts
+++ b/src/chord_sheet/chord_lyrics_pair.ts
@@ -57,6 +57,10 @@ class ChordLyricsPair {
     );
   }
 
+  setLyrics(lyrics: string) {
+    return this.set({ lyrics });
+  }
+
   transpose(delta: number, key: string | Key) {
     const chordObj = Chord.parse(this.chords);
 

--- a/src/chord_sheet/item.ts
+++ b/src/chord_sheet/item.ts
@@ -1,0 +1,8 @@
+import ChordLyricsPair from './chord_lyrics_pair';
+import Comment from './comment';
+import Tag from './tag';
+import Ternary from './chord_pro/ternary';
+
+type Item = ChordLyricsPair | Comment | Tag | Ternary;
+
+export default Item;

--- a/src/chord_sheet/line.ts
+++ b/src/chord_sheet/line.ts
@@ -2,9 +2,8 @@ import ChordLyricsPair from './chord_lyrics_pair';
 import Tag from './tag';
 import Comment from './comment';
 import { CHORUS, NONE, VERSE } from '../constants';
-import Ternary from './chord_pro/ternary';
+import Item from './item';
 
-type Item = ChordLyricsPair | Comment | Tag | Ternary;
 export type LineType = 'verse' | 'chorus' | 'none';
 
 /**

--- a/src/chord_sheet/tag.ts
+++ b/src/chord_sheet/tag.ts
@@ -313,6 +313,10 @@ class Tag extends AstComponent {
   set({ value }) {
     return new Tag(this._originalName, value);
   }
+
+  setValue(value: string) {
+    return this.set({ value });
+  }
 }
 
 export default Tag;

--- a/src/chord_sheet_serializer.ts
+++ b/src/chord_sheet_serializer.ts
@@ -99,7 +99,6 @@ class ChordSheetSerializer {
    */
   deserialize(serializedSong) {
     this.parseAstComponent(serializedSong);
-    this.song.finish();
     return this.song;
   }
 

--- a/src/parser/chord_sheet_parser.ts
+++ b/src/parser/chord_sheet_parser.ts
@@ -50,7 +50,6 @@ class ChordSheetParser {
     }
 
     this.endOfSong();
-    this.song.finish();
     return this.song;
   }
 

--- a/test/chord_sheet/song.test.ts
+++ b/test/chord_sheet/song.test.ts
@@ -1,11 +1,12 @@
 import {
   Song,
-  ChordSheetSerializer,
+  ChordSheetSerializer, ChordLyricsPair, Tag,
 } from '../../src';
 
 import { createSong } from '../utilities';
 import exampleSong from '../fixtures/song';
 import serializedSong from '../fixtures/serialized_song.json';
+import serializedChangedSong from '../fixtures/changed_song.json';
 
 const createLineStub = ({ renderable }) => (
   {
@@ -120,6 +121,62 @@ describe('Song', () => {
       const song = createSong([nonRenderableLine1, nonRenderableLine2, renderableLine1, nonRenderableLine3]);
 
       expect(song.bodyLines).toEqual([renderableLine1, nonRenderableLine3]);
+    });
+  });
+
+  describe('#mapLines', () => {
+    it('changes the song', () => {
+      const song = exampleSong.clone();
+      expect(song.paragraphs.map((p) => p.lines.length)).toEqual([0, 1, 2, 2]);
+
+      const changedSong = song.mapLines((line) => (
+        line.mapItems((item) => {
+          if (item instanceof ChordLyricsPair) {
+            return item.transpose(2, 'D').setLyrics(item.lyrics.toUpperCase());
+          }
+
+          if (item instanceof Tag) {
+            return item.setValue(`${item.value} changed`);
+          }
+
+          return item;
+        })
+      ));
+
+      expect(new ChordSheetSerializer().serialize(changedSong)).toEqual(serializedChangedSong);
+      expect(changedSong.title).toEqual('Let it be changed');
+      expect(changedSong.subtitle).toEqual('ChordSheetJS example version changed');
+      expect(changedSong.key).toEqual('C changed');
+      expect(changedSong.composer).toEqual(['John Lennon changed', 'Paul McCartney changed']);
+      expect(changedSong.paragraphs.length).toEqual(song.paragraphs.length);
+      expect(changedSong.paragraphs.map((p) => p.lines.length)).toEqual([0, 1, 2, 2]);
+    });
+  });
+
+  describe('#mapItems', () => {
+    it('changes the song', () => {
+      const song = exampleSong.clone();
+      expect(song.paragraphs.map((p) => p.lines.length)).toEqual([0, 1, 2, 2]);
+
+      const changedSong = song.mapItems((item) => {
+        if (item instanceof ChordLyricsPair) {
+          return item.transpose(2, 'D').setLyrics(item.lyrics.toUpperCase());
+        }
+
+        if (item instanceof Tag) {
+          return item.setValue(`${item.value} changed`);
+        }
+
+        return item;
+      });
+
+      expect(new ChordSheetSerializer().serialize(changedSong)).toEqual(serializedChangedSong);
+      expect(changedSong.title).toEqual('Let it be changed');
+      expect(changedSong.subtitle).toEqual('ChordSheetJS example version changed');
+      expect(changedSong.key).toEqual('C changed');
+      expect(changedSong.composer).toEqual(['John Lennon changed', 'Paul McCartney changed']);
+      expect(changedSong.paragraphs.length).toEqual(song.paragraphs.length);
+      expect(changedSong.paragraphs.map((p) => p.lines.length)).toEqual([0, 1, 2, 2]);
     });
   });
 

--- a/test/fixtures/changed_song.json
+++ b/test/fixtures/changed_song.json
@@ -1,0 +1,282 @@
+{
+  "type": "chordSheet",
+  "lines": [
+    {
+      "type": "line",
+      "items": [
+        {
+          "type": "tag",
+          "name": "title",
+          "value": "Let it be changed"
+        }
+      ]
+    },
+    {
+      "type": "line",
+      "items": [
+        {
+          "type": "tag",
+          "name": "subtitle",
+          "value": "ChordSheetJS example version changed"
+        }
+      ]
+    },
+    {
+      "type": "line",
+      "items": [
+        {
+          "type": "tag",
+          "name": "key",
+          "value": "C changed"
+        }
+      ]
+    },
+    {
+      "type": "line",
+      "items": [
+        {
+          "type": "tag",
+          "name": "x_some_setting",
+          "value": "null changed"
+        }
+      ]
+    },
+    {
+      "type": "line",
+      "items": [
+        {
+          "type": "tag",
+          "name": "composer",
+          "value": "John Lennon changed"
+        }
+      ]
+    },
+    {
+      "type": "line",
+      "items": [
+        {
+          "type": "tag",
+          "name": "composer",
+          "value": "Paul McCartney changed"
+        }
+      ]
+    },
+    {
+      "type": "line",
+      "items": []
+    },
+    {
+      "type": "line",
+      "items": [
+        {
+          "type": "chordLyricsPair",
+          "chords": "",
+          "lyrics": "WRITTEN BY: "
+        },
+        {
+          "type": "ternary",
+          "variable": "composer",
+          "valueTest": null,
+          "trueExpression": [
+            {
+              "type": "ternary",
+              "variable": null,
+              "valueTest": null
+            }
+          ],
+          "falseExpression": [
+            "No composer defined for ",
+            {
+              "type": "ternary",
+              "variable": "title",
+              "valueTest": null,
+              "trueExpression": [
+                {
+                  "type": "ternary",
+                  "variable": null,
+                  "valueTest": null
+                }
+              ],
+              "falseExpression": [
+                "Untitled song"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "line",
+      "items": []
+    },
+    {
+      "type": "line",
+      "items": [
+        {
+          "type": "tag",
+          "name": "start_of_verse",
+          "value": "null changed"
+        }
+      ]
+    },
+    {
+      "type": "line",
+      "items": [
+        {
+          "type": "chordLyricsPair",
+          "chords": "",
+          "lyrics": "LET IT "
+        },
+        {
+          "type": "chordLyricsPair",
+          "chords": "Bm",
+          "lyrics": "BE, LET IT "
+        },
+        {
+          "type": "chordLyricsPair",
+          "chords": "D/A",
+          "lyrics": "BE, LET IT "
+        },
+        {
+          "type": "chordLyricsPair",
+          "chords": "G",
+          "lyrics": "BE, LET IT "
+        },
+        {
+          "type": "chordLyricsPair",
+          "chords": "D",
+          "lyrics": "BE"
+        }
+      ]
+    },
+    {
+      "type": "line",
+      "items": [
+        {
+          "type": "tag",
+          "name": "transpose",
+          "value": "2 changed"
+        }
+      ]
+    },
+    {
+      "type": "line",
+      "items": [
+        {
+          "type": "chordLyricsPair",
+          "chords": "D",
+          "lyrics": "WHISPER WORDS OF "
+        },
+        {
+          "type": "chordLyricsPair",
+          "chords": "G",
+          "lyrics": "WIS"
+        },
+        {
+          "type": "chordLyricsPair",
+          "chords": "A",
+          "lyrics": "DOM, LET IT "
+        },
+        {
+          "type": "chordLyricsPair",
+          "chords": "G",
+          "lyrics": "BE "
+        },
+        {
+          "type": "chordLyricsPair",
+          "chords": "D/F#",
+          "lyrics": " "
+        },
+        {
+          "type": "chordLyricsPair",
+          "chords": "Em",
+          "lyrics": " "
+        },
+        {
+          "type": "chordLyricsPair",
+          "chords": "D",
+          "lyrics": ""
+        }
+      ]
+    },
+    {
+      "type": "line",
+      "items": [
+        {
+          "type": "tag",
+          "name": "end_of_verse",
+          "value": "null changed"
+        }
+      ]
+    },
+    {
+      "type": "line",
+      "items": []
+    },
+    {
+      "type": "line",
+      "items": [
+        {
+          "type": "tag",
+          "name": "start_of_chorus",
+          "value": "null changed"
+        }
+      ]
+    },
+    {
+      "type": "line",
+      "items": [
+        {
+          "type": "tag",
+          "name": "comment",
+          "value": "Breakdown changed"
+        }
+      ]
+    },
+    {
+      "type": "line",
+      "items": [
+        {
+          "type": "tag",
+          "name": "transpose",
+          "value": "G changed"
+        }
+      ]
+    },
+    {
+      "type": "line",
+      "items": [
+        {
+          "type": "chordLyricsPair",
+          "chords": "Bm",
+          "lyrics": "WHISPER WORDS OF "
+        },
+        {
+          "type": "chordLyricsPair",
+          "chords": "C",
+          "lyrics": "WISDOM, LET IT "
+        },
+        {
+          "type": "chordLyricsPair",
+          "chords": "G",
+          "lyrics": "BE "
+        },
+        {
+          "type": "chordLyricsPair",
+          "chords": "D",
+          "lyrics": ""
+        }
+      ]
+    },
+    {
+      "type": "line",
+      "items": [
+        {
+          "type": "tag",
+          "name": "end_of_chorus",
+          "value": "null changed"
+        }
+      ]
+    }
+  ]
+}

--- a/test/utilities.ts
+++ b/test/utilities.ts
@@ -24,7 +24,6 @@ export function createSong(lines, metadata = null) {
     }
   });
 
-  song.finish();
   return song;
 }
 


### PR DESCRIPTION
- makes `Song#mapItems` and `Song#mapLines` keep song integrity by using implementation similar to parsing a song
- makes `Song#mapItems` and `Song#mapLines` public to be used as the only correct way to change a song
- changes the implementation of `paragraphs` to dynamically determine paragraphs instead of having them composed on parsing

Resolves #481