### PR TITLE
Support all types of line endings

### DIFF
--- a/src/parser/chord_sheet_parser.ts
+++ b/src/parser/chord_sheet_parser.ts
@@ -1,6 +1,7 @@
 import Song from '../chord_sheet/song';
 import Line from '../chord_sheet/line';
 import ChordLyricsPair from '../chord_sheet/chord_lyrics_pair';
+import { normalizeLineEndings } from '../utilities';
 
 const WHITE_SPACE = /\s/;
 const CHORD_LINE_REGEX = /^\s*((([A-G])(#|b)?([^/\s]*)(\/([A-G])(#|b)?)?)(\s|$)+)+(\s|$)+/;
@@ -83,7 +84,7 @@ class ChordSheetParser {
       this.song = song;
     }
 
-    this.lines = document.split('\n');
+    this.lines = normalizeLineEndings(document).split('\n');
     this.currentLine = 0;
     this.lineCount = this.lines.length;
     this.processingText = true;

--- a/src/parser/peg_based_parser.ts
+++ b/src/parser/peg_based_parser.ts
@@ -2,6 +2,7 @@
 import { Song } from '../index';
 import ChordSheetSerializer from '../chord_sheet_serializer';
 import ParserWarning from './parser_warning';
+import { normalizeLineEndings } from '../utilities';
 
 interface IParseOptions {
   filename?: string;
@@ -27,7 +28,7 @@ class PegBasedParser {
   }
 
   protected parseWithParser(chordSheet: string, parser: ParseFunction): Song {
-    const ast = parser(chordSheet);
+    const ast = parser(normalizeLineEndings(chordSheet));
     this.song = new ChordSheetSerializer().deserialize(ast);
     return this.song;
   }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -74,3 +74,7 @@ export function isMinor(suffix: any): boolean {
 
   return suffix[0] === 'm' && suffix.substring(0, 3).toLowerCase() !== 'maj';
 }
+
+export function normalizeLineEndings(string: string): string {
+  return string.replace(/\r\n?/g, '\n');
+}

--- a/test/parser/chord_pro_parser.test.ts
+++ b/test/parser/chord_pro_parser.test.ts
@@ -447,4 +447,64 @@ E|---------------------------3----------------------------------|
     expect(paragraphTypes).toEqual([TAB, VERSE]);
     expect(parser.warnings).toHaveLength(0);
   });
+
+  it('supports CR line endings', () => {
+    const chordSheet = 'Let it [Am]be, let it [C/G]be,\rlet it [F]be, let it [C]be';
+
+    const parser = new ChordProParser();
+    const song = parser.parse(chordSheet);
+    const { lines } = song;
+    const [{ items: line0Items }, { items: line1Items }] = lines;
+
+    expect(lines).toHaveLength(2);
+
+    expect(line0Items[0]).toBeChordLyricsPair('', 'Let it ');
+    expect(line0Items[1]).toBeChordLyricsPair('Am', 'be, ');
+    expect(line0Items[2]).toBeChordLyricsPair('', 'let it ');
+    expect(line0Items[3]).toBeChordLyricsPair('C/G', 'be,');
+    expect(line1Items[0]).toBeChordLyricsPair('', 'let it ');
+    expect(line1Items[1]).toBeChordLyricsPair('F', 'be, ');
+    expect(line1Items[2]).toBeChordLyricsPair('', 'let it ');
+    expect(line1Items[3]).toBeChordLyricsPair('C', 'be');
+  });
+
+  it('supports LF line endings', () => {
+    const chordSheet = 'Let it [Am]be, let it [C/G]be,\nlet it [F]be, let it [C]be';
+
+    const parser = new ChordProParser();
+    const song = parser.parse(chordSheet);
+    const { lines } = song;
+    const [{ items: line0Items }, { items: line1Items }] = lines;
+
+    expect(lines).toHaveLength(2);
+
+    expect(line0Items[0]).toBeChordLyricsPair('', 'Let it ');
+    expect(line0Items[1]).toBeChordLyricsPair('Am', 'be, ');
+    expect(line0Items[2]).toBeChordLyricsPair('', 'let it ');
+    expect(line0Items[3]).toBeChordLyricsPair('C/G', 'be,');
+    expect(line1Items[0]).toBeChordLyricsPair('', 'let it ');
+    expect(line1Items[1]).toBeChordLyricsPair('F', 'be, ');
+    expect(line1Items[2]).toBeChordLyricsPair('', 'let it ');
+    expect(line1Items[3]).toBeChordLyricsPair('C', 'be');
+  });
+
+  it('supports CRLF line endings', () => {
+    const chordSheet = 'Let it [Am]be, let it [C/G]be,\r\nlet it [F]be, let it [C]be';
+
+    const parser = new ChordProParser();
+    const song = parser.parse(chordSheet);
+    const { lines } = song;
+    const [{ items: line0Items }, { items: line1Items }] = lines;
+
+    expect(lines).toHaveLength(2);
+
+    expect(line0Items[0]).toBeChordLyricsPair('', 'Let it ');
+    expect(line0Items[1]).toBeChordLyricsPair('Am', 'be, ');
+    expect(line0Items[2]).toBeChordLyricsPair('', 'let it ');
+    expect(line0Items[3]).toBeChordLyricsPair('C/G', 'be,');
+    expect(line1Items[0]).toBeChordLyricsPair('', 'let it ');
+    expect(line1Items[1]).toBeChordLyricsPair('F', 'be, ');
+    expect(line1Items[2]).toBeChordLyricsPair('', 'let it ');
+    expect(line1Items[3]).toBeChordLyricsPair('C', 'be');
+  });
 });

