### PR TITLE
Add font style tags to HTML table formatter

### DIFF
--- a/src/formatter/templates/html_div_formatter.ts
+++ b/src/formatter/templates/html_div_formatter.ts
@@ -43,9 +43,7 @@ export default (
               ${ each(line.items, (item) => `
                 ${ when(isChordLyricsPair(item), () => `
                   <div class="column">
-                    ${ keep([renderChord(item.chords, line, song, key)], ([renderedChord]) => `
-                      <div class="chord"${ fontStyleTag(line.chordFont) }>${ renderedChord }</div>
-                    `) }
+                    <div class="chord"${ fontStyleTag(line.chordFont) }>${ renderChord(item.chords, line, song, key) }</div>
                     <div class="lyrics"${ fontStyleTag(line.textFont) }>${ item.lyrics }</div>
                   </div>
                 `) }
@@ -63,10 +61,7 @@ export default (
                 ${ when(isEvaluatable(item), () => `
                   <div class="column">
                     <div class="chord"></div>
-                    
-                    ${ keep([evaluate(item, metadata, configuration)], ([evaluated]) => `
-                      <div class="lyrics"${ fontStyleTag(line.textFont) }>${ evaluated }</div>
-                    `) }
+                    <div class="lyrics"${ fontStyleTag(line.textFont) }>${ evaluate(item, metadata, configuration) }</div>
                   </div>
                 `) }
               `) }

--- a/src/formatter/templates/html_table_formatter.ts
+++ b/src/formatter/templates/html_table_formatter.ts
@@ -5,6 +5,7 @@ import { HtmlTemplateArgs } from '../html_formatter';
 import {
   each,
   evaluate,
+  fontStyleTag,
   hasTextContents,
   isChordLyricsPair,
   isComment,
@@ -47,9 +48,7 @@ export default (
                   <tr>
                     ${ each(line.items, (item) => `
                       ${ when(isChordLyricsPair(item), () => `
-                        <td class="chord">${ 
-                          renderChord(item.chords, line, song, key)
-                        }</td>
+                        <td class="chord"${fontStyleTag(line.chordFont)}>${ renderChord(item.chords, line, song, key) }</td>
                       `)}
                     `)}
                   </tr>
@@ -59,21 +58,21 @@ export default (
                   <tr>
                     ${ each(line.items, (item) => `
                       ${ when(isChordLyricsPair(item), () => `
-                        <td class="lyrics">${ item.lyrics}</td>
+                        <td class="lyrics"${fontStyleTag(line.textFont)}>${ item.lyrics}</td>
                       `)}
                       
                       ${ when(isTag(item), () => `
                         ${ when(isComment(item), () => `
-                          <td class="comment">${ item.value }</td>
+                          <td class="comment"${fontStyleTag(line.textFont)}>${ item.value }</td>
                         `) }
                         
                         ${ when(item.hasRenderableLabel(), () => `
-                          <td><h3 class="label">${ item.value }</h3></td>
+                          <td><h3 class="label"${fontStyleTag(line.textFont)}>${ item.value }</h3></td>
                         `) }
                       `) }
                       
                       ${ when(isEvaluatable(item), () => `
-                        <td class="lyrics">${ evaluate(item, metadata, configuration) }</td>
+                        <td class="lyrics"${fontStyleTag(line.textFont)}>${ evaluate(item, metadata, configuration) }</td>
                       `) }
                     `)}
                   </tr>

--- a/test/integration/chord_pro_to_html_table.test.ts
+++ b/test/integration/chord_pro_to_html_table.test.ts
@@ -1,4 +1,5 @@
 import { ChordProParser, HtmlTableFormatter } from '../../src';
+import { stripHTML } from '../../src/template_helpers';
 
 describe('chordpro to HTML with TABLEs', () => {
   it('correctly parses and formats meta expressions', () => {
@@ -59,5 +60,84 @@ describe('chordpro to HTML with TABLEs', () => {
     const formatted = new HtmlTableFormatter().format(song);
 
     expect(formatted).toEqual('');
+  });
+
+  it('renders style attributes for chord/text font, size and color', () => {
+    const chordProSheet = `
+{chordfont: "Times New Roman"}
+{chordfont: sans-serif}
+{chordsize: 12}
+{chordsize: 200%}
+{chordsize: 125%}
+{chordcolour: red}
+{chordcolour: blue}
+{chordcolour: green}
+[Em]30px green sans-serif
+{chordcolour}
+{chordsize}
+[Am]24px blue sans-serif
+{chordsize}
+{chordcolour}
+{chordfont}
+{textcolour: green}
+[Am][Dm]12px red "Times New Roman"
+{textcolour}
+{chordsize}
+{chordcolour}
+{chordfont}
+[Gm]No styles`.substring(1);
+
+    const expectedChordSheet = stripHTML(`
+      <div class="chord-sheet">
+        <div class="paragraph">
+          <table class="row">
+            <tr>
+              <td class="chord" style="color: green; font: 30px sans-serif">Em</td>
+              <td class="chord" style="color: green; font: 30px sans-serif"></td>
+            </tr>
+            <tr>
+              <td class="lyrics">30px </td>
+              <td class="lyrics">green sans-serif</td>
+            </tr>
+          </table>
+          <table class="row">
+            <tr>
+              <td class="chord" style="color: blue; font: 24px sans-serif">Am</td>
+              <td class="chord" style="color: blue; font: 24px sans-serif"></td>
+            </tr>
+            <tr>
+              <td class="lyrics">24px </td>
+              <td class="lyrics">blue sans-serif</td>
+            </tr>
+          </table>
+          <table class="row">
+            <tr>
+              <td class="chord" style="color: red; font: 12px 'Times New Roman'">Am</td>
+              <td class="chord" style="color: red; font: 12px 'Times New Roman'">Dm</td>
+              <td class="chord" style="color: red; font: 12px 'Times New Roman'"></td>
+            </tr>
+            <tr>
+              <td class="lyrics" style="color: green"></td>
+              <td class="lyrics" style="color: green">12px </td>
+              <td class="lyrics" style="color: green">red "Times New Roman"</td>
+            </tr>
+          </table>
+          <table class="row">
+            <tr>
+              <td class="chord">Gm</td>
+              <td class="chord"></td>
+            </tr>
+            <tr>
+              <td class="lyrics">No </td>
+              <td class="lyrics">styles</td>
+            </tr>
+          </table>
+        </div>
+      </div>
+    `);
+
+    const song = new ChordProParser().parse(chordProSheet);
+    const formatted = new HtmlTableFormatter().format(song);
+    expect(formatted).toEqual(expectedChordSheet);
   });
 });


### PR DESCRIPTION
This PR adds HtmlTableFormatter support for the following directives:

- textfont, textsize, textcolour These configure the font used for lyrics. see: https://www.chordpro.org/chordpro/directives-props_text_legacy/
- chordfont, chordsize, chordcolour These configure the font used for chords. see: https://www.chordpro.org/chordpro/directives-props_chord_legacy/

All directives determine the styling for all lines that follow the directive, up until the styling is changed by a new directive or reset to the previous styling by using a directive without value (eg. `{chordfont}`).

When parsing a `Song`,  every `Line` gets its `textFont` and `chordFont` property. Both are of type `Font`, which has properties for `font`, `size` and `colour`.

`HtmlDivFormatter` and `HtmlTableFormatter` add this styling to the HTML output. That means the directives need to have values that make sense in HTML world:

- font is a comma-separated list of fonts, the first that is supported by the browser/viewer will be used. Font names that consist of multiple words, like `Times New Roman` need to be quoted, for example: `{textfont: Verdana, "Times New Roman", sans-serif}` See also: https://developer.mozilla.org/en-US/docs/Web/CSS/font-family

- colour should have a color that is supported by browsers. See also: https://developer.mozilla.org/en-US/docs/Web/CSS/color

- size can be:
  - numeric, that will be treated as pixel values example: `{chordsize: 30}` (30px)
  - pixels: `{textsize: 12px}`
  - percentage, like `{textsize: 120%}`. If the previous size was expressed in pixels, this size will be calculated from that. For example:

    ``` {textsize: 12px} {textsize: 150%} This text will have font-size: 18px ```

    If pixels cannot be calculated, the new size will be a percentage:

    ``` {textsize: 150%} {textsize: 90%} This text will have font-size: 135% ```

Follow up on #18/#748