### PR TITLE
Refactor ChordsOverWordsParser lyrics handling to not use regex lookbehind

### DIFF
--- a/bin/generate_parser
+++ b/bin/generate_parser
@@ -25,4 +25,4 @@ const source = peggy.generate(input, {
   format: 'commonjs',
 });
 
-fs.writeFileSync(outputFile, `import print from 'print';\n\n${source}`);
+fs.writeFileSync(outputFile, `import { chopFirstWord } from './parser_helpers';\n\n${source}`);

--- a/src/parser/chords_over_words_grammar.pegjs
+++ b/src/parser/chords_over_words_grammar.pegjs
@@ -36,19 +36,19 @@ ChordLyricsLines
         const start = chord.column - 1;
         const end = nextChord ? nextChord.column - 1 : lyrics.length;
         const pairLyrics = lyrics.substring(start, end);
-        const result = /(\s+)(\S+)/.exec(pairLyrics);
-        const secondWordPosition = result ? (result.index + result[1].length) : null;
+
+        const [firstWord, rest] = chopFirstWord(pairLyrics);
 
         const chordData = (chord.type === "chord") ? { chord } : { chords: chord.value };
 
-        if (secondWordPosition && secondWordPosition < end) {
+        if (rest) {
           return [
-            { type: "chordLyricsPair", ...chordData, lyrics: pairLyrics.substring(0, secondWordPosition).trim() + " " },
-            { type: "chordLyricsPair", chords: "", lyrics: pairLyrics.substring(secondWordPosition) },
+            { type: "chordLyricsPair", ...chordData, lyrics: `${firstWord} ` },
+            { type: "chordLyricsPair", chords: "", lyrics: rest },
           ];
         }
-		    const trimmedLyrics = /.+\s+$/.test(pairLyrics) ? pairLyrics.trim() + " " : pairLyrics;
-        return { type: "chordLyricsPair", ...chordData, lyrics: trimmedLyrics };
+
+        return { type: "chordLyricsPair", ...chordData, lyrics: firstWord };
       }).flat();
 
       const firstChord = chords[0];

--- a/src/parser/chords_over_words_header.ts
+++ b/src/parser/chords_over_words_header.ts
@@ -11,18 +11,17 @@ function constructChordLyricsPairs(chords, lyrics) {
     const start = chord.column - 1;
     const end = nextChord ? nextChord.column - 1 : lyrics.length;
     const pairLyrics = lyrics.substring(start, end);
-    const secondWordPosition = pairLyrics.search(/(?<=\s+)\S/);
-
+    const [firstWord, rest] = chopFirstWord(pairLyrics);
     const chordData = (chord.type === 'chord') ? { chord } : { chords: chord.value };
 
-    if (secondWordPosition !== -1 && secondWordPosition < end) {
+    if (rest) {
       return [
-        { type: 'chordLyricsPair', ...chordData, lyrics: `${pairLyrics.substring(0, secondWordPosition).trim()} ` },
-        { type: 'chordLyricsPair', chords: '', lyrics: pairLyrics.substring(secondWordPosition) },
+        { type: 'chordLyricsPair', ...chordData, lyrics: `${firstWord} ` },
+        { type: 'chordLyricsPair', chords: '', lyrics: rest },
       ];
     }
-    const trimmedLyrics = /.+\s+$/.test(pairLyrics) ? `${pairLyrics.trim()} ` : pairLyrics;
-    return { type: 'chordLyricsPair', ...chordData, lyrics: trimmedLyrics };
+
+    return { type: 'chordLyricsPair', ...chordData, lyrics: firstWord };
   }).flat();
 }
 

--- a/src/parser/parser_helpers.ts
+++ b/src/parser/parser_helpers.ts
@@ -1,0 +1,17 @@
+// eslint-disable-next-line import/prefer-default-export
+export function chopFirstWord(string: string) {
+  const result = /(\s+)(\S+)/.exec(string);
+  const secondWordPosition = result ? (result.index + result[1].length) : null;
+
+  if (secondWordPosition && secondWordPosition !== -1) {
+    return [
+      string.substring(0, secondWordPosition).trim(),
+      string.substring(secondWordPosition),
+    ];
+  }
+
+  return [
+    /.+\s+$/.test(string) ? `${string.trim()} ` : string,
+    null,
+  ];
+}

--- a/test/parser/parser_helpers.test.ts
+++ b/test/parser/parser_helpers.test.ts
@@ -1,0 +1,23 @@
+import { eachTestCase } from '../utilities';
+import { chopFirstWord } from '../../src/parser/parser_helpers';
+
+describe('parser helpers', () => {
+  describe('chopFirstWord', () => {
+    eachTestCase(`
+      # | string            | outcome                 |
+      - | ----------------- | ----------------------- |
+      1 | "one"             | ["one", null          ] |
+      2 | " one"            | ["", "one"            ] |
+      3 | "one "            | ["one ", null         ] |
+      4 | " one "           | ["", "one "           ] |
+      5 | "one two"         | ["one", "two"         ] |
+      6 | " one two"        | ["", "one two"        ] |
+      7 | "one two "        | ["one", "two "        ] |
+      8 | " one two "       | ["", "one two "       ] |
+      8 | " one two three"  | ["", "one two three"  ] |
+      8 | " one two three " | ["", "one two three " ] |
+    `, ({ string, outcome }) => {
+      expect(chopFirstWord(string)).toEqual(outcome);
+    });
+  });
+});

--- a/test/utilities.ts
+++ b/test/utilities.ts
@@ -156,9 +156,12 @@ export function eachTestCase(table: string, callback: (_testCase: TestCaseProps)
     })
     .forEach((testCaseProps) => {
       const testCase = testCaseProps as TestCaseProps;
-      const description = names.filter((n) => n !== 'outcome').map((name) => `${name}=${testCase[name]}`).join(', ');
 
-      it(`returns ${testCase.outcome} for ${description} (${testCaseProps.index})`, () => {
+      const description = names
+        .filter((n) => n !== 'outcome')
+        .map((name) => `${name}=${JSON.stringify(testCase[name])}`).join(', ');
+
+      it(`returns ${JSON.stringify(testCase.outcome)} for ${description} (${testCaseProps.index})`, () => {
         callback(testCase);
       });
     });


### PR DESCRIPTION
Lookbehind is not working for all users, and the intended functionality could be easily rewritten without regex lookbehind.

Thanks to @MercierCorentin for reporting
Resolves #1042 