--- a/test/parser/chord_sheet_parser.test.ts
+++ b/test/parser/chord_sheet_parser.test.ts
@@ -2,7 +2,7 @@ import { ChordSheetParser } from '../../src';
 
 import '../matchers';
 
-const chordSheet = `
+const defaultChordSheet = `
        Am         C/G        F          C
 Let it be, let it be, let it be, let it be
 C                F  G           F  C/E Dm C
@@ -11,7 +11,7 @@ Whisper words of wisdom, let it be`.substring(1);
 describe('ChordSheetParser', () => {
   it('parses a regular chord sheet correctly', () => {
     const parser = new ChordSheetParser();
-    const song = parser.parse(chordSheet);
+    const song = parser.parse(defaultChordSheet);
     const { lines } = song;
 
     expect(lines.length).toEqual(2);
@@ -75,7 +75,7 @@ Whisper words of wisdom, let it be`.substring(1);
   describe('with option preserveWhitespace:true', () => {
     it('parses a regular chord sheet correctly', () => {
       const parser = new ChordSheetParser({ preserveWhitespace: true });
-      const song = parser.parse(chordSheet);
+      const song = parser.parse(defaultChordSheet);
       const { lines } = song;
 
       expect(lines.length).toEqual(2);
@@ -101,7 +101,7 @@ Whisper words of wisdom, let it be`.substring(1);
   describe('with option preserveWhitespace:false', () => {
     it('parses a regular chord sheet correctly', () => {
       const parser = new ChordSheetParser({ preserveWhitespace: false });
-      const song = parser.parse(chordSheet);
+      const song = parser.parse(defaultChordSheet);
       const { lines } = song;
 
       expect(lines.length).toEqual(2);
@@ -122,5 +122,59 @@ Whisper words of wisdom, let it be`.substring(1);
       expect(line1Items[5]).toBeChordLyricsPair('Dm', '');
       expect(line1Items[6]).toBeChordLyricsPair('C', '');
     });
+  });
+
+  it('support CR line endings', () => {
+    const chordSheet = '       Am         C/G\rLet it be, let it be,\r       F          C\rlet it be, let it be';
+
+    const parser = new ChordSheetParser();
+    const song = parser.parse(chordSheet);
+    const { lines } = song;
+    const [{ items: line0Items }, { items: line1Items }] = lines;
+
+    expect(lines).toHaveLength(2);
+
+    expect(line0Items[0]).toBeChordLyricsPair('      ', 'Let it ');
+    expect(line0Items[1]).toBeChordLyricsPair('Am        ', 'be, let it ');
+    expect(line0Items[2]).toBeChordLyricsPair('C/G', 'be,');
+    expect(line1Items[0]).toBeChordLyricsPair('      ', 'let it ');
+    expect(line1Items[1]).toBeChordLyricsPair('F         ', 'be, let it ');
+    expect(line1Items[2]).toBeChordLyricsPair('C', 'be');
+  });
+
+  it('support LF line endings', () => {
+    const chordSheet = '       Am         C/G\nLet it be, let it be,\n       F          C\nlet it be, let it be';
+
+    const parser = new ChordSheetParser();
+    const song = parser.parse(chordSheet);
+    const { lines } = song;
+    const [{ items: line0Items }, { items: line1Items }] = lines;
+
+    expect(lines).toHaveLength(2);
+
+    expect(line0Items[0]).toBeChordLyricsPair('      ', 'Let it ');
+    expect(line0Items[1]).toBeChordLyricsPair('Am        ', 'be, let it ');
+    expect(line0Items[2]).toBeChordLyricsPair('C/G', 'be,');
+    expect(line1Items[0]).toBeChordLyricsPair('      ', 'let it ');
+    expect(line1Items[1]).toBeChordLyricsPair('F         ', 'be, let it ');
+    expect(line1Items[2]).toBeChordLyricsPair('C', 'be');
+  });
+
+  it('support CRLF line endings', () => {
+    const chordSheet = '       Am         C/G\r\nLet it be, let it be,\r\n       F          C\r\nlet it be, let it be';
+
+    const parser = new ChordSheetParser();
+    const song = parser.parse(chordSheet);
+    const { lines } = song;
+    const [{ items: line0Items }, { items: line1Items }] = lines;
+
+    expect(lines).toHaveLength(2);
+
+    expect(line0Items[0]).toBeChordLyricsPair('      ', 'Let it ');
+    expect(line0Items[1]).toBeChordLyricsPair('Am        ', 'be, let it ');
+    expect(line0Items[2]).toBeChordLyricsPair('C/G', 'be,');
+    expect(line1Items[0]).toBeChordLyricsPair('      ', 'let it ');
+    expect(line1Items[1]).toBeChordLyricsPair('F         ', 'be, let it ');
+    expect(line1Items[2]).toBeChordLyricsPair('C', 'be');
   });
 });

