### PR TITLE
Make chord suffix normalization on song transpose optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,9 +639,9 @@ If not, it returns [INDETERMINATE](#INDETERMINATE)</p>
     * [.clone()](#Song+clone) ⇒ [<code>Song</code>](#Song)
     * [.setKey(key)](#Song+setKey) ⇒ [<code>Song</code>](#Song)
     * [.setCapo(capo)](#Song+setCapo) ⇒ [<code>Song</code>](#Song)
-    * [.transpose(delta)](#Song+transpose) ⇒ [<code>Song</code>](#Song)
-    * [.transposeUp()](#Song+transposeUp) ⇒ [<code>Song</code>](#Song)
-    * [.transposeDown()](#Song+transposeDown) ⇒ [<code>Song</code>](#Song)
+    * [.transpose(delta, [options])](#Song+transpose) ⇒ [<code>Song</code>](#Song)
+    * [.transposeUp([options])](#Song+transposeUp) ⇒ [<code>Song</code>](#Song)
+    * [.transposeDown([options])](#Song+transposeDown) ⇒ [<code>Song</code>](#Song)
     * [.changeKey(newKey)](#Song+changeKey) ⇒ [<code>Song</code>](#Song)
     * [.changeMetadata(name, value)](#Song+changeMetadata)
     * [.mapItems(func)](#Song+mapItems) ⇒ [<code>Song</code>](#Song)
@@ -729,7 +729,7 @@ if you want to skip the &quot;header lines&quot;: the lines that only contain me
 
 <a name="Song+transpose"></a>
 
-### song.transpose(delta) ⇒ [<code>Song</code>](#Song)
+### song.transpose(delta, [options]) ⇒ [<code>Song</code>](#Song)
 <p>Transposes the song by the specified delta. It will:</p>
 <ul>
 <li>transpose all chords, see: [transpose](#Chord+transpose)</li>
@@ -740,13 +740,15 @@ if you want to skip the &quot;header lines&quot;: the lines that only contain me
 **Kind**: instance method of [<code>Song</code>](#Song)  
 **Returns**: [<code>Song</code>](#Song) - <p>The transposed song</p>  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| delta | <code>number</code> | <p>The number of semitones (positive or negative) to transpose with</p> |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| delta | <code>number</code> |  | <p>The number of semitones (positive or negative) to transpose with</p> |
+| [options] | <code>Object</code> | <code>{}</code> | <p>options</p> |
+| [options.normalizeChordSuffix] | <code>boolean</code> | <code>false</code> | <p>whether to normalize the chord suffixes after transposing</p> |
 
 <a name="Song+transposeUp"></a>
 
-### song.transposeUp() ⇒ [<code>Song</code>](#Song)
+### song.transposeUp([options]) ⇒ [<code>Song</code>](#Song)
 <p>Transposes the song up by one semitone. It will:</p>
 <ul>
 <li>transpose all chords, see: [transpose](#Chord+transpose)</li>
@@ -756,9 +758,15 @@ if you want to skip the &quot;header lines&quot;: the lines that only contain me
 
 **Kind**: instance method of [<code>Song</code>](#Song)  
 **Returns**: [<code>Song</code>](#Song) - <p>The transposed song</p>  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [options] | <code>Object</code> | <code>{}</code> | <p>options</p> |
+| [options.normalizeChordSuffix] | <code>boolean</code> | <code>false</code> | <p>whether to normalize the chord suffixes after transposing</p> |
+
 <a name="Song+transposeDown"></a>
 
-### song.transposeDown() ⇒ [<code>Song</code>](#Song)
+### song.transposeDown([options]) ⇒ [<code>Song</code>](#Song)
 <p>Transposes the song down by one semitone. It will:</p>
 <ul>
 <li>transpose all chords, see: [transpose](#Chord+transpose)</li>
@@ -768,6 +776,12 @@ if you want to skip the &quot;header lines&quot;: the lines that only contain me
 
 **Kind**: instance method of [<code>Song</code>](#Song)  
 **Returns**: [<code>Song</code>](#Song) - <p>The transposed song</p>  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [options] | <code>Object</code> | <code>{}</code> | <p>options</p> |
+| [options.normalizeChordSuffix] | <code>boolean</code> | <code>false</code> | <p>whether to normalize the chord suffixes after transposing</p> |
+
 <a name="Song+changeKey"></a>
 
 ### song.changeKey(newKey) ⇒ [<code>Song</code>](#Song)
@@ -1188,7 +1202,7 @@ Inherits from [ChordSheetParser](#ChordSheetParser)</p>
         * [.toNumericString([key])](#Chord+toNumericString) ⇒ <code>string</code>
         * [.isNumeral()](#Chord+isNumeral) ⇒ <code>boolean</code>
         * [.toString()](#Chord+toString) ⇒ <code>string</code>
-        * [.normalize()](#Chord+normalize) ⇒ [<code>Chord</code>](#Chord)
+        * [.normalize([key], [options])](#Chord+normalize) ⇒ [<code>Chord</code>](#Chord)
         * [.useModifier(newModifier)](#Chord+useModifier) ⇒ [<code>Chord</code>](#Chord)
         * [.transposeUp()](#Chord+transposeUp) ⇒ [<code>Chord</code>](#Chord)
         * [.transposeDown()](#Chord+transposeDown) ⇒ [<code>Chord</code>](#Chord)
@@ -1312,7 +1326,7 @@ For example, a chord symbol A# with reference key E will return the numeric chor
 **Returns**: <code>string</code> - <p>the chord string</p>  
 <a name="Chord+normalize"></a>
 
-### chord.normalize() ⇒ [<code>Chord</code>](#Chord)
+### chord.normalize([key], [options]) ⇒ [<code>Chord</code>](#Chord)
 <p>Normalizes the chord root and bass notes:</p>
 <ul>
 <li>Fb becomes E</li>
@@ -1324,11 +1338,19 @@ For example, a chord symbol A# with reference key E will return the numeric chor
 <li>7# becomes 1</li>
 <li>3# becomes 4</li>
 </ul>
-<p>Besides that it normalizes the suffix. For example, <code>sus2</code> becomes <code>2</code>, <code>sus4</code> becomes <code>sus</code>.
+<p>Besides that it normalizes the suffix if <code>normalizeSuffix</code> is <code>true</code>.
+For example, <code>sus2</code> becomes <code>2</code>, <code>sus4</code> becomes <code>sus</code>.
 All suffix normalizations can be found in <code>src/normalize_mappings/suffix-mapping.txt</code>.</p>
 
 **Kind**: instance method of [<code>Chord</code>](#Chord)  
 **Returns**: [<code>Chord</code>](#Chord) - <p>the normalized chord</p>  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [key] | <code>Key</code> \| <code>string</code> | <code></code> | <p>the key to normalize to</p> |
+| [options] | <code>Object</code> | <code>{}</code> | <p>options</p> |
+| [options.normalizeSuffix] | <code>boolean</code> | <code>true</code> | <p>whether to normalize the chord suffix after transposing</p> |
+
 <a name="Chord+useModifier"></a>
 
 ### chord.useModifier(newModifier) ⇒ [<code>Chord</code>](#Chord)

--- a/src/chord.ts
+++ b/src/chord.ts
@@ -15,7 +15,7 @@ import {
   presence,
 } from './utilities';
 
-function normalizeSuffix(suffix) {
+function normalizeChordSuffix(suffix) {
   if (SUFFIX_MAPPING[suffix] === '[blank]') {
     return null;
   }
@@ -88,7 +88,7 @@ class Chord {
     const rootKey = this.root.toChordSymbol(keyObj).normalizeEnharmonics(keyObj);
 
     let chordSymbolChord = new Chord({
-      suffix: normalizeSuffix(this.suffix),
+      suffix: normalizeChordSuffix(this.suffix),
       root: rootKey,
       bass: this.bass?.toChordSymbol(keyObj).normalizeEnharmonics(rootKey),
     });
@@ -141,7 +141,7 @@ class Chord {
     const keyObj = Key.wrap(key);
 
     return new Chord({
-      suffix: normalizeSuffix(this.suffix),
+      suffix: normalizeChordSuffix(this.suffix),
       root: this.root.toNumeric(keyObj),
       bass: this.bass?.toNumeric(keyObj),
     });
@@ -168,7 +168,7 @@ class Chord {
     const keyObj = Key.wrap(key);
 
     return new Chord({
-      suffix: normalizeSuffix(this.suffix),
+      suffix: normalizeChordSuffix(this.suffix),
       root: this.root.toNumeral(keyObj),
       bass: this.bass?.toNumeral(keyObj),
     });
@@ -237,19 +237,24 @@ class Chord {
    * - 7# becomes 1
    * - 3# becomes 4
    *
-   * Besides that it normalizes the suffix. For example, `sus2` becomes `2`, `sus4` becomes `sus`.
+   * Besides that it normalizes the suffix if `normalizeSuffix` is `true`.
+   * For example, `sus2` becomes `2`, `sus4` becomes `sus`.
    * All suffix normalizations can be found in `src/normalize_mappings/suffix-mapping.txt`.
-   *
+   * @param {Key|string} [key=null] the key to normalize to
+   * @param {Object} [options={}] options
+   * @param {boolean} [options.normalizeSuffix=true] whether to normalize the chord suffix after transposing
    * @returns {Chord} the normalized chord
    */
-  normalize(key = null) {
+  normalize(key = null, { normalizeSuffix = true } = {}) {
+    const suffix = normalizeSuffix ? normalizeChordSuffix(this.suffix) : this.suffix;
+
     if (isBlank(key)) {
-      return this.process('normalize').set({ suffix: presence(normalizeSuffix(this.suffix)) });
+      return this.process('normalize').set({ suffix });
     }
 
     return this.set({
+      suffix,
       root: this.root.normalizeEnharmonics(key),
-      suffix: presence(normalizeSuffix(this.suffix)),
       bass: this.bass ? this.bass.normalizeEnharmonics(this.root.toString()) : null,
     });
   }

--- a/src/chord_sheet/chord_lyrics_pair.ts
+++ b/src/chord_sheet/chord_lyrics_pair.ts
@@ -61,14 +61,14 @@ class ChordLyricsPair {
     return this.set({ lyrics });
   }
 
-  transpose(delta: number, key: string | Key | null = null): ChordLyricsPair {
+  transpose(delta: number, key: string | Key | null = null, { normalizeChordSuffix = false } = {}): ChordLyricsPair {
     const chordObj = Chord.parse(this.chords);
 
     if (chordObj) {
       let transposedChord = chordObj.transpose(delta);
 
       if (key) {
-        transposedChord = transposedChord.normalize(key);
+        transposedChord = transposedChord.normalize(key, { normalizeSuffix: normalizeChordSuffix });
       }
 
       return this.set({ chords: transposedChord.toString() });

--- a/src/chord_sheet/song.ts
+++ b/src/chord_sheet/song.ts
@@ -309,9 +309,11 @@ class Song extends MetadataAccessors {
    * - transpose the song key in {@link metadata}
    * - update any existing `key` directive
    * @param {number} delta The number of semitones (positive or negative) to transpose with
+   * @param {Object} [options={}] options
+   * @param {boolean} [options.normalizeChordSuffix=false] whether to normalize the chord suffixes after transposing
    * @returns {Song} The transposed song
    */
-  transpose(delta: number): Song {
+  transpose(delta: number, { normalizeChordSuffix = false } = {}): Song {
     const wrappedKey = Key.wrap(this.key);
     let transposedKey = null;
     let song = (this as Song);
@@ -323,7 +325,7 @@ class Song extends MetadataAccessors {
 
     return song.mapItems((item) => {
       if (item instanceof ChordLyricsPair) {
-        return (item as ChordLyricsPair).transpose(delta, transposedKey);
+        return (item as ChordLyricsPair).transpose(delta, transposedKey, { normalizeChordSuffix });
       }
 
       return item;
@@ -335,10 +337,12 @@ class Song extends MetadataAccessors {
    * - transpose all chords, see: {@link Chord#transpose}
    * - transpose the song key in {@link metadata}
    * - update any existing `key` directive
+   * @param {Object} [options={}] options
+   * @param {boolean} [options.normalizeChordSuffix=false] whether to normalize the chord suffixes after transposing
    * @returns {Song} The transposed song
    */
-  transposeUp(): Song {
-    return this.transpose(1);
+  transposeUp({ normalizeChordSuffix = false } = {}): Song {
+    return this.transpose(1, { normalizeChordSuffix });
   }
 
   /**
@@ -346,10 +350,12 @@ class Song extends MetadataAccessors {
    * - transpose all chords, see: {@link Chord#transpose}
    * - transpose the song key in {@link metadata}
    * - update any existing `key` directive
+   * @param {Object} [options={}] options
+   * @param {boolean} [options.normalizeChordSuffix=false] whether to normalize the chord suffixes after transposing
    * @returns {Song} The transposed song
    */
-  transposeDown(): Song {
-    return this.transpose(-1);
+  transposeDown({ normalizeChordSuffix = false } = {}): Song {
+    return this.transpose(-1, { normalizeChordSuffix });
   }
 
   /**

--- a/test/integration/transpose_song.test.ts
+++ b/test/integration/transpose_song.test.ts
@@ -4,11 +4,11 @@ describe('transposing a song', () => {
   it('transposes with a delta', () => {
     const chordpro = `
 {key: C}
-Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be`.substring(1);
+Let it [Am]be, let it [C/G]be, let it [Fsus2]be, let it [C]be`.substring(1);
 
     const changedSheet = `
 {key: D}
-Let it [Bm]be, let it [D/A]be, let it [G]be, let it [D]be`.substring(1);
+Let it [Bm]be, let it [D/A]be, let it [Gsus2]be, let it [D]be`.substring(1);
 
     const song = new ChordProParser().parse(chordpro);
     const updatedSong = song.transpose(2);
@@ -17,14 +17,30 @@ Let it [Bm]be, let it [D/A]be, let it [G]be, let it [D]be`.substring(1);
     expect(new ChordProFormatter().format(updatedSong)).toEqual(changedSheet);
   });
 
+  it('normalizes chords on transpose with a delta when enabled', () => {
+    const chordpro = `
+{key: C}
+Let it [Am]be, let it [C/G]be, let it [Fsus2]be, let it [C]be`.substring(1);
+
+    const changedSheet = `
+{key: D}
+Let it [Bm]be, let it [D/A]be, let it [G2]be, let it [D]be`.substring(1);
+
+    const song = new ChordProParser().parse(chordpro);
+    const updatedSong = song.transpose(2, { normalizeChordSuffix: true });
+
+    expect(updatedSong.key).toEqual('D');
+    expect(new ChordProFormatter().format(updatedSong)).toEqual(changedSheet);
+  });
+
   it('transposes up', () => {
     const chordpro = `
 {key: C}
-Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be`.substring(1);
+Let it [Am]be, let it [C/G]be, let it [Fsus2]be, let it [C]be`.substring(1);
 
     const changedSheet = `
 {key: C#}
-Let it [A#m]be, let it [C#/G#]be, let it [F#]be, let it [C#]be`.substring(1);
+Let it [A#m]be, let it [C#/G#]be, let it [F#sus2]be, let it [C#]be`.substring(1);
 
     const song = new ChordProParser().parse(chordpro);
     const updatedSong = song.transposeUp();
@@ -33,17 +49,49 @@ Let it [A#m]be, let it [C#/G#]be, let it [F#]be, let it [C#]be`.substring(1);
     expect(new ChordProFormatter().format(updatedSong)).toEqual(changedSheet);
   });
 
+  it('normalizes chords on transpose up when enabled', () => {
+    const chordpro = `
+{key: C}
+Let it [Am]be, let it [C/G]be, let it [Fsus2]be, let it [C]be`.substring(1);
+
+    const changedSheet = `
+{key: C#}
+Let it [A#m]be, let it [C#/G#]be, let it [F#2]be, let it [C#]be`.substring(1);
+
+    const song = new ChordProParser().parse(chordpro);
+    const updatedSong = song.transposeUp({ normalizeChordSuffix: true });
+
+    expect(updatedSong.key).toEqual('C#');
+    expect(new ChordProFormatter().format(updatedSong)).toEqual(changedSheet);
+  });
+
   it('transposes down', () => {
     const chordpro = `
 {key: D}
-Let it [Bm]be, let it [D/A]be, let it [G]be, let it [D]be`.substring(1);
+Let it [Bm]be, let it [D/A]be, let it [Gsus2]be, let it [D]be`.substring(1);
 
     const changedSheet = `
 {key: Db}
-Let it [Bbm]be, let it [Db/Ab]be, let it [Gb]be, let it [Db]be`.substring(1);
+Let it [Bbm]be, let it [Db/Ab]be, let it [Gbsus2]be, let it [Db]be`.substring(1);
 
     const song = new ChordProParser().parse(chordpro);
     const updatedSong = song.transposeDown();
+
+    expect(updatedSong.key).toEqual('Db');
+    expect(new ChordProFormatter().format(updatedSong)).toEqual(changedSheet);
+  });
+
+  it('normalizes on transpose up when enabled', () => {
+    const chordpro = `
+{key: D}
+Let it [Bm]be, let it [D/A]be, let it [Gsus2]be, let it [D]be`.substring(1);
+
+    const changedSheet = `
+{key: Db}
+Let it [Bbm]be, let it [Db/Ab]be, let it [Gb2]be, let it [Db]be`.substring(1);
+
+    const song = new ChordProParser().parse(chordpro);
+    const updatedSong = song.transposeDown({ normalizeChordSuffix: true });
 
     expect(updatedSong.key).toEqual('Db');
     expect(new ChordProFormatter().format(updatedSong)).toEqual(changedSheet);


### PR DESCRIPTION
`song.transpose()`, `song.transposeDown()` and `song.transposeUp()` will only normalize chord suffixes when explicitly enabled: `song.transposeUp({ normalizeChordSuffix: true })`

Fixes #570 