### PR TITLE
Include meta directives in song metadata

### DIFF
--- a/test/parser/chord_pro_parser.test.ts
+++ b/test/parser/chord_pro_parser.test.ts
@@ -99,6 +99,18 @@ Let it [Am]be, let it [C/A][C/G#]be, let it [F]be, let it [C]be
     expect(song.metadata.get('x_other_directive')).toEqual('Bar');
   });
 
+  it('parses meta directives', () => {
+    const chordSheetWithCustomMetaData = `
+      {meta: one_directive Foo}
+      {meta: other_directive Bar}
+    `;
+
+    const song = new ChordProParser().parse(chordSheetWithCustomMetaData);
+
+    expect(song.metadata.get('one_directive')).toEqual('Foo');
+    expect(song.metadata.get('other_directive')).toEqual('Bar');
+  });
+
   it('can have multiple values for a meta directive', () => {
     const chordSheetWithMultipleComposers = `
       {composer: John}


### PR DESCRIPTION
This ensures directives like:

- `{meta: author John Lennon}`
- `{meta: custom_tag This is the value}`

are included in `song.metadata`

Resolves #594