### PR TITLE
Prevent require() for process

### DIFF
--- a/.parcelrc
+++ b/.parcelrc
@@ -1,6 +1,0 @@
-{
-  "extends": "@parcel/config-default",
-  "transformers": {
-    "*.hbs": ["parcel-transformer-hbs"]
-  }
-}

--- a/process
+++ b/process
@@ -1,1 +1,0 @@
-module.exports = {"browser": true}

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -47,8 +47,10 @@ export function deprecate(message) {
   try {
     throw new Error(`DEPRECATION: ${message}`);
   } catch (e) {
-    if (typeof process === 'object' && typeof process.emitWarning === 'function') {
-      process.emitWarning(`${message}\n${e.stack}`);
+    const proc = globalThis.process;
+
+    if (typeof proc === 'object' && typeof proc.emitWarning === 'function') {
+      proc.emitWarning(`${message}\n${e.stack}`);
     } else {
       console.warn(`${message}\n${e.stack}`);
     }


### PR DESCRIPTION
Access `process` as property on `globalThis`, to prevent loading issues in
environments that do not support the `process` module

Resolves #567