### PR TITLE
Add `m` to stringified minor keys

### DIFF
--- a/src/chord.ts
+++ b/src/chord.ts
@@ -217,7 +217,7 @@ class Chord {
    * @returns {string} the chord string
    */
   toString() {
-    const chordString = this.root.toString() + (this.suffix || '');
+    const chordString = this.root.toString({ showMinor: false }) + (this.suffix || '');
 
     if (this.bass) {
       return `${chordString}/${this.bass.toString()}`;
@@ -305,12 +305,13 @@ class Chord {
     },
   ) {
     this.suffix = presence(suffix);
-    this.root = root || new Key({ note: base, modifier, minor: suffix === 'm' });
+    const isMinor = suffix && suffix[0] === 'm' && suffix.substring(0, 3).toLowerCase() !== 'maj';
+    this.root = root || new Key({ note: base, modifier, minor: isMinor });
 
     if (bass) {
       this.bass = bass;
     } else if (bassBase) {
-      this.bass = new Key({ note: bassBase, modifier: bassModifier, minor: suffix === 'm' });
+      this.bass = new Key({ note: bassBase, modifier: bassModifier, minor: isMinor });
     } else {
       this.bass = null;
     }

--- a/src/note.ts
+++ b/src/note.ts
@@ -183,7 +183,12 @@ class Note {
   }
 
   toString() {
-    return `${this.note}`;
+    switch (this.type) {
+      case NUMERAL:
+        return `${this.minor ? this.note.toLowerCase() : this.note.toUpperCase()}`;
+      default:
+        return `${this.note}`;
+    }
   }
 
   private set(attributes) {

--- a/test/chord_symbol/constructor.test.ts
+++ b/test/chord_symbol/constructor.test.ts
@@ -17,6 +17,18 @@ describe('Chord', () => {
           base: 'E', modifier: 'b', suffix: 'sus', bassBase: 'G', bassModifier: '#',
         });
       });
+
+      it('marks simple minor keys as minor', () => {
+        const chord = new Chord({ base: 'E', suffix: 'm' });
+
+        expect(chord.root.minor).toBe(true);
+      });
+
+      it('marks complex minor keys as minor', () => {
+        const chord = new Chord({ base: 'E', suffix: 'm7' });
+
+        expect(chord.root.minor).toBe(true);
+      });
     });
   });
 });

--- a/test/jest.d.ts
+++ b/test/jest.d.ts
@@ -14,7 +14,7 @@ declare global {
 
       toBeNote({ note, type, minor }): CustomMatcherResult;
 
-      toBeKey({ note, modifier }): CustomMatcherResult;
+      toBeKey({ note, modifier, minor = false }): CustomMatcherResult;
 
       toBeChordLyricsPair(chords: string, lyrics: string): CustomMatcherResult;
 

--- a/test/key/to_string.test.ts
+++ b/test/key/to_string.test.ts
@@ -2,22 +2,40 @@ import { Key } from '../../src';
 
 describe('Key', () => {
   describe('toString', () => {
-    it('converts a numeral key to a string', () => {
+    it('converts a major numeral key to a string', () => {
       const key = new Key({ note: 'II', modifier: 'b' });
 
       expect(key.toString()).toEqual('bII');
     });
 
-    it('converts a numeric key to a string', () => {
+    it('converts a minor numeral key to a string', () => {
+      const key = new Key({ note: 'II', modifier: 'b', minor: true });
+
+      expect(key.toString()).toEqual('bii');
+    });
+
+    it('converts a major numeric key to a string', () => {
       const key = new Key({ note: 2, modifier: 'b' });
 
       expect(key.toString()).toEqual('b2');
     });
 
-    it('converts a chord symbol key to a string', () => {
+    it('converts a minor numeric key to a string', () => {
+      const key = new Key({ note: 2, modifier: 'b', minor: true });
+
+      expect(key.toString()).toEqual('b2m');
+    });
+
+    it('converts a major chord symbol key to a string', () => {
       const key = new Key({ note: 'A', modifier: 'b' });
 
       expect(key.toString()).toEqual('Ab');
+    });
+
+    it('converts a minor chord symbol key to a string', () => {
+      const key = new Key({ note: 'A', modifier: 'b', minor: true });
+
+      expect(key.toString()).toEqual('Abm');
     });
   });
 });

--- a/test/key/transpose_up.test.ts
+++ b/test/key/transpose_up.test.ts
@@ -155,5 +155,12 @@ describe('Key', () => {
         expect(transposedKey).toBeKey({ note: 'F', modifier: '#' });
       });
     });
+
+    it('correctly handles minor keys', () => {
+      const key = new Key({ note: 'E', modifier: '#', minor: true });
+
+      const transposedKey = key.transposeUp();
+      expect(transposedKey).toBeKey({ note: 'F', modifier: '#', minor: true });
+    });
   });
 });

--- a/test/matchers.ts
+++ b/test/matchers.ts
@@ -116,14 +116,15 @@ function toBeChord(
   );
 }
 
-function toBeKey(received, { note, modifier }) {
+function toBeKey(received, { note, modifier, minor = false }) {
   return toBeClassInstanceWithProperties(
     {
       note: received.note.note,
       modifier: received.modifier,
+      minor: received.minor,
     },
     null,
-    { note, modifier },
+    { note, modifier, minor },
   );
 }
 


### PR DESCRIPTION
When a minor key is stringified, the `m` suffix should be added.

Resolves #569