### PR TITLE
Allow whitespace for `Chord.parse()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1388,13 +1388,14 @@ of the root note. For example, <code>Em/A#</code> becomes <code>Em/Bb</code>.</p
 <a name="Chord.parse"></a>
 
 ### Chord.parse(chordString) ⇒ [<code>Chord</code>](#Chord) \| <code>null</code>
-<p>Tries to parse a chord string into a chord</p>
+<p>Tries to parse a chord string into a chord
+Any leading or trailing whitespace is removed first, so a chord like <code> \n  E/G# \r</code> is valid.</p>
 
 **Kind**: static method of [<code>Chord</code>](#Chord)  
 
 | Param | Description |
 | --- | --- |
-| chordString | <p>the chord string, eg <code>Esus4/G#</code> or <code>1sus4/#3</code></p> |
+| chordString | <p>the chord string, eg <code>Esus4/G#</code> or <code>1sus4/#3</code>.</p> |
 
 <a name="ChordSheetSerializer"></a>
 

--- a/src/chord.ts
+++ b/src/chord.ts
@@ -36,7 +36,8 @@ class Chord implements ChordProperties {
 
   /**
    * Tries to parse a chord string into a chord
-   * @param chordString the chord string, eg `Esus4/G#` or `1sus4/#3`
+   * Any leading or trailing whitespace is removed first, so a chord like `  \n  E/G# \r ` is valid.
+   * @param chordString the chord string, eg `Esus4/G#` or `1sus4/#3`.
    * @returns {Chord|null}
    */
   static parse(chordString: string): Chord | null {
@@ -48,7 +49,7 @@ class Chord implements ChordProperties {
   }
 
   static parseOrFail(chordString: string): Chord {
-    const ast = parse(chordString);
+    const ast = parse(chordString.trim());
     return new Chord(ast);
   }
 

--- a/test/chord_symbol/parse.test.ts
+++ b/test/chord_symbol/parse.test.ts
@@ -91,6 +91,13 @@ describe('Chord', () => {
           });
         });
       });
+
+      it('allows whitespace', () => {
+        const chord = Chord.parse(' \n F#/C# \r ');
+        expect(chord).toBeChord({
+          base: 'F', modifier: '#', suffix: null, bassBase: 'C', bassModifier: '#',
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
`Chord.parse()` allows any kind of leading or trailing whitespace.

Resolves #495