### PR TITLE
Bugfix: Without key, Song.transpose only transposes last chord on each line

### DIFF
--- a/src/chord_sheet/chord_lyrics_pair.ts
+++ b/src/chord_sheet/chord_lyrics_pair.ts
@@ -62,7 +62,7 @@ class ChordLyricsPair {
   }
 
   transpose(delta: number, key: string | Key | null = null, { normalizeChordSuffix = false } = {}): ChordLyricsPair {
-    const chordObj = Chord.parse(this.chords);
+    const chordObj = Chord.parse(this.chords.trim());
 
     if (chordObj) {
       let transposedChord = chordObj.transpose(delta);

--- a/test/integration/transpose_song.test.ts
+++ b/test/integration/transpose_song.test.ts
@@ -2,7 +2,7 @@ import {
   ChordProFormatter,
   ChordProParser,
   ChordSheetParser,
-  TextFormatter
+  TextFormatter,
 } from '../../src';
 
 describe('transposing a song', () => {

--- a/test/integration/transpose_song.test.ts
+++ b/test/integration/transpose_song.test.ts
@@ -1,4 +1,9 @@
-import { ChordProFormatter, ChordProParser } from '../../src';
+import {
+  ChordProFormatter,
+  ChordProParser,
+  ChordSheetParser,
+  TextFormatter
+} from '../../src';
 
 describe('transposing a song', () => {
   it('transposes with a delta', () => {
@@ -95,5 +100,20 @@ Let it [Bbm]be, let it [Db/Ab]be, let it [Gb2]be, let it [Db]be`.substring(1);
 
     expect(updatedSong.key).toEqual('Db');
     expect(new ChordProFormatter().format(updatedSong)).toEqual(changedSheet);
+  });
+
+  it('may be transposed without a key', () => {
+    const chordpro = `
+       Am         C/G        F          C
+Let it be, let it be, let it be, let it be`.substring(1);
+
+    const changedSheet = `
+       Bm         D/A        G          D
+Let it be, let it be, let it be, let it be`.substring(1);
+
+    const song = new ChordSheetParser().parse(chordpro);
+    const updatedSong = song.transpose(2);
+
+    expect(new TextFormatter().format(updatedSong)).toEqual(changedSheet);
   });
 });

--- a/test/integration/transpose_song.test.ts
+++ b/test/integration/transpose_song.test.ts
@@ -81,7 +81,7 @@ Let it [Bbm]be, let it [Db/Ab]be, let it [Gbsus2]be, let it [Db]be`.substring(1)
     expect(new ChordProFormatter().format(updatedSong)).toEqual(changedSheet);
   });
 
-  it('normalizes on transpose up when enabled', () => {
+  it('normalizes on transpose down when enabled', () => {
     const chordpro = `
 {key: D}
 Let it [Bm]be, let it [D/A]be, let it [Gsus2]be, let it [D]be`.substring(1);


### PR DESCRIPTION
Only affects formats using `ChordLyricsPair`.

Addresses an issue in which, without a key provided, `Song.transpose` only transposes last chord on each line. This was because `ChordLyricsPair` passed `this.chords` (which could include trailing whitespace) to `Chord.parse`.

Resolves:
* #625