### PR TITLE
Add `normalizeChords` formatter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1128,6 +1128,7 @@ https://chordpro.org/chordpro/directives-env_bridge/, https://chordpro.org/chord
 | [configuration.key] | [<code>Key</code>](#Key) \| <code>string</code> | <code></code> | <p>The key to use for rendering. The chord sheet will be transposed from the song's original key (as indicated by the <code>{key}</code> directive) to the specified key. Note that transposing will only work if the original song key is set.</p> |
 | [configuration.expandChorusDirective] | <code>boolean</code> | <code>false</code> | <p>Whether or not to expand <code>{chorus}</code> directives by rendering the last defined chorus inline after the directive.</p> |
 | [configuration.useUnicodeModifiers] | <code>boolean</code> | <code>false</code> | <p>Whether or not to use unicode flat and sharp symbols.</p> |
+| [configuration.normalizeChords] | <code>boolean</code> | <code>true</code> | <p>Whether or not to automatically normalize chords</p> |
 
 <a name="HtmlDivFormatter"></a>
 

--- a/src/formatter/configuration/configuration.ts
+++ b/src/formatter/configuration/configuration.ts
@@ -11,6 +11,7 @@ export type ConfigurationProperties = Record<string, any> & {
   key?: Key | string | null,
   expandChorusDirective?: boolean,
   useUnicodeModifiers?: boolean,
+  normalizeChords?: boolean,
 }
 
 export const defaultConfiguration: ConfigurationProperties = {
@@ -19,6 +20,7 @@ export const defaultConfiguration: ConfigurationProperties = {
   key: null,
   expandChorusDirective: false,
   useUnicodeModifiers: false,
+  normalizeChords: true,
 };
 
 class Configuration {
@@ -34,11 +36,14 @@ class Configuration {
 
   useUnicodeModifiers: boolean;
 
+  normalizeChords: boolean;
+
   constructor(configuration: ConfigurationProperties = defaultConfiguration) {
     const mergedConfig: ConfigurationProperties = { ...defaultConfiguration, ...configuration };
     this.evaluate = !!mergedConfig.evaluate;
     this.expandChorusDirective = !!mergedConfig.expandChorusDirective;
     this.useUnicodeModifiers = !!mergedConfig.useUnicodeModifiers;
+    this.normalizeChords = !!mergedConfig.normalizeChords;
     this.metadata = new MetadataConfiguration(configuration.metadata);
     this.key = configuration.key ? Key.wrap(configuration.key) : null;
     this.configuration = configuration;

--- a/src/formatter/formatter.ts
+++ b/src/formatter/formatter.ts
@@ -9,18 +9,19 @@ class Formatter {
   /**
      * Instantiate
      * @param {Object} [configuration={}] options
-     * @param {boolean} [configuration.evaluate=false] Whether or not to evaluate meta expressions. For more info about
-     * meta expressions, see: https://bit.ly/2SC9c2u
+     * @param {boolean} [configuration.evaluate=false] Whether or not to evaluate meta expressions.
+     * For more info about meta expressions, see: https://bit.ly/2SC9c2u
      * @param {object} [configuration.metadata={}]
-     * @param {string} [configuration.metadata.separator=", "] The separator to be used when rendering a metadata value
-     * that has multiple values. See: https://bit.ly/2SC9c2u
-     * @param {Key|string} [configuration.key=null] The key to use for rendering. The chord sheet will be transposed
-     * from the song's original key (as indicated by the `{key}` directive) to the specified key.
-     * Note that transposing will only work
-     * if the original song key is set.
+     * @param {string} [configuration.metadata.separator=", "] The separator to be used when rendering a
+     * metadata value that has multiple values. See: https://bit.ly/2SC9c2u
+     * @param {Key|string} [configuration.key=null] The key to use for rendering. The chord sheet will be
+     * transposed from the song's original key (as indicated by the `{key}` directive) to the specified key.
+     * Note that transposing will only work if the original song key is set.
      * @param {boolean} [configuration.expandChorusDirective=false] Whether or not to expand `{chorus}` directives
      * by rendering the last defined chorus inline after the directive.
-     * @param {boolean} [configuration.useUnicodeModifiers=false] Whether or not to use unicode flat and sharp symbols.
+     * @param {boolean} [configuration.useUnicodeModifiers=false] Whether or not to use unicode flat and sharp
+     * symbols.
+     * @param {boolean} [configuration.normalizeChords=true] Whether or not to automatically normalize chords
      */
   constructor(configuration: ConfigurationProperties | null = null) {
     this.configuration = new Configuration(configuration || {});

--- a/src/formatter/templates/html_div_formatter.ts
+++ b/src/formatter/templates/html_div_formatter.ts
@@ -43,7 +43,18 @@ export default (
               ${ each(line.items, (item) => `
                 ${ when(isChordLyricsPair(item), () => `
                   <div class="column">
-                    <div class="chord"${ fontStyleTag(line.chordFont) }>${ renderChord(item.chords, line, song, { renderKey: key, useUnicodeModifier: configuration.useUnicodeModifiers }) }</div>
+                    <div class="chord"${ fontStyleTag(line.chordFont) }>${ 
+                      renderChord(
+                        item.chords, 
+                        line, 
+                        song, 
+                        {
+                          renderKey: key, 
+                          useUnicodeModifier: configuration.useUnicodeModifiers,
+                          normalizeChords: configuration.normalizeChords,
+                        }
+                      ) 
+                    }</div>
                     <div class="lyrics"${ fontStyleTag(line.textFont) }>${ item.lyrics }</div>
                   </div>
                 `) }

--- a/src/formatter/templates/html_table_formatter.ts
+++ b/src/formatter/templates/html_table_formatter.ts
@@ -48,7 +48,18 @@ export default (
                   <tr>
                     ${ each(line.items, (item) => `
                       ${ when(isChordLyricsPair(item), () => `
-                        <td class="chord"${fontStyleTag(line.chordFont)}>${ renderChord(item.chords, line, song, { renderKey: key, useUnicodeModifier: configuration.useUnicodeModifiers }) }</td>
+                        <td class="chord"${fontStyleTag(line.chordFont)}>${ 
+                          renderChord(
+                            item.chords, 
+                            line, 
+                            song, 
+                            { 
+                              renderKey: key, 
+                              useUnicodeModifier: configuration.useUnicodeModifiers,
+                              normalizeChords: configuration.normalizeChords,
+                            },
+                          ) 
+                        }</td>
                       `)}
                     `)}
                   </tr>

--- a/src/formatter/text_formatter.ts
+++ b/src/formatter/text_formatter.ts
@@ -94,7 +94,7 @@ class TextFormatter extends Formatter {
   }
 
   chordLyricsPairLength(chordLyricsPair: ChordLyricsPair, line: Line): number {
-    const chords = renderChord(chordLyricsPair.chords, line, this.song, { renderKey: this.configuration.key });
+    const chords = this.renderChords(chordLyricsPair, line);
     const { lyrics } = chordLyricsPair;
     const chordsLength = (chords || '').length;
     const lyricsLength = (lyrics || '').length;
@@ -106,21 +106,27 @@ class TextFormatter extends Formatter {
     return Math.max(chordsLength, lyricsLength);
   }
 
+  private renderChords(chordLyricsPair: ChordLyricsPair, line: Line) {
+    const chords = renderChord(
+      chordLyricsPair.chords,
+      line,
+      this.song,
+      {
+        renderKey: this.configuration.key,
+        useUnicodeModifier: this.configuration.useUnicodeModifiers,
+        normalizeChords: this.configuration.normalizeChords,
+      },
+    );
+    return chords;
+  }
+
   formatItemTop(item: Item, _metadata: Metadata, line: Line): string {
     if (item instanceof Tag && item.isRenderable()) {
       return item.value || '';
     }
 
     if (item instanceof ChordLyricsPair) {
-      const chords = renderChord(
-        item.chords,
-        line,
-        this.song,
-        {
-          renderKey: this.configuration.key,
-          useUnicodeModifier: this.configuration.useUnicodeModifiers,
-        },
-      );
+      const chords = this.renderChords(item, line);
       return padLeft(chords, this.chordLyricsPairLength(item, line));
     }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -32,6 +32,7 @@ function chordTransposeDistance(capo: number, transposeKey: string | null, songK
 interface RenderChordOptions {
   renderKey?: Key | null;
   useUnicodeModifier?: boolean;
+  normalizeChords?: boolean;
 }
 
 export function renderChord(
@@ -41,6 +42,7 @@ export function renderChord(
   {
     renderKey = null,
     useUnicodeModifier = false,
+    normalizeChords = true,
   }: RenderChordOptions = {},
 ): string {
   const chord = Chord.parse(chordString);
@@ -53,11 +55,10 @@ export function renderChord(
 
   const effectiveTransposeDistance = chordTransposeDistance(capo, line.transposeKey, songKey, renderKey);
   const effectiveKey = renderKey || Key.wrap(line.key || song.key)?.transpose(effectiveTransposeDistance) || null;
+  const transposedChord = chord.transpose(effectiveTransposeDistance);
+  const normalizedChord = (normalizeChords ? transposedChord.normalize(effectiveKey) : transposedChord);
 
-  return chord
-    .transpose(effectiveTransposeDistance)
-    .normalize(effectiveKey)
-    .toString({ useUnicodeModifier });
+  return normalizedChord.toString({ useUnicodeModifier });
 }
 
 /**

--- a/test/formatter/html_div_formatter.test.ts
+++ b/test/formatter/html_div_formatter.test.ts
@@ -434,4 +434,27 @@ describe('HtmlDivFormatter', () => {
       expect(formatter.format(songWithFlats)).toEqual(expectedChordSheet);
     });
   });
+
+  it('can skip chord normalization', () => {
+    const songWithSus2 = createSongFromAst([
+      [chordLyricsPair('Asus2', 'Let it be')],
+    ]);
+
+    const expectedHTML = stripHTML(`
+      <div class="chord-sheet">
+        <div class="paragraph">
+          <div class="row">
+            <div class="column">
+              <div class="chord">Asus2</div>
+              <div class="lyrics">Let it be</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `);
+
+    const formatted = new HtmlDivFormatter({ normalizeChords: false }).format(songWithSus2);
+
+    expect(formatted).toEqual(expectedHTML);
+  });
 });

--- a/test/formatter/html_table_formatter.test.ts
+++ b/test/formatter/html_table_formatter.test.ts
@@ -412,5 +412,30 @@ td {
 
       expect(formatter.format(songWithSharps)).toEqual(expectedChordSheet);
     });
+
+    it('can skip chord normalization', () => {
+      const songWithSus2 = createSongFromAst([
+        [chordLyricsPair('Asus2', 'Let it be')],
+      ]);
+
+      const expectedHTML = stripHTML(`
+        <div class="chord-sheet">
+          <div class="paragraph">
+            <table class="row">
+              <tr>
+                <td class="chord">Asus2</td>
+              </tr>
+              <tr>
+                <td class="lyrics">Let it be</td>
+              </tr>
+            </table>
+          </div>
+        </div>
+      `);
+
+      const formatted = new HtmlTableFormatter({ normalizeChords: false }).format(songWithSus2);
+
+      expect(formatted).toEqual(expectedHTML);
+    });
   });
 });

--- a/test/formatter/text_formatter.test.ts
+++ b/test/formatter/text_formatter.test.ts
@@ -93,4 +93,13 @@ The chords are in a broken key where sharps and flats are mixed`.substring(1);
 
     expect(new TextFormatter({ useUnicodeModifiers: true }).format(songWithCapo)).toEqual(expectedChordSheet);
   });
+
+  it('can skip chord normalization', () => {
+    const songWithSus2 = createSongFromAst([
+      [chordLyricsPair('Asus2', 'Let it be')],
+    ]);
+
+    const formatted = new TextFormatter({ normalizeChords: false }).format(songWithSus2);
+    expect(formatted).toEqual('Asus2\nLet it be');
+  });
 });


### PR DESCRIPTION
When instantiating a formatter with option `{ normalizeChords: false }`, automatic normalization is skipped and chords a rendered using their original suffix.

As requested by @kzkpro

Resolves #838