### PR TITLE
Replace deprecated API in README with new API (and fix typo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Let it be, let it be, let it be, let it be
 C                G              F  C/E Dm C
 Whisper words of wisdom, let it be`.substring(1);
 
-const parser = new ChordSheetJS.ChordSheetParser();
+const parser = new ChordSheetJS.ChordsOverWordsParser();
 const song = parser.parse(chordSheet);
 ```
 
@@ -158,19 +158,19 @@ HtmlTableFormatter.cssObject();
 ### Parsing and modifying chords
 
 ```javascript
-import { parseChord } from 'chordsheetjs';
+import { Chord } from 'chordsheetjs';
 ```
 
 #### Parse
 
 ```javascript
-const chord = parseChord('Ebsus4/Bb');
+const chord = Chord.parse('Ebsus4/Bb');
 ```
 
 Parse numeric chords (Nashville system):
 
 ```javascript
-const chord = parseChord('b1sus4/#3');
+const chord = Chord.parse('b1sus4/#3');
 ```
 
 #### Display with #toString
@@ -178,7 +178,7 @@ const chord = parseChord('b1sus4/#3');
 Use #toString() to convert the chord to a chord string (eg Dsus/F#)
 
 ```javascript
-const chord = parseChord('Ebsus4/Bb');
+const chord = Chord.parse('Ebsus4/Bb');
 chord.toString(); // --> "Ebsus4/Bb"
 ```
 
@@ -193,12 +193,14 @@ var chord2 = chord.clone();
 Normalizes keys B#, E#, Cb and Fb to C, F, B and E
 
 ```javascript
-const chord = parseChord('E#/B#'),
+const chord = Chord.parse('E#/B#');
 normalizedChord = chord.normalize();
 normalizedChord.toString(); // --> "F/C"
 ```
 
-#### Switch modifier
+#### ~~Switch modifier~~
+
+***Deprecated***
 
 Convert # to b and vice versa
 
@@ -213,13 +215,13 @@ chord2.toString(); // --> "D#/A#"
 Set the chord to a specific modifier (# or b)
 
 ```javascript
-const chord = parseChord('Eb/Bb');
+const chord = Chord.parse('Eb/Bb');
 const chord2 = chord.useModifier('#');
 chord2.toString(); // --> "D#/A#"
 ```
 
 ```javascript
-const chord = parseChord('Eb/Bb');
+const chord = Chord.parse('Eb/Bb');
 const chord2 = chord.useModifier('b');
 chord2.toString(); // --> "Eb/Bb"
 ```
@@ -227,7 +229,7 @@ chord2.toString(); // --> "Eb/Bb"
 #### Transpose up
 
 ```javascript
-const chord = parseChord('Eb/Bb');
+const chord = Chord.parse('Eb/Bb');
 const chord2 = chord.transposeUp();
 chord2.toString(); // -> "E/B"
 ```
@@ -235,7 +237,7 @@ chord2.toString(); // -> "E/B"
 #### Transpose down
 
 ```javascript
-const chord = parseChord('Eb/Bb');
+const chord = Chord.parse('Eb/Bb');
 const chord2 = chord.transposeDown();
 chord2.toString(); // -> "D/A"
 ```
@@ -243,13 +245,13 @@ chord2.toString(); // -> "D/A"
 #### Transpose
 
 ```javascript
-const chord = parseChord('C/E');
+const chord = Chord.parse('C/E');
 const chord2 = chord.transpose(4);
 chord2.toString(); // -> "E/G#"
 ```
 
 ```javascript
-const chord = parseChord('C/E');
+const chord = Chord.parse('C/E');
 const chord2 = chord.transpose(-4);
 chord2.toString(); // -> "Ab/C"
 ```
@@ -257,9 +259,9 @@ chord2.toString(); // -> "Ab/C"
 #### Convert numeric chord to chord symbol
 
 ```javascript
-const numericChord = parseChord('2/4');
-const chordSymbol = toChordSymbol(numericChord, 'E');
-chordSymbol.toString(); // -> "F#m/A"
+const numericChord = Chord.parse('2/4');
+const chordSymbol = numericChord.toChordSymbol('E');
+chordSymbol.toString(); // -> "F#/A"
 ```
 
 ## Supported ChordPro directives

--- a/doc/README.hbs
+++ b/doc/README.hbs
@@ -58,7 +58,7 @@ Let it be, let it be, let it be, let it be
 C                G              F  C/E Dm C
 Whisper words of wisdom, let it be`.substring(1);
 
-const parser = new ChordSheetJS.ChordSheetParser();
+const parser = new ChordSheetJS.ChordsOverWordsParser();
 const song = parser.parse(chordSheet);
 ```
 
@@ -158,19 +158,19 @@ HtmlTableFormatter.cssObject();
 ### Parsing and modifying chords
 
 ```javascript
-import { parseChord } from 'chordsheetjs';
+import { Chord } from 'chordsheetjs';
 ```
 
 #### Parse
 
 ```javascript
-const chord = parseChord('Ebsus4/Bb');
+const chord = Chord.parse('Ebsus4/Bb');
 ```
 
 Parse numeric chords (Nashville system):
 
 ```javascript
-const chord = parseChord('b1sus4/#3');
+const chord = Chord.parse('b1sus4/#3');
 ```
 
 #### Display with #toString
@@ -178,7 +178,7 @@ const chord = parseChord('b1sus4/#3');
 Use #toString() to convert the chord to a chord string (eg Dsus/F#)
 
 ```javascript
-const chord = parseChord('Ebsus4/Bb');
+const chord = Chord.parse('Ebsus4/Bb');
 chord.toString(); // --> "Ebsus4/Bb"
 ```
 
@@ -193,12 +193,14 @@ var chord2 = chord.clone();
 Normalizes keys B#, E#, Cb and Fb to C, F, B and E
 
 ```javascript
-const chord = parseChord('E#/B#'),
+const chord = Chord.parse('E#/B#');
 normalizedChord = chord.normalize();
 normalizedChord.toString(); // --> "F/C"
 ```
 
-#### Switch modifier
+#### ~~Switch modifier~~
+
+***Deprecated***
 
 Convert # to b and vice versa
 
@@ -213,13 +215,13 @@ chord2.toString(); // --> "D#/A#"
 Set the chord to a specific modifier (# or b)
 
 ```javascript
-const chord = parseChord('Eb/Bb');
+const chord = Chord.parse('Eb/Bb');
 const chord2 = chord.useModifier('#');
 chord2.toString(); // --> "D#/A#"
 ```
 
 ```javascript
-const chord = parseChord('Eb/Bb');
+const chord = Chord.parse('Eb/Bb');
 const chord2 = chord.useModifier('b');
 chord2.toString(); // --> "Eb/Bb"
 ```
@@ -227,7 +229,7 @@ chord2.toString(); // --> "Eb/Bb"
 #### Transpose up
 
 ```javascript
-const chord = parseChord('Eb/Bb');
+const chord = Chord.parse('Eb/Bb');
 const chord2 = chord.transposeUp();
 chord2.toString(); // -> "E/B"
 ```
@@ -235,7 +237,7 @@ chord2.toString(); // -> "E/B"
 #### Transpose down
 
 ```javascript
-const chord = parseChord('Eb/Bb');
+const chord = Chord.parse('Eb/Bb');
 const chord2 = chord.transposeDown();
 chord2.toString(); // -> "D/A"
 ```
@@ -243,13 +245,13 @@ chord2.toString(); // -> "D/A"
 #### Transpose
 
 ```javascript
-const chord = parseChord('C/E');
+const chord = Chord.parse('C/E');
 const chord2 = chord.transpose(4);
 chord2.toString(); // -> "E/G#"
 ```
 
 ```javascript
-const chord = parseChord('C/E');
+const chord = Chord.parse('C/E');
 const chord2 = chord.transpose(-4);
 chord2.toString(); // -> "Ab/C"
 ```
@@ -257,9 +259,9 @@ chord2.toString(); // -> "Ab/C"
 #### Convert numeric chord to chord symbol
 
 ```javascript
-const numericChord = parseChord('2/4');
-const chordSymbol = toChordSymbol(numericChord, 'E');
-chordSymbol.toString(); // -> "F#m/A"
+const numericChord = Chord.parse('2/4');
+const chordSymbol = numericChord.toChordSymbol('E');
+chordSymbol.toString(); // -> "F#/A"
 ```
 
 ## Supported ChordPro directives


### PR DESCRIPTION
I accidentally closed my previous PR that was related to the README file (#923).

This PR likely addresses the issue you mentioned in #923 in [my own way](https://github.com/martijnversluis/ChordSheetJS/pull/923#issuecomment-1663868596). Please take a moment to review it and provide me with feedback.