### PR TITLE
Add labels for UG verse/chorus directives

### DIFF
--- a/src/parser/ultimate_guitar_parser.ts
+++ b/src/parser/ultimate_guitar_parser.ts
@@ -9,8 +9,8 @@ import Tag, {
   START_OF_VERSE,
 } from '../chord_sheet/tag';
 
-const VERSE_LINE_REGEX = /^\[Verse.*]/i;
-const CHORUS_LINE_REGEX = /^\[Chorus]/i;
+const VERSE_LINE_REGEX = /^\[(Verse.*)]/i;
+const CHORUS_LINE_REGEX = /^\[(Chorus)]/i;
 const OTHER_METADATA_LINE_REGEX = /^\[([^\]]+)]/;
 
 const startSectionTags = {
@@ -46,10 +46,12 @@ class UltimateGuitarParser extends ChordSheetParser {
 
     if (VERSE_LINE_REGEX.test(line)) {
       this.startNewLine();
-      this.startSection(VERSE);
+      const label = line.match(VERSE_LINE_REGEX)[1];
+      this.startSection(VERSE, label);
     } else if (CHORUS_LINE_REGEX.test(line)) {
       this.startNewLine();
-      this.startSection(CHORUS);
+      const label = line.match(CHORUS_LINE_REGEX)[1];
+      this.startSection(CHORUS, label);
     } else if (OTHER_METADATA_LINE_REGEX.test(line)) {
       this.parseMetadataLine(line);
     } else {
@@ -82,7 +84,7 @@ class UltimateGuitarParser extends ChordSheetParser {
     this.endSection({ addNewLine: false });
   }
 
-  startSection(sectionType) {
+  startSection(sectionType: 'verse' | 'chorus', label: string) {
     if (this.currentSectionType) {
       this.endSection();
     }
@@ -91,7 +93,7 @@ class UltimateGuitarParser extends ChordSheetParser {
     this.song.setCurrentProperties(sectionType);
 
     if (sectionType in startSectionTags) {
-      this.song.addTag(new Tag(startSectionTags[sectionType]));
+      this.song.addTag(new Tag(startSectionTags[sectionType], label));
     }
   }
 

--- a/test/fixtures/ultimate_guitar_chordsheet_expected_chordpro_format.txt
+++ b/test/fixtures/ultimate_guitar_chordsheet_expected_chordpro_format.txt
@@ -1,22 +1,22 @@
-{start_of_verse}
+{start_of_verse: Verse 1}
 [C]Lorem [G]ipsum dolor sit [Am]amet,
 [C]consectetur [G]adipiscing [F]elit.
 {end_of_verse}
 
 
-{start_of_chorus}
+{start_of_chorus: Chorus}
  Tortor [Am]posuere [C]ac ut [F]consequat semper viverra [C]nam.
 [C]Non nisi est [G]sit amet facilisis [F]magna etiam tempor orci.
 {end_of_chorus}
 
 
-{start_of_verse}
+{start_of_verse: Verse 2}
 [C]Habitasse [G]platea dictumst [Am]vestibulum rhoncus.
 [C]Tristique et [G]egestas quis [F]ipsum.
 {end_of_verse}
 
 
-{start_of_chorus}
+{start_of_chorus: Chorus}
  Tortor [Am]posuere [C]ac ut [F]consequat semper viverra [C]nam.
 [C]Non nisi est [G]sit amet facilisis [F]magna etiam tempor orci.
 {end_of_chorus}
@@ -30,7 +30,7 @@
 [C][G][Am]
 
 
-{start_of_chorus}
+{start_of_chorus: Chorus}
  Tortor [Am]posuere [C]ac ut [F]consequat semper viverra [C]nam.
 [C]Non nisi est [G]sit amet facilisis [F]magna etiam tempor orci.
 {end_of_chorus}

--- a/test/parser/ultimate_guitar_parser.test.ts
+++ b/test/parser/ultimate_guitar_parser.test.ts
@@ -15,7 +15,7 @@ describe('UltimateGuitarParser', () => {
     expect(lines.length).toEqual(2);
 
     const line0Items = lines[0].items;
-    expect(line0Items[0]).toBeTag('start_of_verse', '');
+    expect(line0Items[0]).toBeTag('start_of_verse', 'Verse 1');
 
     const line1Items = lines[1].items;
     expect(line1Items[0]).toBeTag('end_of_verse', '');
@@ -36,7 +36,7 @@ consectetur adipiscing elit.`.substring(1);
     expect(lines.length).toEqual(4);
 
     const line0Items = lines[0].items;
-    expect(line0Items[0]).toBeTag('start_of_verse', '');
+    expect(line0Items[0]).toBeTag('start_of_verse', 'Verse 1');
 
     const line1Items = lines[1].items;
     expect(line1Items.length).toEqual(3);
@@ -64,7 +64,7 @@ consectetur adipiscing elit.`.substring(1);
     expect(lines.length).toEqual(6);
 
     const line0Items = lines[0].items;
-    expect(line0Items[0]).toBeTag('start_of_verse', '');
+    expect(line0Items[0]).toBeTag('start_of_verse', 'VERSE 1');
 
     const line1Items = lines[1].items;
     expect(line1Items.length).toEqual(3);
@@ -73,7 +73,7 @@ consectetur adipiscing elit.`.substring(1);
     expect(line2Items[0]).toBeTag('end_of_verse', '');
 
     const line3Items = lines[3].items;
-    expect(line3Items[0]).toBeTag('start_of_chorus', '');
+    expect(line3Items[0]).toBeTag('start_of_chorus', 'chorus');
 
     const line4Items = lines[4].items;
     expect(line4Items.length).toEqual(3);


### PR DESCRIPTION
This ensures verse/chorus directives are rendered in a chord sheet.

For example:

- `[Verse 2]` is parsed as `{start_of_verse: Verse 2}`, and rendered as `Verse 2`
- `[Chorus]` is parsed as `{start_of_chorus: Chorus}` and rendered as `Chorus`

Resolves #942
Reported by @eplebel