--- a/test/parser/chords_over_words_parser.test.ts
+++ b/test/parser/chords_over_words_parser.test.ts
@@ -407,4 +407,64 @@ Let it   be, let it be
       expect(line1Pairs[3]).toBeChordLyricsPair('C/G', 'be');
     });
   });
+
+  it('support CR line endings', () => {
+    const chordSheet = '       Am         C/G\rLet it be, let it be,\r       F          C\rlet it be, let it be';
+
+    const parser = new ChordsOverWordsParser();
+    const song = parser.parse(chordSheet);
+    const { lines } = song;
+    const [{ items: line0Items }, { items: line1Items }] = lines;
+
+    expect(lines).toHaveLength(2);
+
+    expect(line0Items[0]).toBeChordLyricsPair('', 'Let it ');
+    expect(line0Items[1]).toBeChordLyricsPair('Am', 'be, ');
+    expect(line0Items[2]).toBeChordLyricsPair('', 'let it ');
+    expect(line0Items[3]).toBeChordLyricsPair('C/G', 'be,');
+    expect(line1Items[0]).toBeChordLyricsPair('', 'let it ');
+    expect(line1Items[1]).toBeChordLyricsPair('F', 'be, ');
+    expect(line1Items[2]).toBeChordLyricsPair('', 'let it ');
+    expect(line1Items[3]).toBeChordLyricsPair('C', 'be');
+  });
+
+  it('support LF line endings', () => {
+    const chordSheet = '       Am         C/G\nLet it be, let it be,\n       F          C\nlet it be, let it be';
+
+    const parser = new ChordsOverWordsParser();
+    const song = parser.parse(chordSheet);
+    const { lines } = song;
+    const [{ items: line0Items }, { items: line1Items }] = lines;
+
+    expect(lines).toHaveLength(2);
+
+    expect(line0Items[0]).toBeChordLyricsPair('', 'Let it ');
+    expect(line0Items[1]).toBeChordLyricsPair('Am', 'be, ');
+    expect(line0Items[2]).toBeChordLyricsPair('', 'let it ');
+    expect(line0Items[3]).toBeChordLyricsPair('C/G', 'be,');
+    expect(line1Items[0]).toBeChordLyricsPair('', 'let it ');
+    expect(line1Items[1]).toBeChordLyricsPair('F', 'be, ');
+    expect(line1Items[2]).toBeChordLyricsPair('', 'let it ');
+    expect(line1Items[3]).toBeChordLyricsPair('C', 'be');
+  });
+
+  it('support CRLF line endings', () => {
+    const chordSheet = '       Am         C/G\r\nLet it be, let it be,\r\n       F          C\r\nlet it be, let it be';
+
+    const parser = new ChordsOverWordsParser();
+    const song = parser.parse(chordSheet);
+    const { lines } = song;
+    const [{ items: line0Items }, { items: line1Items }] = lines;
+
+    expect(lines).toHaveLength(2);
+
+    expect(line0Items[0]).toBeChordLyricsPair('', 'Let it ');
+    expect(line0Items[1]).toBeChordLyricsPair('Am', 'be, ');
+    expect(line0Items[2]).toBeChordLyricsPair('', 'let it ');
+    expect(line0Items[3]).toBeChordLyricsPair('C/G', 'be,');
+    expect(line1Items[0]).toBeChordLyricsPair('', 'let it ');
+    expect(line1Items[1]).toBeChordLyricsPair('F', 'be, ');
+    expect(line1Items[2]).toBeChordLyricsPair('', 'let it ');
+    expect(line1Items[3]).toBeChordLyricsPair('C', 'be');
+  });
 });

