### PR TITLE
Skip deprecation warning for UltimateGuitarParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ subject to breaking changes between major versions.
 <dd><p>Represents a chord with the corresponding (partial) lyrics</p></dd>
 <dt><a href="#Comment">Comment</a></dt>
 <dd><p>Represents a comment. See https://www.chordpro.org/chordpro/chordpro-file-format-specification/#overview</p></dd>
-<dt><a href="#Line">Line</a> : <code><a href="#Font">Font</a></code></dt>
+<dt><a href="#Line">Line</a></dt>
 <dd><p>Represents a line in a chord sheet, consisting of items of type ChordLyricsPair or Tag</p></dd>
 <dt><a href="#Metadata">Metadata</a></dt>
 <dd><p>Stores song metadata. Properties can be accessed using the get() method:</p>
@@ -453,10 +453,6 @@ Inherits from [ChordSheetParser](#ChordSheetParser)</p></dd>
 ## Members
 
 <dl>
-<dt><a href="#Font">Font</a> : <code>string</code> | <code>null</code></dt>
-<dd><p>The font color</p></dd>
-<dt><a href="#FontSize">FontSize</a> : <code>number</code></dt>
-<dd><p>The font size</p></dd>
 <dt><a href="#ALBUM">ALBUM</a> : <code>string</code></dt>
 <dd><p>Artist meta directive. See https://www.chordpro.org/chordpro/directives-artist/</p></dd>
 <dt><a href="#ARTIST">ARTIST</a> : <code>string</code></dt>
@@ -638,13 +634,12 @@ For a CSS string see [scopedCss](scopedCss)</p></dd>
 **Kind**: instance method of [<code>Comment</code>](#Comment)  
 <a name="Line"></a>
 
-## Line : [<code>Font</code>](#Font)
+## Line
 <p>Represents a line in a chord sheet, consisting of items of type ChordLyricsPair or Tag</p>
 
 **Kind**: global class  
 
-* [Line](#Line) : [<code>Font</code>](#Font)
-    * [new Line()](#new_Line_new)
+* [Line](#Line)
     * [.isEmpty()](#Line+isEmpty) ⇒ <code>boolean</code>
     * [.addItem(item)](#Line+addItem)
     * [.hasRenderableItems()](#Line+hasRenderableItems) ⇒ <code>boolean</code>
@@ -652,13 +647,6 @@ For a CSS string see [scopedCss](scopedCss)</p></dd>
     * [.isVerse()](#Line+isVerse) ⇒ <code>boolean</code>
     * [.isChorus()](#Line+isChorus) ⇒ <code>boolean</code>
     * ~~[.hasContent()](#Line+hasContent) ⇒ <code>boolean</code>~~
-
-<a name="new_Line_new"></a>
-
-### new Line()
-<p>The chord font that applies to this line. Is derived from the directives:
-<code>chordfont</code>, <code>chordsize</code> and <code>chordcolour</code>
-See: https://www.chordpro.org/chordpro/directives-props_chord_legacy/</p>
 
 <a name="Line+isEmpty"></a>
 
@@ -762,16 +750,9 @@ else it returns an array of strings.</p>
 **Kind**: global class  
 
 * [Paragraph](#Paragraph)
-    * [.addLine](#Paragraph+addLine) : [<code>Array.&lt;Line&gt;</code>](#Line)
     * [.type](#Paragraph+type) ⇒ <code>string</code>
     * [.hasRenderableItems()](#Paragraph+hasRenderableItems) ⇒ <code>boolean</code>
 
-<a name="Paragraph+addLine"></a>
-
-### paragraph.addLine : [<code>Array.&lt;Line&gt;</code>](#Line)
-<p>The [Line](#Line) items of which the paragraph consists</p>
-
-**Kind**: instance property of [<code>Paragraph</code>](#Paragraph)  
 <a name="Paragraph+type"></a>
 
 ### paragraph.type ⇒ <code>string</code>
@@ -1406,6 +1387,17 @@ Whisper words of wisdom, let it be
 Inherits from [ChordSheetParser](#ChordSheetParser)</p>
 
 **Kind**: global class  
+<a name="new_UltimateGuitarParser_new"></a>
+
+### new UltimateGuitarParser([options])
+<p>Instantiate a chord sheet parser</p>
+
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [options] | <code>Object</code> | <code>{}</code> | <p>options</p> |
+| [options.preserveWhitespace] | <code>boolean</code> | <code>true</code> | <p>whether to preserve trailing whitespace for chords</p> |
+
 <a name="Chord"></a>
 
 ## Chord
@@ -1684,64 +1676,6 @@ Can be deserialized using [deserialize](deserialize)</p>
 | oneKey | [<code>Key</code>](#Key) \| <code>string</code> | <p>the key</p> |
 | otherKey | [<code>Key</code>](#Key) \| <code>string</code> | <p>the other key</p> |
 
-<a name="Font"></a>
-
-## Font : <code>string</code> \| <code>null</code>
-<p>The font color</p>
-
-**Kind**: global variable  
-<a name="Font+toCssString"></a>
-
-### font.toCssString() ⇒ <code>string</code>
-<p>Converts the font, size and color to a CSS string.
-If possible, font and size are combined to the <code>font</code> shorthand.
-If <code>font</code> contains double quotes (<code>&quot;</code>) those will be converted to single quotes (<code>'</code>).</p>
-
-**Kind**: instance method of [<code>Font</code>](#Font)  
-**Returns**: <code>string</code> - <p>The CSS string</p>  
-**Example**  
-```js
-// Returns "font-family: 'Times New Roman'"
-new Font({ font: '"Times New Roman"' }).toCssString()
-```
-**Example**  
-```js
-// Returns "color: red; font-family: Verdana"
-new Font({ font: 'Verdana', colour: 'red' }).toCssString()
-```
-**Example**  
-```js
-// Returns "font: 30px Verdana"
-new Font({ font: 'Verdana', size: '30' }).toCssString()
-```
-**Example**  
-```js
-// Returns "color: blue; font: 30% Verdana"
-new Font({ font: 'Verdana', size: '30%', colour: 'blue' }).toCssString()
-```
-<a name="FontSize"></a>
-
-## FontSize : <code>number</code>
-<p>The font size</p>
-
-**Kind**: global variable  
-<a name="FontSize+toString"></a>
-
-### fontSize.toString() ⇒ <code>string</code>
-<p>Stringifies the font size by concatenating size and unit</p>
-
-**Kind**: instance method of [<code>FontSize</code>](#FontSize)  
-**Returns**: <code>string</code> - <p>The font size</p>  
-**Example**  
-```js
-// Returns "30px"
-new FontSize(30, 'px').toString()
-```
-**Example**  
-```js
-// Returns "120%"
-new FontSize(120, '%').toString()
-```
 <a name="ALBUM"></a>
 
 ## ALBUM : <code>string</code>

--- a/src/parser/chord_sheet_parser.ts
+++ b/src/parser/chord_sheet_parser.ts
@@ -39,14 +39,20 @@ class ChordSheetParser {
    * @param {boolean} [options.preserveWhitespace=true] whether to preserve trailing whitespace for chords
    * @deprecated
    */
-  constructor({ preserveWhitespace = true }: { preserveWhitespace?: boolean } = {}) {
-    deprecate(
-      `ChordSheetParser is deprecated, please use ChordsOverWordsParser. 
+  constructor(
+    { preserveWhitespace = true }: { preserveWhitespace?: boolean } = {},
+    showDeprecationWarning: boolean = true,
+  ) {
+    if (showDeprecationWarning) {
+      deprecate(
+        `ChordSheetParser is deprecated, please use ChordsOverWordsParser.
 
-ChordsOverWordsParser aims to support any kind of chord, whereas ChordSheetParser lacks 
-support for many variations. Besides that, some chordpro feature have been ported back 
-to ChordsOverWordsParser, which adds some interesting functionality.`,
-    );
+  ChordsOverWordsParser aims to support any kind of chord, whereas ChordSheetParser lacks
+  support for many variations. Besides that, some chordpro feature have been ported back
+  to ChordsOverWordsParser, which adds some interesting functionality.`,
+      );
+    }
+
     this.preserveWhitespace = preserveWhitespace;
   }
 

--- a/src/parser/ultimate_guitar_parser.ts
+++ b/src/parser/ultimate_guitar_parser.ts
@@ -30,6 +30,15 @@ const endSectionTags = {
 class UltimateGuitarParser extends ChordSheetParser {
   currentSectionType: string | null = null;
 
+  /**
+   * Instantiate a chord sheet parser
+   * @param {Object} [options={}] options
+   * @param {boolean} [options.preserveWhitespace=true] whether to preserve trailing whitespace for chords
+   */
+  constructor({ preserveWhitespace = true }: { preserveWhitespace?: boolean } = {}) {
+    super({ preserveWhitespace }, false);
+  }
+
   parseLine(line): void {
     if (this.isSectionEnd()) {
       this.endSection();


### PR DESCRIPTION
`UltimateGuitarParser` inherits from `ChordSheetParser`. `ChordSheetParser` is deprecated in favor of `ChordsOverWordsParser`, but there is no alternative yet for `UltimateGuitarParser`. Let's mute the deprecation warning for now.

Resolves #922