### PR TITLE
Validate types file after build

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "ts-jest": "^27.1.4",
     "ts-node": "^10.7.0",
     "ts-pegjs": "^3.0.0",
+    "tsc": "^2.0.4",
     "typescript": "^4.6.3"
   },
   "scripts": {
@@ -63,7 +64,8 @@
     "build:code-generate": "yarn build:suffix-normalize && yarn build:chord-suffix-grammar && yarn build:pegjs && yarn build:scales",
     "build:sources": "parcel build",
     "build:browserify": "browserify lib/index.js --outfile lib/bundle.js --standalone ChordSheetJS",
-    "build": "yarn build:code-generate && yarn build:sources && yarn build:browserify",
+    "build:check-types": "tsc lib/main.d.ts",
+    "build": "yarn build:code-generate && yarn build:sources && yarn build:browserify && yarn build:check-types",
     "dev": "parcel watch --no-cache",
     "jest": "jest",
     "test": "yarn lint && yarn jest",

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,22 +20,6 @@ import TextFormatter from './formatter/text_formatter';
 import UltimateGuitarParser from './parser/ultimate_guitar_parser';
 
 import {
-  isEvaluatable,
-  isChordLyricsPair,
-  lineHasContents,
-  isTag,
-  isComment,
-  stripHTML,
-  each,
-  when,
-  hasTextContents,
-  lineClasses,
-  paragraphClasses,
-  evaluate,
-  fontStyleTag,
-} from './template_helpers';
-
-import {
   CHORUS,
   INDETERMINATE,
   NONE,
@@ -67,22 +51,7 @@ export { default as Tag } from './chord_sheet/tag';
 export { default as Ternary } from './chord_sheet/chord_pro/ternary';
 export { default as TextFormatter } from './formatter/text_formatter';
 export { default as UltimateGuitarParser } from './parser/ultimate_guitar_parser';
-
-export const templateHelpers = {
-  isEvaluatable,
-  isChordLyricsPair,
-  lineHasContents,
-  isTag,
-  isComment,
-  stripHTML,
-  each,
-  when,
-  hasTextContents,
-  lineClasses,
-  paragraphClasses,
-  evaluate,
-  fontStyleTag,
-};
+export { default as templateHelpers } from './template_helpers';
 
 export {
   CHORUS,
@@ -121,5 +90,4 @@ export default {
   TextFormatter,
   UltimateGuitarParser,
   VERSE,
-  templateHelpers,
 };

--- a/src/template_helpers.ts
+++ b/src/template_helpers.ts
@@ -81,3 +81,19 @@ export function fontStyleTag(font: Font) {
 
   return '';
 }
+
+export default {
+  isEvaluatable,
+  isChordLyricsPair,
+  lineHasContents,
+  isTag,
+  isComment,
+  stripHTML,
+  each,
+  when,
+  hasTextContents,
+  lineClasses,
+  paragraphClasses,
+  evaluate,
+  fontStyleTag,
+};

--- a/test/default_export.test.ts
+++ b/test/default_export.test.ts
@@ -24,7 +24,6 @@ describe('default export', () => {
     'INDETERMINATE',
     'VERSE',
     'NONE',
-    'templateHelpers',
   ].forEach((constantName) => {
     it(`contains ${constantName}`, () => {
       expect(typeof chordsheetjs[constantName]).not.toEqual('undefined');

--- a/yarn.lock
+++ b/yarn.lock
@@ -7496,6 +7496,11 @@ ts-pegjs@^3.0.0:
   resolved "https://registry.yarnpkg.com/ts-pegjs/-/ts-pegjs-3.1.0.tgz#a308135d9a4bbe62d89327024d91af7bc80c1ac9"
   integrity sha512-CZ80MYdzoh/setHAcrOdWh7ws4GsIPAahFEZ1019xPLe2snSzwuCLDAwQ0r7xHLIuOuRJ7v87jvz/Lr5YTLN4g==
 
+tsc@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/tsc/-/tsc-2.0.4.tgz#5f6499146abea5dca4420b451fa4f2f9345238f5"
+  integrity sha512-fzoSieZI5KKJVBYGvwbVZs/J5za84f2lSTLPYf6AGiIf43tZ3GNrI1QzTLcjtyDDP4aLxd46RTZq1nQxe7+k5Q==
+
 tsconfig-paths@^3.14.2:
   version "3.14.2"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz#6e32f1f79412decd261f92d633a9dc1cfa99f088"


### PR DESCRIPTION
Removes the `templateHelpers` property on the `default` export because it causes Typescript to generate a `main.d.ts` file which contains `import()` statements. 

This means that the following is no longer possible:

```js
import chordsheetjs from 'chordsheetjs';
const { templateHelpers } = chordsheetjs;
```

But this still works:

```js
import { templateHelpers } from 'chordsheetjs';
```

Resolves #988 