--- a/test/parser/ultimate_guitar_parser.test.ts
+++ b/test/parser/ultimate_guitar_parser.test.ts
@@ -1,9 +1,6 @@
 import fs from 'fs';
 
-import {
-  UltimateGuitarParser,
-  ChordProFormatter,
-} from '../../src';
+import { UltimateGuitarParser, ChordProFormatter } from '../../src';
 
 import '../matchers';
 
@@ -74,7 +71,7 @@ F  C Dm
     expect(line2Items.length).toEqual(0);
   });
 
-  it('parses entire chordsheet with several sections correctly', () => {
+  it('parses entire chord sheet with several sections correctly', () => {
     const chordSheet = fs.readFileSync('./test/fixtures/ultimate_guitar_chordsheet.txt', 'utf8');
     const expected = fs.readFileSync('./test/fixtures/ultimate_guitar_chordsheet_expected_chordpro_format.txt', 'utf8');
 
@@ -83,5 +80,59 @@ F  C Dm
     const result = new ChordProFormatter().format(song);
 
     expect(result).toEqual(expected);
+  });
+
+  it('support CR line endings', () => {
+    const chordSheet = '       Am         C/G\rLet it be, let it be,\r       F          C\rlet it be, let it be';
+
+    const parser = new UltimateGuitarParser();
+    const song = parser.parse(chordSheet);
+    const { lines } = song;
+    const [{ items: line0Items }, { items: line1Items }] = lines;
+
+    expect(lines).toHaveLength(2);
+
+    expect(line0Items[0]).toBeChordLyricsPair('      ', 'Let it ');
+    expect(line0Items[1]).toBeChordLyricsPair('Am        ', 'be, let it ');
+    expect(line0Items[2]).toBeChordLyricsPair('C/G', 'be,');
+    expect(line1Items[0]).toBeChordLyricsPair('      ', 'let it ');
+    expect(line1Items[1]).toBeChordLyricsPair('F         ', 'be, let it ');
+    expect(line1Items[2]).toBeChordLyricsPair('C', 'be');
+  });
+
+  it('support LF line endings', () => {
+    const chordSheet = '       Am         C/G\nLet it be, let it be,\n       F          C\nlet it be, let it be';
+
+    const parser = new UltimateGuitarParser();
+    const song = parser.parse(chordSheet);
+    const { lines } = song;
+    const [{ items: line0Items }, { items: line1Items }] = lines;
+
+    expect(lines).toHaveLength(2);
+
+    expect(line0Items[0]).toBeChordLyricsPair('      ', 'Let it ');
+    expect(line0Items[1]).toBeChordLyricsPair('Am        ', 'be, let it ');
+    expect(line0Items[2]).toBeChordLyricsPair('C/G', 'be,');
+    expect(line1Items[0]).toBeChordLyricsPair('      ', 'let it ');
+    expect(line1Items[1]).toBeChordLyricsPair('F         ', 'be, let it ');
+    expect(line1Items[2]).toBeChordLyricsPair('C', 'be');
+  });
+
+  it('support CRLF line endings', () => {
+    const chordSheet = '       Am         C/G\r\nLet it be, let it be,\r\n       F          C\r\nlet it be, let it be';
+
+    const parser = new UltimateGuitarParser();
+    const song = parser.parse(chordSheet);
+    const { lines } = song;
+    const [{ items: line0Items }, { items: line1Items }] = lines;
+
+    expect(lines).toHaveLength(2);
+
+    expect(line0Items[0]).toBeChordLyricsPair('      ', 'Let it ');
+    expect(line0Items[1]).toBeChordLyricsPair('Am        ', 'be, let it ');
+    expect(line0Items[2]).toBeChordLyricsPair('C/G', 'be,');
+    expect(line1Items[0]).toBeChordLyricsPair('      ', 'let it ');
+    expect(line1Items[1]).toBeChordLyricsPair('F         ', 'be, let it ');
+    expect(line1Items[2]).toBeChordLyricsPair('C', 'be');
   });
 });


### PR DESCRIPTION
This makes sure all parsers are able to parse documents with any type of line endings:

- CR (\r)
- LF (\n)
- CRLF (\r\n)

Resolves #545