### PR TITLE
Allow passing rendering key to formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1114,6 +1114,7 @@ https://chordpro.org/chordpro/directives-env_bridge/, https://chordpro.org/chord
 | [configuration.evaluate] | <code>boolean</code> | <code>false</code> | <p>Whether or not to evaluate meta expressions. For more info about meta expressions, see: https://bit.ly/2SC9c2u</p> |
 | [configuration.metadata] | <code>object</code> | <code>{}</code> |  |
 | [configuration.metadata.separator] | <code>string</code> | <code>&quot;\&quot;, \&quot;&quot;</code> | <p>The separator to be used when rendering a metadata value that has multiple values. See: https://bit.ly/2SC9c2u</p> |
+| [configuration.key] | [<code>Key</code>](#Key) \| <code>string</code> | <code></code> | <p>The key to use for rendering. The chord sheet will be transposed from the song's original key (as indicated by the <code>{key}</code> directive) to the specified key. Note that transposing will only work if the original song key is set.</p> |
 
 <a name="HtmlDivFormatter"></a>
 

--- a/src/chord.ts
+++ b/src/chord.ts
@@ -237,7 +237,7 @@ class Chord implements ChordProperties {
   normalize(key: Key | string | null = null, { normalizeSuffix = true } = {}): Chord {
     const suffix = normalizeSuffix ? normalizeChordSuffix(this.suffix) : this.suffix;
 
-    let bassRootKey = this.root.normalize();
+    let bassRootKey = this.root.normalize().normalizeEnharmonics(key);
     if (this.root.isMinor() && this.bass) {
       bassRootKey = this.root.transpose(3).removeMinor().normalize();
     }

--- a/src/formatter/configuration/configuration.ts
+++ b/src/formatter/configuration/configuration.ts
@@ -1,20 +1,28 @@
 import lodashGet from 'lodash.get';
 
 import MetadataConfiguration from './metadata_configuration';
+import Key from '../../key';
 
 export type ConfigurationProperties = Record<string, any> & {
   evaluate?: boolean,
   metadata?: {
     separator: string,
   },
+  key?: Key | string | null,
 }
 
-export const defaultConfiguration: ConfigurationProperties = { evaluate: false, metadata: { separator: ',' } };
+export const defaultConfiguration: ConfigurationProperties = {
+  evaluate: false,
+  metadata: { separator: ',' },
+  key: null,
+};
 
 class Configuration {
   metadata: MetadataConfiguration;
 
   evaluate: boolean;
+
+  key: Key | null;
 
   configuration: Record<string, any>;
 
@@ -26,6 +34,7 @@ class Configuration {
     }
 
     this.metadata = new MetadataConfiguration(configuration.metadata);
+    this.key = configuration.key ? Key.wrap(configuration.key) : null;
     this.configuration = configuration;
   }
 

--- a/src/formatter/formatter.ts
+++ b/src/formatter/formatter.ts
@@ -14,6 +14,10 @@ class Formatter {
      * @param {object} [configuration.metadata={}]
      * @param {string} [configuration.metadata.separator=", "] The separator to be used when rendering a metadata value
      * that has multiple values. See: https://bit.ly/2SC9c2u
+     * @param {Key|string} [configuration.key=null] The key to use for rendering. The chord sheet will be transposed
+     * from the song's original key (as indicated by the `{key}` directive) to the specified key.
+     * Note that transposing will only work
+     * if the original song key is set.
      */
   constructor(configuration: ConfigurationProperties | null = null) {
     this.configuration = new Configuration(configuration || {});

--- a/src/formatter/templates/html_div_formatter.ts
+++ b/src/formatter/templates/html_div_formatter.ts
@@ -18,6 +18,9 @@ import {
 export default (
   {
     configuration,
+    configuration: {
+      key,
+    },
     song,
     renderBlankLines = false,
     song: {
@@ -40,7 +43,7 @@ export default (
               ${ each(line.items, (item) => `
                 ${ when(isChordLyricsPair(item), () => `
                   <div class="column">
-                    ${ keep([renderChord(item.chords, line, song)], ([renderedChord]) => `
+                    ${ keep([renderChord(item.chords, line, song, key)], ([renderedChord]) => `
                       <div class="chord"${ renderedChord ? fontStyleTag(line.chordFont) : '' }>${ renderedChord }</div>
                     `) }
                     <div class="lyrics"${ item.lyrics ? fontStyleTag(line.textFont) : '' }>${ item.lyrics }</div>

--- a/src/formatter/templates/html_table_formatter.ts
+++ b/src/formatter/templates/html_table_formatter.ts
@@ -19,6 +19,9 @@ import {
 export default (
   {
     configuration,
+    configuration: {
+      key,
+    },
     song,
     renderBlankLines = false,
     song: {
@@ -45,7 +48,7 @@ export default (
                     ${ each(line.items, (item) => `
                       ${ when(isChordLyricsPair(item), () => `
                         <td class="chord">${ 
-                          renderChord(item.chords, line, song)
+                          renderChord(item.chords, line, song, key)
                         }</td>
                       `)}
                     `)}

--- a/src/formatter/text_formatter.ts
+++ b/src/formatter/text_formatter.ts
@@ -93,7 +93,7 @@ class TextFormatter extends Formatter {
   }
 
   chordLyricsPairLength(chordLyricsPair: ChordLyricsPair, line: Line): number {
-    const chords = renderChord(chordLyricsPair.chords, line, this.song);
+    const chords = renderChord(chordLyricsPair.chords, line, this.song, this.configuration.key);
     const { lyrics } = chordLyricsPair;
     const chordsLength = (chords || '').length;
     const lyricsLength = (lyrics || '').length;
@@ -111,7 +111,7 @@ class TextFormatter extends Formatter {
     }
 
     if (item instanceof ChordLyricsPair) {
-      const chords = renderChord(item.chords, line, this.song);
+      const chords = renderChord(item.chords, line, this.song, this.configuration.key);
       return padLeft(chords, this.chordLyricsPairLength(item, line));
     }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -13,16 +13,23 @@ export function transposeDistance(transposeKey: string, songKey: string): number
   return Key.distance(songKey, transposeKey);
 }
 
-function chordTransposeDistance(capo: number, transposeKey: string | null, songKey: string) {
+function chordTransposeDistance(capo: number, transposeKey: string | null, songKey: string, renderKey: Key | null) {
   let transpose = -1 * (capo || 0);
 
-  if (transposeKey && songKey) {
-    transpose += transposeDistance(transposeKey, songKey);
+  if (songKey) {
+    if (transposeKey) {
+      transpose += transposeDistance(transposeKey, songKey);
+    }
+
+    if (renderKey) {
+      transpose += Key.distance(songKey, renderKey);
+    }
   }
+
   return transpose;
 }
 
-export function renderChord(chordString: string, line: Line, song: Song): string {
+export function renderChord(chordString: string, line: Line, song: Song, renderKey: Key | null = null): string {
   const chord = Chord.parse(chordString);
   const songKey = song.key;
   const capo = parseInt(song.metadata.getSingle(CAPO), 10);
@@ -31,8 +38,8 @@ export function renderChord(chordString: string, line: Line, song: Song): string
     return chordString;
   }
 
-  const effectiveTransposeDistance = chordTransposeDistance(capo, line.transposeKey, songKey);
-  const effectiveKey = Key.wrap(line.key || song.key)?.transpose(effectiveTransposeDistance) || null;
+  const effectiveTransposeDistance = chordTransposeDistance(capo, line.transposeKey, songKey, renderKey);
+  const effectiveKey = renderKey || Key.wrap(line.key || song.key)?.transpose(effectiveTransposeDistance) || null;
 
   return chord
     .transpose(effectiveTransposeDistance)

--- a/src/normalize_mappings/enharmonic-normalize.ts
+++ b/src/normalize_mappings/enharmonic-normalize.ts
@@ -27,6 +27,12 @@ const enharmonics: Record<string, Record<string, string>> = {
     'A#': 'Bb',
     'Gb': 'F#',
   },
+  'Eb': {
+    'D#': 'Eb',
+    'F#': 'Gb',
+    'G#': 'Ab',
+    'A#': 'Bb'
+  },
   'E': {
     'Ab': 'G#',
     'A#': 'Bb',

--- a/test/formatter/html_div_formatter.test.ts
+++ b/test/formatter/html_div_formatter.test.ts
@@ -290,4 +290,107 @@ describe('HtmlDivFormatter', () => {
 
     expect(new HtmlDivFormatter().format(songWithCapo)).toEqual(expectedChordSheet);
   });
+
+  it('can render in a different key', () => {
+    const expectedChordSheet = stripHTML(`
+      <h1>Let it be</h1>
+      <h2>ChordSheetJS example version</h2>
+      <div class="chord-sheet">
+        <div class="paragraph">
+          <div class="row">
+            <div class="column">
+              <div class="chord"></div>
+              <div class="lyrics">Written by: </div>
+            </div>
+            <div class="column">
+              <div class="chord"></div>
+              <div class="lyrics">John Lennon,Paul McCartney</div>
+            </div>
+          </div>
+        </div>
+        <div class="paragraph verse">
+          <div class="row">
+            <h3 class="label">Verse 1</h3>
+          </div>
+          <div class="row">
+            <div class="column">
+              <div class="chord"></div>
+              <div class="lyrics">Let it </div>
+            </div>
+            <div class="column">
+              <div class="chord">Cm</div>
+              <div class="lyrics">be, let it </div>
+            </div>
+            <div class="column">
+              <div class="chord">Eb/Bb</div>
+              <div class="lyrics">be, let it </div>
+            </div>
+            <div class="column">
+              <div class="chord">Ab</div>
+              <div class="lyrics">be, let it </div>
+            </div>
+            <div class="column">
+              <div class="chord">Eb</div>
+              <div class="lyrics">be</div>
+            </div>
+          </div>
+          <div class="row">
+            <div class="column">
+              <div class="chord">F</div>
+              <div class="lyrics">Whisper words of </div>
+            </div>
+            <div class="column">
+              <div class="chord">Bb</div>
+              <div class="lyrics">wis</div>
+            </div>
+            <div class="column">
+              <div class="chord">C</div>
+              <div class="lyrics">dom, let it </div>
+            </div>
+            <div class="column">
+              <div class="chord">Bb</div>
+              <div class="lyrics">be </div>
+            </div>
+            <div class="column">
+              <div class="chord">F/A</div>
+              <div class="lyrics"> </div>
+            </div>
+            <div class="column">
+              <div class="chord">Gm</div>
+              <div class="lyrics"> </div>
+            </div>
+            <div class="column">
+              <div class="chord">F</div>
+              <div class="lyrics"></div>
+            </div>
+          </div>
+        </div>
+        <div class="paragraph chorus">
+          <div class="row">
+            <div class="comment">Breakdown</div>
+          </div>
+          <div class="row">
+            <div class="column">
+              <div class="chord">Gm</div>
+              <div class="lyrics">Whisper words of </div>
+            </div>
+            <div class="column">
+              <div class="chord">Ab</div>
+              <div class="lyrics">wisdom, let it </div>
+            </div>
+            <div class="column">
+              <div class="chord">Eb</div>
+              <div class="lyrics">be </div>
+            </div>
+            <div class="column">
+              <div class="chord">Bb</div>
+              <div class="lyrics"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `);
+
+    expect(new HtmlDivFormatter({ key: 'Eb' }).format(song)).toEqual(expectedChordSheet);
+  });
 });

--- a/test/formatter/html_table_formatter.test.ts
+++ b/test/formatter/html_table_formatter.test.ts
@@ -285,4 +285,87 @@ td {
 
     expect(new HtmlTableFormatter().format(songWithCapo)).toEqual(expectedChordSheet);
   });
+
+  it('can render in a different key', () => {
+    const expectedChordSheet = stripHTML(`
+      <h1>Let it be</h1>
+      <h2>ChordSheetJS example version</h2>
+      <div class="chord-sheet">
+        <div class="paragraph">
+          <table class="row">
+            <tr>
+              <td class="lyrics">Written by: </td>
+              <td class="lyrics">John Lennon,Paul McCartney</td>
+            </tr>
+          </table>
+        </div>
+        <div class="paragraph verse">
+          <table class="row">
+            <tr>
+              <td><h3 class="label">Verse 1</h3></td>
+            </tr>
+          </table>
+          <table class="row">
+            <tr>
+              <td class="chord"></td>
+              <td class="chord">Cm</td>
+              <td class="chord">Eb/Bb</td>
+              <td class="chord">Ab</td>
+              <td class="chord">Eb</td>
+            </tr>
+            <tr>
+              <td class="lyrics">Let it </td>
+              <td class="lyrics">be, let it </td>
+              <td class="lyrics">be, let it </td>
+              <td class="lyrics">be, let it </td>
+              <td class="lyrics">be</td>
+            </tr>
+          </table>
+          <table class="row">
+            <tr>
+              <td class="chord">F</td>
+              <td class="chord">Bb</td>
+              <td class="chord">C</td>
+              <td class="chord">Bb</td>
+              <td class="chord">F/A</td>
+              <td class="chord">Gm</td>
+              <td class="chord">F</td>
+            </tr>
+            <tr>
+              <td class="lyrics">Whisper words of </td>
+              <td class="lyrics">wis</td>
+              <td class="lyrics">dom, let it </td>
+              <td class="lyrics">be </td>
+              <td class="lyrics"> </td>
+              <td class="lyrics"> </td>
+              <td class="lyrics"></td>
+            </tr>
+          </table>
+        </div>
+        <div class="paragraph chorus">
+          <table class="row">
+            <tr>
+              <td class="comment">Breakdown</td>
+            </tr>
+          </table>
+          <table class="row">
+            <tr>
+              <td class="chord">Gm</td>
+              <td class="chord">Ab</td>
+              <td class="chord">Eb</td>
+              <td class="chord">Bb</td>
+            </tr>
+            <tr>
+              <td class="lyrics">Whisper words of </td>
+              <td class="lyrics">wisdom, let it </td>
+              <td class="lyrics">be </td>
+              <td class="lyrics"></td>
+            </tr>
+          </table>
+        </div>
+      </div>
+    `);
+
+    expect(new HtmlTableFormatter({ key: 'Eb' }).format(song)).toEqual(expectedChordSheet);
+  });
 });

--- a/test/formatter/text_formatter.test.ts
+++ b/test/formatter/text_formatter.test.ts
@@ -55,4 +55,24 @@ My heart has always longed for something more`.substring(1);
 
     expect(new TextFormatter().format(songWithCapo)).toEqual(expectedChordSheet);
   });
+
+  it('can render in a different key', () => {
+    const expectedChordSheet = `
+LET IT BE
+ChordSheetJS example version
+
+Written by: John Lennon,Paul McCartney
+
+Verse 1
+       Cm         Eb/Bb      Ab         Eb
+Let it be, let it be, let it be, let it be
+F                Bb C           Bb F/A Gm F
+Whisper words of wisdom, let it be
+
+Breakdown
+Gm               Ab             Eb Bb
+Whisper words of wisdom, let it be`.substring(1);
+
+    expect(new TextFormatter({ key: 'Eb' }).format(song)).toEqual(expectedChordSheet);
+  });
 });

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,6 +1,7 @@
 import Song from '../src/chord_sheet/song';
 import { createLine } from './utilities';
 import { renderChord } from '../src/helpers';
+import Key from '../src/key';
 
 describe('renderChord', () => {
   it('correctly normalizes when a capo is set', () => {
@@ -10,5 +11,13 @@ describe('renderChord', () => {
     song.setMetadata('capo', '1');
 
     expect(renderChord('Dm7', line, song)).toEqual('C#m7');
+  });
+
+  it('can render in a different key', () => {
+    const line = createLine();
+    const song = new Song();
+    song.setMetadata('key', 'F');
+
+    expect(renderChord('Dm7', line, song, Key.parse('B'))).toEqual('G#m7');
   });
 });


### PR DESCRIPTION
This allows you to render a song in any key without transposing it.

For example:

Having a chordpro source:

```
{key: C}
Let it [Am]be let it [C/G]be
```

and rendering it with `{ key: 'Eb' }`:

```
const song = new ChordProParser().parse(chordpro);
const formatted = new TextFormatter({ key: 'Eb' });
```

Results in:

```
       Cm        Eb/Bb
Let it be let it be
```