### PR TITLE
Sections support

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,9 +798,25 @@ else it returns an array of strings.</p>
 **Kind**: global class  
 
 * [Paragraph](#Paragraph)
+    * [.contents](#Paragraph+contents) ⇒ <code>string</code>
+    * [.label](#Paragraph+label) ⇒ <code>string</code> \| <code>null</code>
     * [.type](#Paragraph+type) ⇒ <code>string</code>
+    * [.isLiteral()](#Paragraph+isLiteral) ⇒ <code>boolean</code>
     * [.hasRenderableItems()](#Paragraph+hasRenderableItems) ⇒ <code>boolean</code>
 
+<a name="Paragraph+contents"></a>
+
+### paragraph.contents ⇒ <code>string</code>
+<p>Returns the paragraph contents as one string where lines are separated by newlines</p>
+
+**Kind**: instance property of [<code>Paragraph</code>](#Paragraph)  
+<a name="Paragraph+label"></a>
+
+### paragraph.label ⇒ <code>string</code> \| <code>null</code>
+<p>Returns the label of the paragraph. The label is the value of the first section delimiter tag
+in the first line.</p>
+
+**Kind**: instance property of [<code>Paragraph</code>](#Paragraph)  
 <a name="Paragraph+type"></a>
 
 ### paragraph.type ⇒ <code>string</code>
@@ -808,6 +824,14 @@ else it returns an array of strings.</p>
 If not, it returns [INDETERMINATE](#INDETERMINATE)</p>
 
 **Kind**: instance property of [<code>Paragraph</code>](#Paragraph)  
+<a name="Paragraph+isLiteral"></a>
+
+### paragraph.isLiteral() ⇒ <code>boolean</code>
+<p>Indicates whether the paragraph only contains literals. If true, [contents](contents) can be used to retrieve
+the paragraph contents as one string where lines are separated by newlines.</p>
+
+**Kind**: instance method of [<code>Paragraph</code>](#Paragraph)  
+**See**: [contents](contents)  
 <a name="Paragraph+hasRenderableItems"></a>
 
 ### paragraph.hasRenderableItems() ⇒ <code>boolean</code>

--- a/README.md
+++ b/README.md
@@ -471,12 +471,16 @@ Inherits from [ChordSheetParser](#ChordSheetParser)</p></dd>
 <dd><p>Copyright meta directive. See https://www.chordpro.org/chordpro/directives-copyright/</p></dd>
 <dt><a href="#DURATION">DURATION</a> : <code>string</code></dt>
 <dd><p>Duration meta directive. See https://www.chordpro.org/chordpro/directives-duration/</p></dd>
+<dt><a href="#END_OF_ABC">END_OF_ABC</a> : <code>string</code></dt>
+<dd><p>End of ABC music notation section See https://chordpro.org/chordpro/directives-env_abc/</p></dd>
 <dt><a href="#END_OF_BRIDGE">END_OF_BRIDGE</a> : <code>string</code></dt>
 <dd><p>End of bridge directive. See https://chordpro.org/chordpro/directives-env_bridge/</p></dd>
 <dt><a href="#END_OF_CHORUS">END_OF_CHORUS</a> : <code>string</code></dt>
 <dd><p>End of chorus directive. See https://www.chordpro.org/chordpro/directives-env_chorus/</p></dd>
 <dt><a href="#END_OF_GRID">END_OF_GRID</a> : <code>string</code></dt>
 <dd><p>End of grid directive. See https://www.chordpro.org/chordpro/directives-env_grid/</p></dd>
+<dt><a href="#END_OF_LY">END_OF_LY</a> : <code>string</code></dt>
+<dd><p>End of Lilypond music notation section See https://chordpro.org/chordpro/directives-env_ly/</p></dd>
 <dt><a href="#END_OF_TAB">END_OF_TAB</a> : <code>string</code></dt>
 <dd><p>End of tab directive. See https://www.chordpro.org/chordpro/directives-env_tab/</p></dd>
 <dt><a href="#END_OF_VERSE">END_OF_VERSE</a> : <code>string</code></dt>
@@ -490,12 +494,16 @@ See https://www.chordpro.org/chordpro/directives-key/</p></dd>
 <dd><p>Lyricist meta directive. See https://www.chordpro.org/chordpro/directives-lyricist/</p></dd>
 <dt><a href="#SORTTITLE">SORTTITLE</a> : <code>string</code></dt>
 <dd><p>Sorttitle meta directive. See https://chordpro.org/chordpro/directives-sorttitle/</p></dd>
+<dt><a href="#START_OF_ABC">START_OF_ABC</a> : <code>string</code></dt>
+<dd><p>Start of ABC music notation section See https://chordpro.org/chordpro/directives-env_abc/</p></dd>
 <dt><a href="#START_OF_BRIDGE">START_OF_BRIDGE</a> : <code>string</code></dt>
 <dd><p>Start of bridge directive. See https://chordpro.org/chordpro/directives-env_bridge/</p></dd>
 <dt><a href="#START_OF_CHORUS">START_OF_CHORUS</a> : <code>string</code></dt>
 <dd><p>Start of chorus directive. See https://www.chordpro.org/chordpro/directives-env_chorus/</p></dd>
 <dt><a href="#START_OF_GRID">START_OF_GRID</a> : <code>string</code></dt>
 <dd><p>Start of grid directive. See https://www.chordpro.org/chordpro/directives-env_grid/</p></dd>
+<dt><a href="#START_OF_LY">START_OF_LY</a> : <code>string</code></dt>
+<dd><p>Start of Lilypond music notation section See https://chordpro.org/chordpro/directives-env_ly/</p></dd>
 <dt><a href="#START_OF_TAB">START_OF_TAB</a> : <code>string</code></dt>
 <dd><p>Start of tab directive. See https://www.chordpro.org/chordpro/directives-env_tab/</p></dd>
 <dt><a href="#START_OF_VERSE">START_OF_VERSE</a> : <code>string</code></dt>
@@ -552,6 +560,10 @@ Possible values are 'solfege', 'symbol', 'numeral' and 'number'</p></dd>
 <dd><p>Used to mark a paragraph as tab</p></dd>
 <dt><a href="#VERSE">VERSE</a> : <code>string</code></dt>
 <dd><p>Used to mark a paragraph as verse</p></dd>
+<dt><a href="#LILYPOND">LILYPOND</a> : <code>string</code></dt>
+<dd><p>Used to mark a section as Lilypond notation</p></dd>
+<dt><a href="#ABC">ABC</a> : <code>string</code></dt>
+<dd><p>Used to mark a section as ABC music notation</p></dd>
 </dl>
 
 ## Functions
@@ -862,7 +874,7 @@ if you want to skip the &quot;header lines&quot;: the lines that only contain me
 <a name="Song+expandedBodyParagraphs"></a>
 
 ### song.expandedBodyParagraphs : [<code>Array.&lt;Paragraph&gt;</code>](#Paragraph)
-<p>The body paragraphs of the song, with any <code>{chorus}</code> tag expanded into the targetted chorus</p>
+<p>The body paragraphs of the song, with any <code>{chorus}</code> tag expanded into the targeted chorus</p>
 
 **Kind**: instance property of [<code>Song</code>](#Song)  
 <a name="Song+clone"></a>
@@ -1772,6 +1784,12 @@ Can be deserialized using [deserialize](deserialize)</p>
 <p>Duration meta directive. See https://www.chordpro.org/chordpro/directives-duration/</p>
 
 **Kind**: global constant  
+<a name="END_OF_ABC"></a>
+
+## END\_OF\_ABC : <code>string</code>
+<p>End of ABC music notation section See https://chordpro.org/chordpro/directives-env_abc/</p>
+
+**Kind**: global constant  
 <a name="END_OF_BRIDGE"></a>
 
 ## END\_OF\_BRIDGE : <code>string</code>
@@ -1788,6 +1806,12 @@ Can be deserialized using [deserialize](deserialize)</p>
 
 ## END\_OF\_GRID : <code>string</code>
 <p>End of grid directive. See https://www.chordpro.org/chordpro/directives-env_grid/</p>
+
+**Kind**: global constant  
+<a name="END_OF_LY"></a>
+
+## END\_OF\_LY : <code>string</code>
+<p>End of Lilypond music notation section See https://chordpro.org/chordpro/directives-env_ly/</p>
 
 **Kind**: global constant  
 <a name="END_OF_TAB"></a>
@@ -1827,6 +1851,12 @@ See https://www.chordpro.org/chordpro/directives-key/</p>
 <p>Sorttitle meta directive. See https://chordpro.org/chordpro/directives-sorttitle/</p>
 
 **Kind**: global constant  
+<a name="START_OF_ABC"></a>
+
+## START\_OF\_ABC : <code>string</code>
+<p>Start of ABC music notation section See https://chordpro.org/chordpro/directives-env_abc/</p>
+
+**Kind**: global constant  
 <a name="START_OF_BRIDGE"></a>
 
 ## START\_OF\_BRIDGE : <code>string</code>
@@ -1843,6 +1873,12 @@ See https://www.chordpro.org/chordpro/directives-key/</p>
 
 ## START\_OF\_GRID : <code>string</code>
 <p>Start of grid directive. See https://www.chordpro.org/chordpro/directives-env_grid/</p>
+
+**Kind**: global constant  
+<a name="START_OF_LY"></a>
+
+## START\_OF\_LY : <code>string</code>
+<p>Start of Lilypond music notation section See https://chordpro.org/chordpro/directives-env_ly/</p>
 
 **Kind**: global constant  
 <a name="START_OF_TAB"></a>
@@ -2008,6 +2044,18 @@ Possible values are 'solfege', 'symbol', 'numeral' and 'number'</p>
 
 ## VERSE : <code>string</code>
 <p>Used to mark a paragraph as verse</p>
+
+**Kind**: global constant  
+<a name="LILYPOND"></a>
+
+## LILYPOND : <code>string</code>
+<p>Used to mark a section as Lilypond notation</p>
+
+**Kind**: global constant  
+<a name="ABC"></a>
+
+## ABC : <code>string</code>
+<p>Used to mark a section as ABC music notation</p>
 
 **Kind**: global constant  
 <a name="scopedCss"></a>

--- a/src/chord_sheet/chord_pro/literal.ts
+++ b/src/chord_sheet/chord_pro/literal.ts
@@ -3,9 +3,9 @@ import Evaluatable from './evaluatable';
 class Literal extends Evaluatable {
   string: string;
 
-  constructor(expression: string) {
+  constructor(string: string) {
     super();
-    this.string = expression;
+    this.string = string;
   }
 
   evaluate(): string {

--- a/src/chord_sheet/item.ts
+++ b/src/chord_sheet/item.ts
@@ -2,7 +2,8 @@ import ChordLyricsPair from './chord_lyrics_pair';
 import Comment from './comment';
 import Tag from './tag';
 import Ternary from './chord_pro/ternary';
+import Literal from './chord_pro/literal';
 
-type Item = ChordLyricsPair | Comment | Tag | Ternary;
+type Item = ChordLyricsPair | Comment | Tag | Ternary | Literal;
 
 export default Item;

--- a/src/chord_sheet/line.ts
+++ b/src/chord_sheet/line.ts
@@ -3,7 +3,7 @@ import Tag from './tag';
 import Comment from './comment';
 import Item from './item';
 import Font from './font';
-import { ContentType } from '../chord_sheet_serializer';
+import { ContentType } from '../serialized_types';
 
 import {
   BRIDGE,

--- a/src/chord_sheet/line.ts
+++ b/src/chord_sheet/line.ts
@@ -3,6 +3,7 @@ import Tag from './tag';
 import Comment from './comment';
 import Item from './item';
 import Font from './font';
+import { ContentType } from '../chord_sheet_serializer';
 
 import {
   BRIDGE,
@@ -15,7 +16,7 @@ import {
 
 type MapItemFunc = (_item: Item) => Item | null;
 
-export type LineType = 'bridge' | 'chorus' | 'grid' | 'none' | 'tab' | 'verse';
+export type LineType = 'bridge' | 'chorus' | 'none' | 'tab' | 'verse' | ContentType | 'indeterminate';
 
 /**
  * Represents a line in a chord sheet, consisting of items of type ChordLyricsPair or Tag

--- a/src/chord_sheet/paragraph.ts
+++ b/src/chord_sheet/paragraph.ts
@@ -1,5 +1,8 @@
 import { INDETERMINATE } from '../constants';
 import Line from './line';
+import Literal from './chord_pro/literal';
+import Tag from './tag';
+import Item from './item';
 
 /**
  * Represents a paragraph of lines in a chord sheet
@@ -14,6 +17,62 @@ class Paragraph {
 
   addLine(line): void {
     this.lines.push(line);
+  }
+
+  /**
+   * Indicates whether the paragraph only contains literals. If true, {@link contents} can be used to retrieve
+   * the paragraph contents as one string where lines are separated by newlines.
+   * @see {@link contents}
+   * @returns {boolean}
+   */
+  isLiteral() {
+    return this
+      .lines
+      .every((line) => line.items.every((item) => {
+        if (item instanceof Literal) {
+          return true;
+        }
+
+        if (item instanceof Tag && (item as Tag).isSectionDelimiter()) {
+          return true;
+        }
+
+        return false;
+      }));
+  }
+
+  /**
+   * Returns the paragraph contents as one string where lines are separated by newlines
+   * @returns {string}
+   */
+  get contents(): string {
+    return this
+      .lines
+      .filter((line) => (
+        line.items.every((item) => item instanceof Literal)
+      ))
+      .map((line) => (
+        line.items.map((item) => (item as Literal).string).join('')
+      )).join('\n');
+  }
+
+  /**
+   * Returns the label of the paragraph. The label is the value of the first section delimiter tag
+   * in the first line.
+   * @returns {string|null}
+   */
+  get label(): string | null {
+    if (this.lines.length === 0) {
+      return null;
+    }
+
+    const startTag = this.lines[0].items.find((item: Item) => item instanceof Tag && item.isSectionDelimiter());
+
+    if (startTag) {
+      return (startTag as Tag).value;
+    }
+
+    return null;
   }
 
   /**

--- a/src/chord_sheet/paragraph.ts
+++ b/src/chord_sheet/paragraph.ts
@@ -1,5 +1,5 @@
 import { INDETERMINATE } from '../constants';
-import Line from './line';
+import Line, { LineType } from './line';
 import Literal from './chord_pro/literal';
 import Tag from './tag';
 import Item from './item';
@@ -80,7 +80,7 @@ class Paragraph {
    * If not, it returns {@link INDETERMINATE}
    * @returns {string}
    */
-  get type(): 'bridge' | 'chorus' | 'grid' | 'indeterminate' | 'none' | 'tab' | 'verse' {
+  get type(): LineType {
     const types = this.lines.map((line) => line.type);
     const uniqueTypes = [...new Set(types)];
 

--- a/src/chord_sheet/song.ts
+++ b/src/chord_sheet/song.ts
@@ -10,39 +10,44 @@ import TraceInfo from './trace_info';
 import FontStack from './font_stack';
 
 import {
-  BRIDGE, CHORUS, GRID, NONE, ParagraphType, TAB, VERSE,
+  ABC,
+  BRIDGE, CHORUS, GRID, LILYPOND, NONE, ParagraphType, TAB, VERSE,
 } from '../constants';
 
 import Tag, {
   CAPO,
-  CHORUS as CHORUS_TAG,
+  CHORUS as CHORUS_TAG, END_OF_ABC,
   END_OF_BRIDGE,
   END_OF_CHORUS,
-  END_OF_GRID,
+  END_OF_GRID, END_OF_LY,
   END_OF_TAB,
   END_OF_VERSE,
   KEY,
-  NEW_KEY,
+  NEW_KEY, START_OF_ABC,
   START_OF_BRIDGE,
   START_OF_CHORUS,
-  START_OF_GRID,
+  START_OF_GRID, START_OF_LY,
   START_OF_TAB,
   START_OF_VERSE,
   TRANSPOSE,
 } from './tag';
 
 const START_TAG_TO_SECTION_TYPE = {
+  [START_OF_ABC]: ABC,
   [START_OF_BRIDGE]: BRIDGE,
   [START_OF_CHORUS]: CHORUS,
   [START_OF_GRID]: GRID,
+  [START_OF_LY]: LILYPOND,
   [START_OF_TAB]: TAB,
   [START_OF_VERSE]: VERSE,
 };
 
 const END_TAG_TO_SECTION_TYPE = {
+  [END_OF_ABC]: ABC,
   [END_OF_BRIDGE]: BRIDGE,
   [END_OF_CHORUS]: CHORUS,
   [END_OF_GRID]: GRID,
+  [END_OF_LY]: LILYPOND,
   [END_OF_TAB]: TAB,
   [END_OF_VERSE]: VERSE,
 };
@@ -227,7 +232,7 @@ class Song extends MetadataAccessors {
   }
 
   /**
-   * The body paragraphs of the song, with any `{chorus}` tag expanded into the targetted chorus
+   * The body paragraphs of the song, with any `{chorus}` tag expanded into the targeted chorus
    * @type {Paragraph[]}
    */
   get expandedBodyParagraphs(): Paragraph[] {
@@ -319,7 +324,7 @@ class Song extends MetadataAccessors {
 
   checkCurrentSectionType(sectionType: ParagraphType, tag: Tag): void {
     if (this.sectionType !== sectionType) {
-      this.addWarning(`Unexpected tag {${tag.originalName}, current section is: ${this.sectionType}`, tag);
+      this.addWarning(`Unexpected tag {${tag.originalName}}, current section is: ${this.sectionType}`, tag);
     }
   }
 
@@ -499,7 +504,7 @@ Or set the song key before changing key:
   private insertDirective(name: string, value: string, { after = null } = {}): Song {
     const insertIndex = this.lines.findIndex((line) => (
       line.items.some((item) => (
-        !(item instanceof Tag) || (after && item instanceof Tag && item.name === after)
+        !(item instanceof Tag) || (after && item.name === after)
       ))
     ));
 

--- a/src/chord_sheet/tag.ts
+++ b/src/chord_sheet/tag.ts
@@ -50,6 +50,12 @@ export const COPYRIGHT = 'copyright';
 export const DURATION = 'duration';
 
 /**
+ * End of ABC music notation section See https://chordpro.org/chordpro/directives-env_abc/
+ * @type {string}
+ */
+export const END_OF_ABC = 'end_of_abc';
+
+/**
  * End of bridge directive. See https://chordpro.org/chordpro/directives-env_bridge/
  * @type {string}
  */
@@ -66,6 +72,12 @@ export const END_OF_CHORUS = 'end_of_chorus';
  * @type {string}
  */
 export const END_OF_GRID = 'end_of_grid';
+
+/**
+ * End of Lilypond music notation section See https://chordpro.org/chordpro/directives-env_ly/
+ * @type {string}
+ */
+export const END_OF_LY = 'end_of_ly';
 
 /**
  * End of tab directive. See https://www.chordpro.org/chordpro/directives-env_tab/
@@ -105,6 +117,12 @@ export const LYRICIST = 'lyricist';
 export const SORTTITLE = 'sorttitle';
 
 /**
+ * Start of ABC music notation section See https://chordpro.org/chordpro/directives-env_abc/
+ * @type {string}
+ */
+export const START_OF_ABC = 'start_of_abc';
+
+/**
  * Start of bridge directive. See https://chordpro.org/chordpro/directives-env_bridge/
  * @type {string}
  */
@@ -121,6 +139,12 @@ export const START_OF_CHORUS = 'start_of_chorus';
  * @type {string}
  */
 export const START_OF_GRID = 'start_of_grid';
+
+/**
+ * Start of Lilypond music notation section See https://chordpro.org/chordpro/directives-env_ly/
+ * @type {string}
+ */
+export const START_OF_LY = 'start_of_ly';
 
 /**
  * Start of tab directive. See https://www.chordpro.org/chordpro/directives-env_tab/
@@ -289,12 +313,16 @@ export const META_TAGS = [
 export const READ_ONLY_TAGS = [_KEY];
 
 const SECTION_DELIMITERS = [
+  START_OF_ABC,
+  END_OF_ABC,
   START_OF_BRIDGE,
   END_OF_BRIDGE,
   START_OF_CHORUS,
   END_OF_CHORUS,
   START_OF_GRID,
   END_OF_GRID,
+  START_OF_LY,
+  END_OF_LY,
   START_OF_TAB,
   END_OF_TAB,
   START_OF_VERSE,
@@ -312,9 +340,11 @@ const INLINE_FONT_TAGS = [
 
 const DIRECTIVES_WITH_RENDERABLE_LABEL = [
   CHORUS,
+  START_OF_ABC,
   START_OF_BRIDGE,
   START_OF_CHORUS,
   START_OF_GRID,
+  START_OF_LY,
   START_OF_TAB,
   START_OF_VERSE,
 ];

--- a/src/chord_sheet_serializer.ts
+++ b/src/chord_sheet_serializer.ts
@@ -128,17 +128,10 @@ class ChordSheetSerializer {
 
   parseAstComponent(astComponent: SerializedComponent)
     : null | ChordLyricsPair | Tag | Comment | Ternary | Literal {
-    if (!astComponent) {
-      return null;
-    }
+    if (!astComponent) return null;
+    if (typeof astComponent === 'string') return new Literal(astComponent);
 
-    if (typeof astComponent === 'string') {
-      return new Literal(astComponent);
-    }
-
-    const { type } = astComponent;
-
-    switch (type) {
+    switch (astComponent.type) {
       case CHORD_SHEET:
         this.parseChordSheet(astComponent);
         break;
@@ -154,7 +147,7 @@ class ChordSheetSerializer {
         this.parseLine(astComponent);
         break;
       default:
-        console.warn(`Unhandled AST component "${type}"`, astComponent);
+        console.warn(`Unhandled AST component "${astComponent.type}"`, astComponent);
     }
 
     return null;

--- a/src/chord_sheet_serializer.ts
+++ b/src/chord_sheet_serializer.ts
@@ -9,7 +9,16 @@ import Line from './chord_sheet/line';
 import AstType from './chord_sheet/ast_type';
 import Item from './chord_sheet/item';
 import Evaluatable from './chord_sheet/chord_pro/evaluatable';
-import { ChordType, Modifier } from './constants';
+
+import {
+  SerializedChordLyricsPair,
+  SerializedComment,
+  SerializedComponent,
+  SerializedItem,
+  SerializedLine, SerializedLiteral,
+  SerializedSong,
+  SerializedTag, SerializedTernary,
+} from './serialized_types';
 
 const CHORD_SHEET = 'chordSheet';
 const CHORD_LYRICS_PAIR = 'chordLyricsPair';
@@ -17,92 +26,6 @@ const TAG = 'tag';
 const COMMENT = 'comment';
 const TERNARY = 'ternary';
 const LINE = 'line';
-
-type SerializedTraceInfo = {
-  location?: {
-    offset: number | null,
-    line: number | null,
-    column: number | null,
-  },
-};
-
-type SerializedChord = {
-  type: 'chord',
-  base: string,
-  modifier: Modifier | null,
-  suffix: string | null,
-  bassBase: string | null,
-  bassModifier: Modifier | null,
-  chordType: ChordType,
-};
-
-export type SerializedChordLyricsPair = {
-  type: 'chordLyricsPair',
-  chord?: SerializedChord | null,
-  chords: string,
-  lyrics: string | null,
-  annotation?: string | null,
-};
-
-export type SerializedTag = SerializedTraceInfo & {
-  type: 'tag',
-  name: string,
-  value: string,
-};
-
-export type SerializedComment = {
-  type: 'comment',
-  comment: string,
-};
-
-export type ContentType = 'tab' | 'abc' | 'ly' | 'grid';
-
-export type SerializedSection = {
-  type: 'section',
-  sectionType: ContentType,
-  content: string[],
-  startTag: SerializedTag,
-  endTag: SerializedTag,
-};
-
-type SerializedLiteral = string;
-
-export interface SerializedTernary extends SerializedTraceInfo {
-  type: 'ternary',
-  variable: string | null,
-  valueTest: string | null,
-  trueExpression: Array<SerializedLiteral | SerializedTernary>,
-  falseExpression: Array<SerializedLiteral | SerializedTernary>,
-}
-
-export type SerializedComposite = Array<SerializedLiteral | SerializedTernary>;
-
-export type SerializedItem =
-  SerializedChordLyricsPair |
-  SerializedTag |
-  SerializedComment |
-  SerializedTernary |
-  SerializedLiteral;
-
-export type SerializedLine = {
-  type: 'line',
-  items: SerializedItem[],
-};
-
-export type SerializedSong = {
-  type: 'chordSheet',
-  lines: SerializedLine[],
-};
-
-type SerializedComponent =
-  SerializedLine |
-  SerializedSong |
-  SerializedChordLyricsPair |
-  SerializedTag |
-  SerializedComment |
-  SerializedTernary |
-  SerializedLiteral |
-  SerializedSection;
 
 /**
  * Serializes a song into een plain object, and deserializes the serialized object back into a {@link Song}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,7 +47,30 @@ export const TAB = 'tab';
  */
 export const VERSE = 'verse';
 
-export type ParagraphType = 'bridge' | 'chorus' | 'grid' | 'indeterminate' | 'none' | 'tab' | 'verse';
+/**
+ * Used to mark a section as Lilypond notation
+ * @constant
+ * @type {string}
+ */
+export const LILYPOND = 'ly';
+
+/**
+ * Used to mark a section as ABC music notation
+ * @constant
+ * @type {string}
+ */
+export const ABC = 'abc';
+
+export type ParagraphType =
+  'abc' |
+  'bridge' |
+  'chorus' |
+  'grid' |
+  'indeterminate' |
+  'ly' |
+  'none' |
+  'tab' |
+  'verse';
 
 export const SYMBOL = 'symbol';
 export const NUMERIC = 'numeric';

--- a/src/formatter/chords_over_words_formatter.ts
+++ b/src/formatter/chords_over_words_formatter.ts
@@ -70,22 +70,6 @@ class ChordsOverWordsFormatter extends Formatter {
       .join('\n');
   }
 
-  formatTitle(title: string): string {
-    if (title) {
-      return `title: ${title}\n`;
-    }
-
-    return '';
-  }
-
-  formatSubTitle(subtitle: string): string {
-    if (subtitle) {
-      return `${subtitle}\n`;
-    }
-
-    return '';
-  }
-
   formatLineTop(line: Line, metadata: Metadata): string | null {
     if (hasRemarkContents(line)) {
       return this.formatLineWithFormatter(line, this.formatItemTop, metadata);
@@ -147,6 +131,10 @@ class ChordsOverWordsFormatter extends Formatter {
   }
 
   formatItemBottom(item: Item, metadata: Metadata, line: Line): string {
+    if (typeof item === 'string') {
+      return item;
+    }
+
     if (item instanceof Tag && item.isRenderable()) {
       return item.value || '';
     }

--- a/src/formatter/chords_over_words_formatter.ts
+++ b/src/formatter/chords_over_words_formatter.ts
@@ -9,6 +9,7 @@ import Paragraph from '../chord_sheet/paragraph';
 import Metadata from '../chord_sheet/metadata';
 import Line from '../chord_sheet/line';
 import Item from '../chord_sheet/item';
+import { Ternary } from '../index';
 
 /**
  * Formats a song into a plain text chord sheet
@@ -146,14 +147,22 @@ class ChordsOverWordsFormatter extends Formatter {
     }
 
     if (item instanceof ChordLyricsPair) {
-      return padLeft(item.lyrics || '', this.chordLyricsPairLength(item, line));
+      return this.formatChordLyricsPair(item, line);
     }
 
     if ('evaluate' in item) {
-      return item.evaluate(metadata, this.configuration.get('metadata.separator'));
+      return this.formatEvaluatable(item as Ternary, metadata);
     }
 
     return '';
+  }
+
+  private formatEvaluatable(item: Ternary, metadata: Metadata) {
+    return item.evaluate(metadata, this.configuration.get('metadata.separator'));
+  }
+
+  private formatChordLyricsPair(item: ChordLyricsPair, line: Line) {
+    return padLeft(item.lyrics || '', this.chordLyricsPairLength(item, line));
   }
 }
 

--- a/src/formatter/chords_over_words_formatter.ts
+++ b/src/formatter/chords_over_words_formatter.ts
@@ -2,7 +2,7 @@ import Formatter from './formatter';
 import ChordLyricsPair from '../chord_sheet/chord_lyrics_pair';
 import Tag from '../chord_sheet/tag';
 import { renderChord } from '../helpers';
-import { hasTextContents } from '../template_helpers';
+import { hasTextContents, renderSection } from '../template_helpers';
 import Song from '../chord_sheet/song';
 import { hasRemarkContents, isEmptyString, padLeft } from '../utilities';
 import Paragraph from '../chord_sheet/paragraph';
@@ -52,6 +52,12 @@ class ChordsOverWordsFormatter extends Formatter {
   }
 
   formatParagraph(paragraph: Paragraph, metadata: Metadata): string {
+    if (paragraph.isLiteral()) {
+      return [paragraph.label, renderSection(paragraph, this.configuration)]
+        .filter((part) => part)
+        .join('\n');
+    }
+
     return paragraph.lines
       .filter((line) => line.hasRenderableItems())
       .map((line) => this.formatLine(line, metadata))

--- a/src/formatter/configuration/configuration.ts
+++ b/src/formatter/configuration/configuration.ts
@@ -1,27 +1,28 @@
 import lodashGet from 'lodash.get';
 
-import MetadataConfiguration from './metadata_configuration';
+import MetadataConfiguration, {
+  defaultMetadataConfiguration,
+  MetadataConfigurationProperties,
+} from './metadata_configuration';
 import Key from '../../key';
 import { ContentType } from '../../chord_sheet_serializer';
 
 export type Delegate = (_string: string) => string;
-const defaultDelegate: Delegate = (string: string) => string;
+export const defaultDelegate: Delegate = (string: string) => string;
 
 export type ConfigurationProperties = Record<string, any> & {
-  evaluate?: boolean,
-  metadata?: {
-    separator: string,
-  },
-  key?: Key | string | null,
-  expandChorusDirective?: boolean,
-  useUnicodeModifiers?: boolean,
-  normalizeChords?: boolean,
-  delegates?: Partial<Record<ContentType, Delegate>>;
+  evaluate: boolean,
+  metadata: Partial<MetadataConfigurationProperties>,
+  key: Key | string | null,
+  expandChorusDirective: boolean,
+  useUnicodeModifiers: boolean,
+  normalizeChords: boolean,
+  delegates: Partial<Record<ContentType, Delegate>>;
 }
 
 export const defaultConfiguration: ConfigurationProperties = {
   evaluate: false,
-  metadata: { separator: ',' },
+  metadata: defaultMetadataConfiguration,
   key: null,
   expandChorusDirective: false,
   useUnicodeModifiers: false,
@@ -51,16 +52,16 @@ class Configuration {
 
   delegates: Partial<Record<ContentType, Delegate>>;
 
-  constructor(configuration: ConfigurationProperties = defaultConfiguration) {
+  constructor(configuration: Partial<ConfigurationProperties> = defaultConfiguration) {
     const mergedConfig: ConfigurationProperties = { ...defaultConfiguration, ...configuration };
-    this.evaluate = !!mergedConfig.evaluate;
-    this.expandChorusDirective = !!mergedConfig.expandChorusDirective;
-    this.useUnicodeModifiers = !!mergedConfig.useUnicodeModifiers;
-    this.normalizeChords = !!mergedConfig.normalizeChords;
+    this.evaluate = mergedConfig.evaluate;
+    this.expandChorusDirective = mergedConfig.expandChorusDirective;
+    this.useUnicodeModifiers = mergedConfig.useUnicodeModifiers;
+    this.normalizeChords = mergedConfig.normalizeChords;
     this.metadata = new MetadataConfiguration(configuration.metadata);
     this.key = configuration.key ? Key.wrap(configuration.key) : null;
-    this.delegates = mergedConfig.delegates || {};
-    this.configuration = configuration;
+    this.delegates = { ...defaultConfiguration.delegates, ...configuration.delegates };
+    this.configuration = { configuration, delegates: this.delegates };
   }
 
   get(key: string): string {

--- a/src/formatter/configuration/configuration.ts
+++ b/src/formatter/configuration/configuration.ts
@@ -1,11 +1,12 @@
 import lodashGet from 'lodash.get';
 
+import Key from '../../key';
+import { ContentType } from '../../serialized_types';
+
 import MetadataConfiguration, {
   defaultMetadataConfiguration,
   MetadataConfigurationProperties,
 } from './metadata_configuration';
-import Key from '../../key';
-import { ContentType } from '../../chord_sheet_serializer';
 
 export type Delegate = (_string: string) => string;
 export const defaultDelegate: Delegate = (string: string) => string;

--- a/src/formatter/configuration/configuration.ts
+++ b/src/formatter/configuration/configuration.ts
@@ -2,6 +2,11 @@ import lodashGet from 'lodash.get';
 
 import MetadataConfiguration from './metadata_configuration';
 import Key from '../../key';
+import Literal from '../../chord_sheet/chord_pro/literal';
+import { ContentType } from '../../chord_sheet_serializer';
+
+export type Delegate = (_literal: Literal) => string;
+const defaultDelegate: Delegate = (literal: Literal) => literal.string;
 
 export type ConfigurationProperties = Record<string, any> & {
   evaluate?: boolean,
@@ -12,6 +17,7 @@ export type ConfigurationProperties = Record<string, any> & {
   expandChorusDirective?: boolean,
   useUnicodeModifiers?: boolean,
   normalizeChords?: boolean,
+  delegates?: Partial<Record<ContentType, Delegate>>;
 }
 
 export const defaultConfiguration: ConfigurationProperties = {
@@ -21,6 +27,11 @@ export const defaultConfiguration: ConfigurationProperties = {
   expandChorusDirective: false,
   useUnicodeModifiers: false,
   normalizeChords: true,
+  delegates: {
+    abc: defaultDelegate,
+    ly: defaultDelegate,
+    tab: defaultDelegate,
+  },
 };
 
 class Configuration {
@@ -38,6 +49,8 @@ class Configuration {
 
   normalizeChords: boolean;
 
+  delegates: Partial<Record<ContentType, Delegate>>;
+
   constructor(configuration: ConfigurationProperties = defaultConfiguration) {
     const mergedConfig: ConfigurationProperties = { ...defaultConfiguration, ...configuration };
     this.evaluate = !!mergedConfig.evaluate;
@@ -46,6 +59,7 @@ class Configuration {
     this.normalizeChords = !!mergedConfig.normalizeChords;
     this.metadata = new MetadataConfiguration(configuration.metadata);
     this.key = configuration.key ? Key.wrap(configuration.key) : null;
+    this.delegates = mergedConfig.delegates || {};
     this.configuration = configuration;
   }
 

--- a/src/formatter/configuration/configuration.ts
+++ b/src/formatter/configuration/configuration.ts
@@ -2,11 +2,10 @@ import lodashGet from 'lodash.get';
 
 import MetadataConfiguration from './metadata_configuration';
 import Key from '../../key';
-import Literal from '../../chord_sheet/chord_pro/literal';
 import { ContentType } from '../../chord_sheet_serializer';
 
-export type Delegate = (_literal: Literal) => string;
-const defaultDelegate: Delegate = (literal: Literal) => literal.string;
+export type Delegate = (_string: string) => string;
+const defaultDelegate: Delegate = (string: string) => string;
 
 export type ConfigurationProperties = Record<string, any> & {
   evaluate?: boolean,
@@ -31,6 +30,7 @@ export const defaultConfiguration: ConfigurationProperties = {
     abc: defaultDelegate,
     ly: defaultDelegate,
     tab: defaultDelegate,
+    grid: defaultDelegate,
   },
 };
 

--- a/src/formatter/configuration/metadata_configuration.ts
+++ b/src/formatter/configuration/metadata_configuration.ts
@@ -1,4 +1,4 @@
-interface MetadataConfigurationProperties {
+export interface MetadataConfigurationProperties {
   separator?: string;
 }
 

--- a/src/formatter/formatter.ts
+++ b/src/formatter/formatter.ts
@@ -23,7 +23,7 @@ class Formatter {
      * symbols.
      * @param {boolean} [configuration.normalizeChords=true] Whether or not to automatically normalize chords
      */
-  constructor(configuration: ConfigurationProperties | null = null) {
+  constructor(configuration: Partial<ConfigurationProperties> = {}) {
     this.configuration = new Configuration(configuration || {});
   }
 }

--- a/src/formatter/templates/html_div_formatter.ts
+++ b/src/formatter/templates/html_div_formatter.ts
@@ -7,7 +7,7 @@ import {
   fontStyleTag,
   isChordLyricsPair,
   isComment,
-  isEvaluatable,
+  isEvaluatable, isLiteral,
   isTag,
   lineClasses,
   lineHasContents,
@@ -62,9 +62,7 @@ export default (
                    `) }
                     <div class="lyrics"${ fontStyleTag(line.textFont) }>${ item.lyrics }</div>
                   </div>
-                `) }
-                
-                ${ when(isTag(item), () => `
+                `).elseWhen(isTag(item), () => `
                   ${ when(isComment(item), () => `
                     <div class="comment">${ item.value }</div>
                   `) }
@@ -72,9 +70,9 @@ export default (
                   ${ when(item.hasRenderableLabel(), () => `
                     <h3 class="label">${ item.value }</h3>
                   `) }
-                `) }
-                
-                ${ when(isEvaluatable(item), () => `
+                `).elseWhen(isLiteral(item), () => `
+                  <div class="literal">${item.string}</div>
+                `).elseWhen(isEvaluatable(item), () => `
                   <div class="column">
                     <div class="chord"></div>
                     <div class="lyrics"${ fontStyleTag(line.textFont) }>${ evaluate(item, metadata, configuration) }</div>

--- a/src/formatter/templates/html_div_formatter.ts
+++ b/src/formatter/templates/html_div_formatter.ts
@@ -11,7 +11,7 @@ import {
   isTag,
   lineClasses,
   lineHasContents, newlinesToBreaks,
-  paragraphClasses,
+  paragraphClasses, renderSection,
   stripHTML,
   when,
 } from '../../template_helpers';
@@ -21,6 +21,7 @@ export default (
     configuration,
     configuration: {
       key,
+      delegates,
     },
     song,
     renderBlankLines = false,
@@ -41,7 +42,7 @@ export default (
         ${ when(paragraph.isLiteral(), () => `
           <div class="row">
             <h3 class="label">${ paragraph.label }</h3>
-            <div class="literal">${ newlinesToBreaks(paragraph.contents) }</div>
+            <div class="literal">${ newlinesToBreaks(renderSection(paragraph, configuration)) }</div>
           </div>
         `).else(() => `
           ${ each(paragraph.lines, (line) => `

--- a/src/formatter/templates/html_div_formatter.ts
+++ b/src/formatter/templates/html_div_formatter.ts
@@ -10,7 +10,7 @@ import {
   isEvaluatable, isLiteral,
   isTag,
   lineClasses,
-  lineHasContents,
+  lineHasContents, newlinesToBreaks,
   paragraphClasses,
   stripHTML,
   when,
@@ -38,48 +38,53 @@ export default (
   <div class="chord-sheet">
     ${ each(bodyParagraphs, (paragraph) => `
       <div class="${ paragraphClasses(paragraph) }">
-        ${ each(paragraph.lines, (line) => `
-          ${ when(renderBlankLines || lineHasContents(line), () => `
-            <div class="${ lineClasses(line) }">
-              ${ each(line.items, (item) => `
-                ${ when(isChordLyricsPair(item), () => `
-                  <div class="column">
-                   ${ when(item.annotation).then(() => `
-                     <div class="annotation"${ fontStyleTag(line.chordFont) }>${item.annotation}</div>
-                   `).else(() => `
-                      <div class="chord"${ fontStyleTag(line.chordFont) }>${
-                        renderChord(
-                          item.chords,
-                          line,
-                          song,
-                          {
-                            renderKey: key,
-                            useUnicodeModifier: configuration.useUnicodeModifiers,
-                            normalizeChords: configuration.normalizeChords,
-                          }
-                        )
-                      }</div>
-                   `) }
-                    <div class="lyrics"${ fontStyleTag(line.textFont) }>${ item.lyrics }</div>
-                  </div>
-                `).elseWhen(isTag(item), () => `
-                  ${ when(isComment(item), () => `
-                    <div class="comment">${ item.value }</div>
+        ${ when(paragraph.isLiteral(), () => `
+          <div class="row">
+            <h3 class="label">${ paragraph.label }</h3>
+            <div class="literal">${ newlinesToBreaks(paragraph.contents) }</div>
+          </div>
+        `).else(() => `
+          ${ each(paragraph.lines, (line) => `
+            ${ when(renderBlankLines || lineHasContents(line), () => `
+              <div class="${ lineClasses(line) }">
+                ${ each(line.items, (item) => `
+                  ${ when(isChordLyricsPair(item), () => `
+                    <div class="column">
+                     ${ when(item.annotation).then(() => `
+                       <div class="annotation"${ fontStyleTag(line.chordFont) }>${item.annotation}</div>
+                     `).else(() => `
+                        <div class="chord"${ fontStyleTag(line.chordFont) }>${
+                          renderChord(
+                            item.chords,
+                            line,
+                            song,
+                            {
+                              renderKey: key,
+                              useUnicodeModifier: configuration.useUnicodeModifiers,
+                              normalizeChords: configuration.normalizeChords,
+                            }
+                          )
+                        }</div>
+                     `) }
+                      <div class="lyrics"${ fontStyleTag(line.textFont) }>${ item.lyrics }</div>
+                    </div>
+                  `).elseWhen(isTag(item), () => `
+                    ${ when(isComment(item), () => `
+                      <div class="comment">${ item.value }</div>
+                    `) }
+                    
+                    ${ when(item.hasRenderableLabel(), () => `
+                      <h3 class="label">${ item.value }</h3>
+                    `) }
+                  `).elseWhen(isEvaluatable(item), () => `
+                    <div class="column">
+                      <div class="chord"></div>
+                      <div class="lyrics"${ fontStyleTag(line.textFont) }>${ evaluate(item, metadata, configuration) }</div>
+                    </div>
                   `) }
-                  
-                  ${ when(item.hasRenderableLabel(), () => `
-                    <h3 class="label">${ item.value }</h3>
-                  `) }
-                `).elseWhen(isLiteral(item), () => `
-                  <div class="literal">${item.string}</div>
-                `).elseWhen(isEvaluatable(item), () => `
-                  <div class="column">
-                    <div class="chord"></div>
-                    <div class="lyrics"${ fontStyleTag(line.textFont) }>${ evaluate(item, metadata, configuration) }</div>
-                  </div>
                 `) }
-              `) }
-            </div>
+              </div>
+            `) }
           `) }
         `) }
       </div>

--- a/src/formatter/templates/html_table_formatter.ts
+++ b/src/formatter/templates/html_table_formatter.ts
@@ -12,7 +12,7 @@ import {
   isTag,
   lineClasses,
   lineHasContents, newlinesToBreaks,
-  paragraphClasses,
+  paragraphClasses, renderSection,
   stripHTML,
   when,
 } from '../../template_helpers';
@@ -22,6 +22,7 @@ export default (
     configuration,
     configuration: {
       key,
+      delegates,
     },
     song,
     renderBlankLines = false,
@@ -45,7 +46,7 @@ export default (
             <table class="literal">
               <tr>
                 <td class="label">${ paragraph.label }</td>
-                <td class="contents">${ newlinesToBreaks(paragraph.contents) }</td>
+                <td class="contents">${ newlinesToBreaks(renderSection(paragraph, configuration)) }</td>
               </tr>
             </table>
           `).else(() => `

--- a/src/formatter/templates/html_table_formatter.ts
+++ b/src/formatter/templates/html_table_formatter.ts
@@ -8,7 +8,7 @@ import {
   fontStyleTag,
   hasTextContents,
   isChordLyricsPair,
-  isComment,
+  isComment, isLiteral,
   isTag,
   lineClasses,
   lineHasContents,
@@ -74,9 +74,7 @@ export default (
                     ${ each(line.items, (item) => `
                       ${ when(isChordLyricsPair(item), () => `
                         <td class="lyrics"${fontStyleTag(line.textFont)}>${ item.lyrics}</td>
-                      `)}
-                      
-                      ${ when(isTag(item), () => `
+                      `).elseWhen(isTag(item), () => `
                         ${ when(isComment(item), () => `
                           <td class="comment"${fontStyleTag(line.textFont)}>${ item.value }</td>
                         `) }
@@ -84,9 +82,9 @@ export default (
                         ${ when(item.hasRenderableLabel(), () => `
                           <td><h3 class="label"${fontStyleTag(line.textFont)}>${ item.value }</h3></td>
                         `) }
-                      `) }
-                      
-                      ${ when(isEvaluatable(item), () => `
+                      `).elseWhen(isLiteral(item), () => `
+                        <td class="literal">${item.string}</td>
+                      `).elseWhen(isEvaluatable(item), () => `
                         <td class="lyrics"${fontStyleTag(line.textFont)}>${ evaluate(item, metadata, configuration) }</td>
                       `) }
                     `)}

--- a/src/formatter/templates/html_table_formatter.ts
+++ b/src/formatter/templates/html_table_formatter.ts
@@ -11,7 +11,7 @@ import {
   isComment, isLiteral,
   isTag,
   lineClasses,
-  lineHasContents,
+  lineHasContents, newlinesToBreaks,
   paragraphClasses,
   stripHTML,
   when,
@@ -40,61 +40,70 @@ export default (
   ${ when(bodyLines.length > 0, () => `
     <div class="chord-sheet">
       ${ each(bodyParagraphs, (paragraph) => `
-        <div class="${ paragraphClasses(paragraph)}">
-          ${ each(paragraph.lines, (line) => `
-            ${ when(renderBlankLines || lineHasContents(line), () => `
-              <table class="${ lineClasses(line)}">
-                ${ when(hasChordContents(line), () => `
-                  <tr>
-                    ${ each(line.items, (item) => `
-                      ${ when(isChordLyricsPair(item), () => `
-                        ${when(item.annotation).then(() => `
-                          <td class="annotation"${fontStyleTag(line.chordFont)}>${item.annotation}</td>
-                        `).else(() => `
-                          <td class="chord"${fontStyleTag(line.chordFont)}>${
-                            renderChord(
-                              item.chords,
-                              line,
-                              song,
-                              {
-                                renderKey: key,
-                                useUnicodeModifier: configuration.useUnicodeModifiers,
-                                normalizeChords: configuration.normalizeChords,
-                              },
-                            )
-                          }</td>
-                        `)}
-                      `)}
-                    `)}
-                  </tr>
-                `)}
-                
-                ${ when(hasTextContents(line), () => `
-                  <tr>
-                    ${ each(line.items, (item) => `
-                      ${ when(isChordLyricsPair(item), () => `
-                        <td class="lyrics"${fontStyleTag(line.textFont)}>${ item.lyrics}</td>
-                      `).elseWhen(isTag(item), () => `
-                        ${ when(isComment(item), () => `
-                          <td class="comment"${fontStyleTag(line.textFont)}>${ item.value }</td>
+        <div class="${ paragraphClasses(paragraph) }">
+          ${ when(paragraph.isLiteral(), () => `
+            <table class="literal">
+              <tr>
+                <td class="label">${ paragraph.label }</td>
+                <td class="contents">${ newlinesToBreaks(paragraph.contents) }</td>
+              </tr>
+            </table>
+          `).else(() => `
+            ${ each(paragraph.lines, (line) => `
+              ${ when(renderBlankLines || lineHasContents(line), () => `
+                <table class="${ lineClasses(line)}">
+                  ${ when(hasChordContents(line), () => `
+                    <tr>
+                      ${ each(line.items, (item) => `
+                        ${ when(isChordLyricsPair(item), () => `
+                          ${ when(item.annotation).then(() => `
+                            <td class="annotation"${fontStyleTag(line.chordFont)}>${item.annotation}</td>
+                          `).else(() => `
+                            <td class="chord"${fontStyleTag(line.chordFont)}>${
+                              renderChord(
+                                item.chords,
+                                line,
+                                song,
+                                {
+                                  renderKey: key,
+                                  useUnicodeModifier: configuration.useUnicodeModifiers,
+                                  normalizeChords: configuration.normalizeChords,
+                                },
+                              )
+                            }</td>
+                          `) }
                         `) }
-                        
-                        ${ when(item.hasRenderableLabel(), () => `
-                          <td><h3 class="label"${fontStyleTag(line.textFont)}>${ item.value }</h3></td>
-                        `) }
-                      `).elseWhen(isLiteral(item), () => `
-                        <td class="literal">${item.string}</td>
-                      `).elseWhen(isEvaluatable(item), () => `
-                        <td class="lyrics"${fontStyleTag(line.textFont)}>${ evaluate(item, metadata, configuration) }</td>
                       `) }
-                    `)}
-                  </tr>
-                `)}
-              </table>
-            `)}
-          `)}
+                    </tr>
+                  `)}
+                  
+                  ${ when(hasTextContents(line), () => `
+                    <tr>
+                      ${ each(line.items, (item) => `
+                        ${ when(isChordLyricsPair(item), () => `
+                          <td class="lyrics"${fontStyleTag(line.textFont)}>${ item.lyrics}</td>
+                        `).elseWhen(isTag(item), () => `
+                          ${ when(isComment(item), () => `
+                            <td class="comment"${fontStyleTag(line.textFont)}>${ item.value }</td>
+                          `) }
+                          
+                          ${ when(item.hasRenderableLabel(), () => `
+                            <td><h3 class="label"${fontStyleTag(line.textFont)}>${ item.value }</h3></td>
+                          `) }
+                        `).elseWhen(isLiteral(item), () => `
+                          <td class="literal">${item.string}</td>
+                        `).elseWhen(isEvaluatable(item), () => `
+                          <td class="lyrics"${fontStyleTag(line.textFont)}>${ evaluate(item, metadata, configuration) }</td>
+                        `) }
+                      `) }
+                    </tr>
+                  `) }
+                </table>
+              `) }
+            `) }
+          `) }
         </div>
-      `)}
+      `) }
     </div>
   `)}
 `);

--- a/src/formatter/text_formatter.ts
+++ b/src/formatter/text_formatter.ts
@@ -2,7 +2,7 @@ import Formatter from './formatter';
 import ChordLyricsPair from '../chord_sheet/chord_lyrics_pair';
 import Tag from '../chord_sheet/tag';
 import { renderChord } from '../helpers';
-import { hasTextContents } from '../template_helpers';
+import { hasTextContents, renderSection } from '../template_helpers';
 import Song from '../chord_sheet/song';
 import { hasRemarkContents, isEmptyString, padLeft } from '../utilities';
 import Paragraph from '../chord_sheet/paragraph';
@@ -51,6 +51,12 @@ class TextFormatter extends Formatter {
   }
 
   formatParagraph(paragraph: Paragraph, metadata: Metadata): string {
+    if (paragraph.isLiteral()) {
+      return [paragraph.label, renderSection(paragraph, this.configuration)]
+        .filter((part) => part)
+        .join('\n');
+    }
+
     return paragraph.lines
       .filter((line) => line.hasRenderableItems())
       .map((line) => this.formatLine(line, metadata))

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,8 +54,10 @@ export { default as UltimateGuitarParser } from './parser/ultimate_guitar_parser
 export { default as templateHelpers } from './template_helpers';
 
 export {
+  ABC,
   CHORUS,
   INDETERMINATE,
+  LILYPOND,
   NONE,
   NUMERIC,
   SOLFEGE,

--- a/src/parser/chord_pro_grammar.pegjs
+++ b/src/parser/chord_pro_grammar.pegjs
@@ -1,10 +1,116 @@
+{
+  function buildSection(sectionType, startTag, endTag, content) {
+    return [
+      buildLine([startTag]),
+      ...splitSectionContent(content).map((line) => buildLine([line])),
+      buildLine([endTag]),
+    ];
+  }
+
+  function buildTag(name, value, location) {
+    return {
+      type: 'tag',
+      name,
+      value,
+      location: location.start,
+    };
+  }
+
+  function buildLine(items) {
+    return {
+      type: 'line',
+      items,
+    };
+  }
+
+  function splitSectionContent(content) {
+    return content
+      .replace(/\n$/, '')
+      .split('\n');
+  }
+}
+
 ChordSheet
-  = lines:LineWithNewline* trailingLine:Line? {
+  = lines:ComponentWithNewline* trailingLine:Component? {
       return {
         type: 'chordSheet',
-        lines: [...lines, trailingLine],
+        lines: [...lines, trailingLine].flat(),
       };
     }
+
+ComponentWithNewline
+  = component:Component NewLine {
+      return component;
+    }
+
+Component
+  = Section / Line
+
+Section =
+  ABCSection / GridSection/ LYSection / TabSection
+
+TabSection
+  = startTag:TabStartTag NewLine content:$(!TabEndTag SectionCharacter)* endTag:TabEndTag {
+      return buildSection("tab", startTag, endTag, content);
+    }
+
+TabStartTag
+  = "{" _ tagName:("sot" / "start_of_tab") _ tagColonWithValue: TagColonWithValue? _ "}" {
+      return buildTag(tagName, tagColonWithValue, location());
+    }
+
+TabEndTag
+  = "{" _ tagName:("eot" / "end_of_tab") _ "}" {
+      return buildTag(tagName, null, location());
+    }
+
+ABCSection
+  = startTag:ABCStartTag NewLine content:$(!ABCEndTag SectionCharacter)* endTag:ABCEndTag {
+      return buildSection("abc", startTag, endTag, content);
+    }
+
+ABCStartTag
+  = "{" _ tagName:("start_of_abc") _ tagColonWithValue: TagColonWithValue? _ "}" {
+      return buildTag(tagName, tagColonWithValue, location());
+    }
+
+ABCEndTag
+  = "{" _ tagName:("end_of_abc") _ "}" {
+      return buildTag(tagName, null, location());
+    }
+
+LYSection
+  = startTag:LYStartTag NewLine content:$(!LYEndTag SectionCharacter)* endTag:LYEndTag {
+      return buildSection("ly", startTag, endTag, content);
+    }
+
+LYStartTag
+  = "{" _ tagName:("start_of_ly") _ tagColonWithValue: TagColonWithValue? _ "}" {
+      return buildTag(tagName, tagColonWithValue, location());
+    }
+
+LYEndTag
+  = "{" _ name:("end_of_ly") _ "}" {
+      return buildTag(name, null, location());
+    }
+
+GridSection
+  = startTag:GridStartTag NewLine content:$(!GridEndTag SectionCharacter)* endTag:GridEndTag {
+      return buildSection("grid", startTag, endTag, content);
+    }
+
+GridStartTag
+  = "{" _ tagName:("sog" / "start_of_grid") _ tagColonWithValue: TagColonWithValue? _ "}" {
+      return buildTag(tagName, tagColonWithValue, location());
+    }
+
+GridEndTag
+  = "{" _ tagName:("eog" / "end_of_grid") _ "}" {
+      return buildTag(tagName, null, location());
+    }
+
+SectionCharacter
+  = .
 
 LineWithNewline
   = line: Line NewLine {
@@ -13,15 +119,13 @@ LineWithNewline
 
 Line
   = lyrics:$(Lyrics?) tokens:Token* chords:Chord? comment:Comment? Space* {
-      return {
-        type: 'line',
-        items: [
+      return buildLine([
           lyrics ? { type: 'chordLyricsPair', chords: '', lyrics } : null,
           ...tokens,
           chords ? { type: 'chordLyricsPair', chords, lyrics: '' } : null,
           comment ? { type: 'comment', comment } : null,
         ].filter(x => x),
-      };
+      );
     }
 
 Token

--- a/src/serialized_types.ts
+++ b/src/serialized_types.ts
@@ -1,0 +1,87 @@
+import { ChordType, Modifier } from './constants';
+
+export type SerializedTraceInfo = {
+  location?: {
+    offset: number | null,
+    line: number | null,
+    column: number | null,
+  },
+};
+
+export type SerializedChord = {
+  type: 'chord',
+  base: string,
+  modifier: Modifier | null,
+  suffix: string | null,
+  bassBase: string | null,
+  bassModifier: Modifier | null,
+  chordType: ChordType,
+};
+
+export type SerializedChordLyricsPair = {
+  type: 'chordLyricsPair',
+  chord?: SerializedChord | null,
+  chords: string,
+  lyrics: string | null,
+  annotation?: string | null,
+};
+
+export type SerializedTag = SerializedTraceInfo & {
+  type: 'tag',
+  name: string,
+  value: string,
+};
+
+export type SerializedComment = {
+  type: 'comment',
+  comment: string,
+};
+
+export type ContentType = 'tab' | 'abc' | 'ly' | 'grid';
+
+export type SerializedSection = {
+  type: 'section',
+  sectionType: ContentType,
+  content: string[],
+  startTag: SerializedTag,
+  endTag: SerializedTag,
+};
+
+export type SerializedLiteral = string;
+
+export interface SerializedTernary extends SerializedTraceInfo {
+  type: 'ternary',
+  variable: string | null,
+  valueTest: string | null,
+  trueExpression: Array<SerializedLiteral | SerializedTernary>,
+  falseExpression: Array<SerializedLiteral | SerializedTernary>,
+}
+
+export type SerializedComposite = Array<SerializedLiteral | SerializedTernary>;
+
+export type SerializedItem =
+  SerializedChordLyricsPair |
+  SerializedTag |
+  SerializedComment |
+  SerializedTernary |
+  SerializedLiteral;
+
+export type SerializedLine = {
+  type: 'line',
+  items: SerializedItem[],
+};
+
+export type SerializedSong = {
+  type: 'chordSheet',
+  lines: SerializedLine[],
+};
+
+export type SerializedComponent =
+  SerializedLine |
+  SerializedSong |
+  SerializedChordLyricsPair |
+  SerializedTag |
+  SerializedComment |
+  SerializedTernary |
+  SerializedLiteral |
+  SerializedSection;

--- a/src/template_helpers.ts
+++ b/src/template_helpers.ts
@@ -6,7 +6,7 @@ import Item from './chord_sheet/item';
 import Line from './chord_sheet/line';
 import Paragraph from './chord_sheet/paragraph';
 import Metadata from './chord_sheet/metadata';
-import Configuration from './formatter/configuration/configuration';
+import Configuration, { defaultDelegate, Delegate } from './formatter/configuration/configuration';
 import Evaluatable from './chord_sheet/chord_pro/evaluatable';
 import Font from './chord_sheet/font';
 import { renderChord } from './helpers';
@@ -32,10 +32,20 @@ export const isLiteral = (item: Item): boolean => item instanceof Literal;
 export const isComment = (item: Tag): boolean => item.name === 'comment';
 
 export function stripHTML(string: string): string {
-  return string.trim().replace(/(<\/[a-z]+>)\s+(<)/g, '$1$2').replace(/(\n)\s+/g, '');
+  return string
+    .trim()
+    .replace(/(<\/[a-z]+>)\s+(<)/g, '$1$2')
+    .replace(/(>)\s+(<\/[a-z]+>)/g, '$1$2')
+    .replace(/(\n)\s+/g, '');
 }
 
 export const newlinesToBreaks = (string: string): string => string.replace(/\n/g, '<br>');
+
+export function renderSection(paragraph: Paragraph, configuration: Configuration): string {
+  const delegate: Delegate = configuration.delegates[paragraph.type] || defaultDelegate;
+
+  return delegate(paragraph.contents);
+}
 
 export function each(collection: any[], callback: EachCallback): string {
   return collection.map(callback).join('');

--- a/src/template_helpers.ts
+++ b/src/template_helpers.ts
@@ -10,7 +10,9 @@ import Configuration from './formatter/configuration/configuration';
 import Evaluatable from './chord_sheet/chord_pro/evaluatable';
 import Font from './chord_sheet/font';
 import { renderChord } from './helpers';
-import When, { WhenCallback } from './template_helpers/when';
+import When from './template_helpers/when';
+import { Literal } from './index';
+import WhenCallback from './template_helpers/when_callback';
 
 interface EachCallback {
   (_item: any): string;
@@ -25,6 +27,8 @@ export const lineHasContents = (line: Line): boolean => line.items.some((item: I
 
 export const isTag = (item: Item): boolean => item instanceof Tag;
 
+export const isLiteral = (item: Item): boolean => item instanceof Literal;
+
 export const isComment = (item: Tag): boolean => item.name === 'comment';
 
 export function stripHTML(string: string): string {
@@ -35,7 +39,7 @@ export function each(collection: any[], callback: EachCallback): string {
   return collection.map(callback).join('');
 }
 
-export function when(condition: any, callback: WhenCallback | null = null): When {
+export function when(condition: any, callback?: WhenCallback): When {
   return new When(condition, callback);
 }
 

--- a/src/template_helpers.ts
+++ b/src/template_helpers.ts
@@ -35,6 +35,8 @@ export function stripHTML(string: string): string {
   return string.trim().replace(/(<\/[a-z]+>)\s+(<)/g, '$1$2').replace(/(\n)\s+/g, '');
 }
 
+export const newlinesToBreaks = (string: string): string => string.replace(/\n/g, '<br>');
+
 export function each(collection: any[], callback: EachCallback): string {
   return collection.map(callback).join('');
 }

--- a/src/template_helpers/when.ts
+++ b/src/template_helpers/when.ts
@@ -1,35 +1,45 @@
-export interface WhenCallback {
-  (): string;
-}
+import WhenClause from './when_clause';
+import WhenCallback from './when_callback';
 
 class When {
   condition: boolean = false;
 
-  thenCallback: WhenCallback | null = null;
+  clauses: WhenClause[] = [];
 
-  elseCallback: WhenCallback | null = null;
-
-  constructor(condition: any, thenCallback: WhenCallback | null = null) {
-    this.condition = !!condition;
-    this.thenCallback = thenCallback;
+  constructor(condition: any, thenCallback?: WhenCallback) {
+    this.add(condition, thenCallback);
   }
 
   then(thenCallback: WhenCallback): When {
-    this.thenCallback = thenCallback;
-    return this;
+    return this.add(this.condition, thenCallback);
   }
 
-  else(elseCallback: WhenCallback): When {
-    this.elseCallback = elseCallback;
+  elseWhen(condition: any, callback?: WhenCallback): When {
+    return this.add(condition, callback);
+  }
+
+  else(callback: WhenCallback): When {
+    return this.add(true, callback);
+  }
+
+  private add(condition: any, callback?: WhenCallback): When {
+    this.condition = !!condition;
+
+    if (callback) {
+      this.clauses.push(new WhenClause(condition, callback));
+    }
+
     return this;
   }
 
   toString(): string {
-    if (this.condition) {
-      return this.thenCallback ? this.thenCallback() : '';
+    const [firstClause, ...rest] = this.clauses;
+
+    if (firstClause) {
+      return firstClause.evaluate(rest);
     }
 
-    return this.elseCallback ? this.elseCallback() : '';
+    throw new Error('Expected at least one .then() clause');
   }
 }
 

--- a/src/template_helpers/when_callback.ts
+++ b/src/template_helpers/when_callback.ts
@@ -1,0 +1,5 @@
+interface WhenCallback {
+  (): string;
+}
+
+export default WhenCallback;

--- a/src/template_helpers/when_clause.ts
+++ b/src/template_helpers/when_clause.ts
@@ -1,0 +1,27 @@
+import WhenCallback from './when_callback';
+
+class WhenClause {
+  condition: boolean;
+
+  callback: WhenCallback;
+
+  constructor(condition: any, callback: WhenCallback) {
+    this.condition = !!condition;
+    this.callback = callback;
+  }
+
+  evaluate(otherClauses: WhenClause[]): string {
+    if (this.condition) {
+      return this.callback();
+    }
+
+    if (otherClauses.length > 0) {
+      const [firstClause, ...rest] = otherClauses;
+      return firstClause.evaluate(rest);
+    }
+
+    return '';
+  }
+}
+
+export default WhenClause;

--- a/test/chord_sheet/line.test.ts
+++ b/test/chord_sheet/line.test.ts
@@ -4,7 +4,11 @@ import {
   Tag, VERSE,
 } from '../../src';
 
-import { createChordLyricsPair, createLine, createTag } from '../utilities';
+import {
+  createChordLyricsPair,
+  createLine,
+  createTag,
+} from '../utilities';
 
 describe('Line', () => {
   describe('#clone', () => {

--- a/test/chord_sheet/paragraph.test.ts
+++ b/test/chord_sheet/paragraph.test.ts
@@ -1,5 +1,7 @@
 import { CHORUS, INDETERMINATE, VERSE } from '../../src';
-import { createLine, createParagraph } from '../utilities';
+import {
+  createLine, createLiteral, createParagraph, createTag,
+} from '../utilities';
 
 describe('Paragraph', () => {
   describe('#type', () => {
@@ -22,6 +24,106 @@ describe('Paragraph', () => {
         ]);
 
         expect(paragraph.type).toEqual(INDETERMINATE);
+      });
+    });
+  });
+
+  describe('#isLiteral', () => {
+    describe('when all content lines are literal', () => {
+      it('returns true', () => {
+        const paragraph = createParagraph([
+          createLine([
+            createTag('start_of_tab'),
+          ]),
+          createLine([
+            createLiteral('Tab line 1'),
+          ]),
+          createLine([
+            createLiteral('Tab line 2'),
+          ]),
+          createLine([
+            createTag('end_of_tab'),
+          ]),
+        ]);
+
+        expect(paragraph.isLiteral()).toBe(true);
+      });
+    });
+
+    describe('when not all lines are literal', () => {
+      it('returns false', () => {
+        const paragraph = createParagraph([
+          createLine([
+            createTag('start_of_tab'),
+          ]),
+          createLine([
+            createLiteral('Tab line 1'),
+          ]),
+          createLine([
+            createTag('comment', 'This is a comment'),
+          ]),
+          createLine([
+            createTag('end_of_tab'),
+          ]),
+        ]);
+
+        expect(paragraph.isLiteral()).toBe(false);
+      });
+    });
+  });
+
+  describe('#contents', () => {
+    it('returns the paragraph contents as a string', () => {
+      const paragraph = createParagraph([
+        createLine([
+          createTag('start_of_tab'),
+        ]),
+        createLine([
+          createLiteral('Tab line 1'),
+        ]),
+        createLine([
+          createLiteral('Tab line 2'),
+        ]),
+        createLine([
+          createTag('end_of_tab'),
+        ]),
+      ]);
+
+      expect(paragraph.contents).toEqual('Tab line 1\nTab line 2');
+    });
+  });
+
+  describe('#label', () => {
+    describe('when the first line has a section delimiter', () => {
+      it('returns the value of the section delimiter', () => {
+        const paragraph = createParagraph([
+          createLine([
+            createTag('start_of_tab', 'Tab section'),
+          ]),
+          createLine([
+            createTag('tab'),
+          ]),
+          createLine([
+            createTag('end_of_tab'),
+          ]),
+        ]);
+
+        expect(paragraph.label).toEqual('Tab section');
+      });
+    });
+
+    describe('when the first line does not have a section delimiter', () => {
+      it('returns null', () => {
+        const paragraph = createParagraph([
+          createLine([
+            createLiteral('Tab line 1'),
+          ]),
+          createLine([
+            createLiteral('Tab line 2'),
+          ]),
+        ]);
+
+        expect(paragraph.label).toBeNull();
       });
     });
   });

--- a/test/chord_sheet/song.test.ts
+++ b/test/chord_sheet/song.test.ts
@@ -206,7 +206,7 @@ describe('Song', () => {
   describe('#mapItems', () => {
     it('changes the symbol song', () => {
       const song = exampleSongSymbol.clone();
-      expect(song.paragraphs.map((p) => p.lines.length)).toEqual([0, 1, 3, 2, 2, 2, 2]);
+      expect(song.paragraphs.map((p) => p.lines.length)).toEqual([0, 1, 3, 2, 3, 3, 3, 2, 3]);
 
       const changedSong = song.mapItems((item) => {
         if (item instanceof ChordLyricsPair) {
@@ -237,7 +237,7 @@ describe('Song', () => {
 
     it('changes the solfege song', () => {
       const song = exampleSongSolfege.clone();
-      expect(song.paragraphs.map((p) => p.lines.length)).toEqual([0, 1, 3, 2, 2, 2, 2]);
+      expect(song.paragraphs.map((p) => p.lines.length)).toEqual([0, 1, 3, 2, 3, 3, 3, 2, 3]);
 
       const changedSong = song.mapItems((item) => {
         if (item instanceof ChordLyricsPair) {

--- a/test/fixtures/changed_song.ts
+++ b/test/fixtures/changed_song.ts
@@ -343,6 +343,114 @@ export const changedSongSymbol: SerializedSong = {
       items: [
         {
           type: 'tag',
+          name: 'start_of_tab',
+          value: 'Tab 1 changed',
+        },
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'Tab line 1',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'Tab line 2',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        {
+          type: 'tag',
+          name: 'end_of_tab',
+          value: 'changed',
+        },
+      ],
+    },
+    {
+      type: 'line',
+      items: [],
+    },
+    {
+      type: 'line',
+      items: [
+        {
+          type: 'tag',
+          name: 'start_of_abc',
+          value: 'ABC 1 changed',
+        },
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'ABC line 1',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'ABC line 2',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        {
+          type: 'tag',
+          name: 'end_of_abc',
+          value: 'changed',
+        },
+      ],
+    },
+    {
+      type: 'line',
+      items: [],
+    },
+    {
+      type: 'line',
+      items: [
+        {
+          type: 'tag',
+          name: 'start_of_ly',
+          value: 'LY 1 changed',
+        },
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'LY line 1',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'LY line 2',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        {
+          type: 'tag',
+          name: 'end_of_ly',
+          value: 'changed',
+        },
+      ],
+    },
+    {
+      type: 'line',
+      items: [],
+    },
+    {
+      type: 'line',
+      items: [
+        {
+          type: 'tag',
           name: 'start_of_bridge',
           value: 'Bridge 1 changed',
         },
@@ -387,13 +495,13 @@ export const changedSongSymbol: SerializedSong = {
     {
       type: 'line',
       items: [
-        {
-          type: 'chordLyricsPair',
-          chords: '',
-          lyrics: 'GRID LINE',
-          chord: null,
-          annotation: '',
-        },
+        'Grid line 1',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'Grid line 2',
       ],
     },
     {
@@ -402,42 +510,6 @@ export const changedSongSymbol: SerializedSong = {
         {
           type: 'tag',
           name: 'end_of_grid',
-          value: 'changed',
-        },
-      ],
-    },
-    {
-      type: 'line',
-      items: [],
-    },
-    {
-      type: 'line',
-      items: [
-        {
-          type: 'tag',
-          name: 'start_of_tab',
-          value: 'Tab 1 changed',
-        },
-      ],
-    },
-    {
-      type: 'line',
-      items: [
-        {
-          type: 'chordLyricsPair',
-          chords: '',
-          lyrics: 'TAB LINE',
-          chord: null,
-          annotation: '',
-        },
-      ],
-    },
-    {
-      type: 'line',
-      items: [
-        {
-          type: 'tag',
-          name: 'end_of_tab',
           value: 'changed',
         },
       ],
@@ -788,6 +860,114 @@ export const changedSongSolfege: SerializedSong = {
       items: [
         {
           type: 'tag',
+          name: 'start_of_tab',
+          value: 'Tab 1 changed',
+        },
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'Tab line 1',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'Tab line 2',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        {
+          type: 'tag',
+          name: 'end_of_tab',
+          value: 'changed',
+        },
+      ],
+    },
+    {
+      type: 'line',
+      items: [],
+    },
+    {
+      type: 'line',
+      items: [
+        {
+          type: 'tag',
+          name: 'start_of_abc',
+          value: 'ABC 1 changed',
+        },
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'ABC line 1',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'ABC line 2',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        {
+          type: 'tag',
+          name: 'end_of_abc',
+          value: 'changed',
+        },
+      ],
+    },
+    {
+      type: 'line',
+      items: [],
+    },
+    {
+      type: 'line',
+      items: [
+        {
+          type: 'tag',
+          name: 'start_of_ly',
+          value: 'LY 1 changed',
+        },
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'LY line 1',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'LY line 2',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        {
+          type: 'tag',
+          name: 'end_of_ly',
+          value: 'changed',
+        },
+      ],
+    },
+    {
+      type: 'line',
+      items: [],
+    },
+    {
+      type: 'line',
+      items: [
+        {
+          type: 'tag',
           name: 'start_of_bridge',
           value: 'Bridge 1 changed',
         },
@@ -832,13 +1012,13 @@ export const changedSongSolfege: SerializedSong = {
     {
       type: 'line',
       items: [
-        {
-          type: 'chordLyricsPair',
-          chords: '',
-          lyrics: 'GRID LINE',
-          chord: null,
-          annotation: '',
-        },
+        'Grid line 1',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'Grid line 2',
       ],
     },
     {
@@ -847,42 +1027,6 @@ export const changedSongSolfege: SerializedSong = {
         {
           type: 'tag',
           name: 'end_of_grid',
-          value: 'changed',
-        },
-      ],
-    },
-    {
-      type: 'line',
-      items: [],
-    },
-    {
-      type: 'line',
-      items: [
-        {
-          type: 'tag',
-          name: 'start_of_tab',
-          value: 'Tab 1 changed',
-        },
-      ],
-    },
-    {
-      type: 'line',
-      items: [
-        {
-          type: 'chordLyricsPair',
-          chords: '',
-          lyrics: 'TAB LINE',
-          chord: null,
-          annotation: '',
-        },
-      ],
-    },
-    {
-      type: 'line',
-      items: [
-        {
-          type: 'tag',
-          name: 'end_of_tab',
           value: 'changed',
         },
       ],

--- a/test/fixtures/changed_song.ts
+++ b/test/fixtures/changed_song.ts
@@ -1,4 +1,4 @@
-import { SerializedSong } from '../../src/chord_sheet_serializer';
+import { SerializedSong } from '../../src/serialized_types';
 
 export const changedSongSymbol: SerializedSong = {
   type: 'chordSheet',

--- a/test/fixtures/chord_pro_sheet.ts
+++ b/test/fixtures/chord_pro_sheet.ts
@@ -23,17 +23,29 @@ Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be
 [Am]Whisper words of [Bb]wisdom, let it [F]be [C]
 {end_of_chorus}
 
+{start_of_tab: Tab 1}
+Tab line 1
+Tab line 2
+{end_of_tab}
+
+{start_of_abc: ABC 1}
+ABC line 1
+ABC line 2
+{end_of_abc}
+
+{start_of_ly: LY 1}
+LY line 1
+LY line 2
+{end_of_ly}
+
 {start_of_bridge: Bridge 1}
 Bridge line
 {end_of_bridge}
 
 {start_of_grid: Grid 1}
-Grid line
-{end_of_grid}
-
-{start_of_tab: Tab 1}
-Tab line
-{end_of_tab}`;
+Grid line 1
+Grid line 2
+{end_of_grid}`;
 
 export const chordProSheetSolfege = heredoc`
 {title: Let it be}
@@ -58,14 +70,26 @@ Let it [Lam]be, let it [Do/Sol]be, let it [Fa]be, let it [Do]be
 [Lam]Whisper words of [Sib]wisdom, let it [Fa]be [Do]
 {end_of_chorus}
 
+{start_of_tab: Tab 1}
+Tab line 1
+Tab line 2
+{end_of_tab}
+
+{start_of_abc: ABC 1}
+ABC line 1
+ABC line 2
+{end_of_abc}
+
+{start_of_ly: LY 1}
+LY line 1
+LY line 2
+{end_of_ly}
+
 {start_of_bridge: Bridge 1}
 Bridge line
 {end_of_bridge}
 
 {start_of_grid: Grid 1}
-Grid line
-{end_of_grid}
-
-{start_of_tab: Tab 1}
-Tab line
-{end_of_tab}`;
+Grid line 1
+Grid line 2
+{end_of_grid}`;

--- a/test/fixtures/serialized_song.ts
+++ b/test/fixtures/serialized_song.ts
@@ -1,4 +1,4 @@
-import { SerializedSong } from '../../src/chord_sheet_serializer';
+import { SerializedSong } from '../../src/serialized_types';
 
 export const serializedSongSymbol: SerializedSong = {
   type: 'chordSheet',

--- a/test/fixtures/serialized_song.ts
+++ b/test/fixtures/serialized_song.ts
@@ -343,6 +343,114 @@ export const serializedSongSymbol: SerializedSong = {
       items: [
         {
           type: 'tag',
+          name: 'start_of_tab',
+          value: 'Tab 1',
+        },
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'Tab line 1',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'Tab line 2',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        {
+          type: 'tag',
+          name: 'end_of_tab',
+          value: '',
+        },
+      ],
+    },
+    {
+      type: 'line',
+      items: [],
+    },
+    {
+      type: 'line',
+      items: [
+        {
+          type: 'tag',
+          name: 'start_of_abc',
+          value: 'ABC 1',
+        },
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'ABC line 1',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'ABC line 2',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        {
+          type: 'tag',
+          name: 'end_of_abc',
+          value: '',
+        },
+      ],
+    },
+    {
+      type: 'line',
+      items: [],
+    },
+    {
+      type: 'line',
+      items: [
+        {
+          type: 'tag',
+          name: 'start_of_ly',
+          value: 'LY 1',
+        },
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'LY line 1',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'LY line 2',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        {
+          type: 'tag',
+          name: 'end_of_ly',
+          value: '',
+        },
+      ],
+    },
+    {
+      type: 'line',
+      items: [],
+    },
+    {
+      type: 'line',
+      items: [
+        {
+          type: 'tag',
           name: 'start_of_bridge',
           value: 'Bridge 1',
         },
@@ -387,13 +495,13 @@ export const serializedSongSymbol: SerializedSong = {
     {
       type: 'line',
       items: [
-        {
-          type: 'chordLyricsPair',
-          chords: '',
-          lyrics: 'Grid line',
-          chord: null,
-          annotation: '',
-        },
+        'Grid line 1',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'Grid line 2',
       ],
     },
     {
@@ -402,42 +510,6 @@ export const serializedSongSymbol: SerializedSong = {
         {
           type: 'tag',
           name: 'end_of_grid',
-          value: '',
-        },
-      ],
-    },
-    {
-      type: 'line',
-      items: [],
-    },
-    {
-      type: 'line',
-      items: [
-        {
-          type: 'tag',
-          name: 'start_of_tab',
-          value: 'Tab 1',
-        },
-      ],
-    },
-    {
-      type: 'line',
-      items: [
-        {
-          type: 'chordLyricsPair',
-          chords: '',
-          lyrics: 'Tab line',
-          chord: null,
-          annotation: '',
-        },
-      ],
-    },
-    {
-      type: 'line',
-      items: [
-        {
-          type: 'tag',
-          name: 'end_of_tab',
           value: '',
         },
       ],
@@ -788,6 +860,114 @@ export const serializedSongSolfege: SerializedSong = {
       items: [
         {
           type: 'tag',
+          name: 'start_of_tab',
+          value: 'Tab 1',
+        },
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'Tab line 1',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'Tab line 2',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        {
+          type: 'tag',
+          name: 'end_of_tab',
+          value: '',
+        },
+      ],
+    },
+    {
+      type: 'line',
+      items: [],
+    },
+    {
+      type: 'line',
+      items: [
+        {
+          type: 'tag',
+          name: 'start_of_abc',
+          value: 'ABC 1',
+        },
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'ABC line 1',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'ABC line 2',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        {
+          type: 'tag',
+          name: 'end_of_abc',
+          value: '',
+        },
+      ],
+    },
+    {
+      type: 'line',
+      items: [],
+    },
+    {
+      type: 'line',
+      items: [
+        {
+          type: 'tag',
+          name: 'start_of_ly',
+          value: 'LY 1',
+        },
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'LY line 1',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'LY line 2',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        {
+          type: 'tag',
+          name: 'end_of_ly',
+          value: '',
+        },
+      ],
+    },
+    {
+      type: 'line',
+      items: [],
+    },
+    {
+      type: 'line',
+      items: [
+        {
+          type: 'tag',
           name: 'start_of_bridge',
           value: 'Bridge 1',
         },
@@ -832,13 +1012,13 @@ export const serializedSongSolfege: SerializedSong = {
     {
       type: 'line',
       items: [
-        {
-          type: 'chordLyricsPair',
-          chords: '',
-          lyrics: 'Grid line',
-          chord: null,
-          annotation: '',
-        },
+        'Grid line 1',
+      ],
+    },
+    {
+      type: 'line',
+      items: [
+        'Grid line 2',
       ],
     },
     {
@@ -847,42 +1027,6 @@ export const serializedSongSolfege: SerializedSong = {
         {
           type: 'tag',
           name: 'end_of_grid',
-          value: '',
-        },
-      ],
-    },
-    {
-      type: 'line',
-      items: [],
-    },
-    {
-      type: 'line',
-      items: [
-        {
-          type: 'tag',
-          name: 'start_of_tab',
-          value: 'Tab 1',
-        },
-      ],
-    },
-    {
-      type: 'line',
-      items: [
-        {
-          type: 'chordLyricsPair',
-          chords: '',
-          lyrics: 'Tab line',
-          chord: null,
-          annotation: '',
-        },
-      ],
-    },
-    {
-      type: 'line',
-      items: [
-        {
-          type: 'tag',
-          name: 'end_of_tab',
           value: '',
         },
       ],

--- a/test/fixtures/song.ts
+++ b/test/fixtures/song.ts
@@ -1,5 +1,5 @@
 import {
-  chordLyricsPair, comment, createSongFromAst, tag, ternary,
+  chordLyricsPair, comment, createSongFromAst, section, tag, ternary,
 } from '../utilities';
 
 // This Song object mimics the chord pro sheet in chord_pro_sheet.js
@@ -60,17 +60,17 @@ export const exampleSongSymbol = createSongFromAst([
   ],
   [tag('end_of_chorus')],
   [],
+  ...section('tab', 'Tab 1', 'Tab line 1\nTab line 2'),
+  [],
+  ...section('abc', 'ABC 1', 'ABC line 1\nABC line 2'),
+  [],
+  ...section('ly', 'LY 1', 'LY line 1\nLY line 2'),
+  [],
   [tag('start_of_bridge', 'Bridge 1')],
   [chordLyricsPair('', 'Bridge line')],
   [tag('end_of_bridge')],
   [],
-  [tag('start_of_grid', 'Grid 1')],
-  [chordLyricsPair('', 'Grid line')],
-  [tag('end_of_grid')],
-  [],
-  [tag('start_of_tab', 'Tab 1')],
-  [chordLyricsPair('', 'Tab line')],
-  [tag('end_of_tab')],
+  ...section('grid', 'Grid 1', 'Grid line 1\nGrid line 2'),
 ]);
 
 export const exampleSongSolfege = createSongFromAst([
@@ -130,15 +130,15 @@ export const exampleSongSolfege = createSongFromAst([
   ],
   [tag('end_of_chorus')],
   [],
+  ...section('tab', 'Tab 1', 'Tab line 1\nTab line 2'),
+  [],
+  ...section('abc', 'ABC 1', 'ABC line 1\nABC line 2'),
+  [],
+  ...section('ly', 'LY 1', 'LY line 1\nLY line 2'),
+  [],
   [tag('start_of_bridge', 'Bridge 1')],
   [chordLyricsPair('', 'Bridge line')],
   [tag('end_of_bridge')],
   [],
-  [tag('start_of_grid', 'Grid 1')],
-  [chordLyricsPair('', 'Grid line')],
-  [tag('end_of_grid')],
-  [],
-  [tag('start_of_tab', 'Tab 1')],
-  [chordLyricsPair('', 'Tab line')],
-  [tag('end_of_tab')],
+  ...section('grid', 'Grid 1', 'Grid line 1\nGrid line 2'),
 ]);

--- a/test/formatter.test.ts
+++ b/test/formatter.test.ts
@@ -1,0 +1,18 @@
+import Configuration from '../src/formatter/configuration/configuration';
+import Formatter from '../src/formatter/formatter';
+
+describe('Formatter', () => {
+  it('correctly assigns configuration', () => {
+    const customDelegate = (content: string) => content.toUpperCase();
+
+    const configuration = new Configuration({
+      delegates: {
+        abc: customDelegate,
+      },
+    });
+
+    const formatter = new Formatter(configuration);
+
+    expect(formatter.configuration.delegates.abc).toEqual(customDelegate);
+  });
+});

--- a/test/formatter/chords_over_words_formatter.test.ts
+++ b/test/formatter/chords_over_words_formatter.test.ts
@@ -27,14 +27,24 @@ describe('ChordsOverWordsFormatter', () => {
       Em               F              C  G
       Whisper words of wisdom, let it be
       
+      Tab 1
+      Tab line 1
+      Tab line 2
+      
+      ABC 1
+      ABC line 1
+      ABC line 2
+      
+      LY 1
+      LY line 1
+      LY line 2
+      
       Bridge 1
       Bridge line
       
       Grid 1
-      Grid line
-      
-      Tab 1
-      Tab line`;
+      Grid line 1
+      Grid line 2`;
 
     expect(formatter.format(exampleSongSymbol)).toEqual(expectedChordSheet);
   });
@@ -42,7 +52,7 @@ describe('ChordsOverWordsFormatter', () => {
   it('formats a solfege song to a text chord sheet correctly', () => {
     const formatter = new ChordsOverWordsFormatter();
 
-    const expectedChordSheet = `
+    const expectedChordSheet = heredoc`
 title: Let it be
 subtitle: ChordSheetJS example version
 key: Do
@@ -61,14 +71,24 @@ Breakdown
 Mim              Fa             Do Sol
 Whisper words of wisdom, let it be
 
+Tab 1
+Tab line 1
+Tab line 2
+
+ABC 1
+ABC line 1
+ABC line 2
+
+LY 1
+LY line 1
+LY line 2
+
 Bridge 1
 Bridge line
 
 Grid 1
-Grid line
-
-Tab 1
-Tab line`.substring(1);
+Grid line 1
+Grid line 2`;
 
     expect(formatter.format(exampleSongSolfege)).toEqual(expectedChordSheet);
   });

--- a/test/formatter/chords_over_words_formatter.test.ts
+++ b/test/formatter/chords_over_words_formatter.test.ts
@@ -1,8 +1,18 @@
-import { ChordsOverWordsFormatter } from '../../src';
 import '../matchers';
 import { exampleSongSolfege, exampleSongSymbol } from '../fixtures/song';
 import songWithIntro from '../fixtures/song_with_intro';
-import { heredoc } from '../utilities';
+
+import { GRID } from '../../src/constants';
+import { ContentType } from '../../src/chord_sheet_serializer';
+import Configuration from '../../src/formatter/configuration/configuration';
+
+import {
+  ABC, ChordsOverWordsFormatter, LILYPOND, TAB,
+} from '../../src';
+
+import {
+  createSongFromAst, heredoc, section,
+} from '../utilities';
 
 describe('ChordsOverWordsFormatter', () => {
   it('formats a symbol song to a text chord sheet correctly', () => {
@@ -102,5 +112,47 @@ Grid line 2`;
       Let it be, let it be, let it be, let it be`;
 
     expect(formatter.format(songWithIntro)).toEqual(expectedChordSheet);
+  });
+
+  describe('delegates', () => {
+    [ABC, GRID, LILYPOND, TAB].forEach((type) => {
+      describe(`for ${type}`, () => {
+        it('uses a configured delegate', () => {
+          const song = createSongFromAst([
+            ...section(type as ContentType, `${type} section`, `${type} line 1\n${type} line 2`),
+          ]);
+
+          const configuration = new Configuration({
+            delegates: {
+              [type]: (content: string) => content.toUpperCase(),
+            },
+          });
+
+          const expectedOutput = heredoc`
+            ${type} section
+            ${type.toUpperCase()} LINE 1
+            ${type.toUpperCase()} LINE 2
+          `;
+
+          expect(new ChordsOverWordsFormatter(configuration).format(song)).toEqual(expectedOutput);
+        });
+
+        it('defaults to the default delegate', () => {
+          const song = createSongFromAst([
+            ...section(type as ContentType, `${type} section`, `${type} line 1\n${type} line 2`),
+          ]);
+
+          const configuration = new Configuration();
+
+          const expectedOutput = heredoc`
+            ${type} section
+            ${type} line 1
+            ${type} line 2
+          `;
+
+          expect(new ChordsOverWordsFormatter(configuration).format(song)).toEqual(expectedOutput);
+        });
+      });
+    });
   });
 });

--- a/test/formatter/chords_over_words_formatter.test.ts
+++ b/test/formatter/chords_over_words_formatter.test.ts
@@ -3,7 +3,7 @@ import { exampleSongSolfege, exampleSongSymbol } from '../fixtures/song';
 import songWithIntro from '../fixtures/song_with_intro';
 
 import { GRID } from '../../src/constants';
-import { ContentType } from '../../src/chord_sheet_serializer';
+import { ContentType } from '../../src/serialized_types';
 import Configuration from '../../src/formatter/configuration/configuration';
 
 import {

--- a/test/formatter/configuration.test.ts
+++ b/test/formatter/configuration.test.ts
@@ -1,0 +1,15 @@
+import Configuration from '../../src/formatter/configuration/configuration';
+
+describe('Configuration', () => {
+  it('merges in default delegates', () => {
+    const customDelegate = (content: string) => content.toUpperCase();
+
+    const configuration = new Configuration({
+      delegates: {
+        abc: customDelegate,
+      },
+    });
+
+    expect(configuration.delegates.abc).toEqual(customDelegate);
+  });
+});

--- a/test/formatter/html_div_formatter.test.ts
+++ b/test/formatter/html_div_formatter.test.ts
@@ -110,6 +110,42 @@ describe('HtmlDivFormatter', () => {
           </div>
         </div>
         
+        <div class="paragraph tab">
+          <div class="row">
+            <h3 class="label">Tab 1</h3>
+          </div>
+          <div class="row">
+            <div class="literal">Tab line 1</div>
+          </div>
+          <div class="row">
+            <div class="literal">Tab line 2</div>
+          </div>
+        </div>
+        
+        <div class="paragraph abc">
+          <div class="row">
+            <h3 class="label">ABC 1</h3>
+          </div>
+          <div class="row">
+            <div class="literal">ABC line 1</div>
+          </div>
+          <div class="row">
+            <div class="literal">ABC line 2</div>
+          </div>
+        </div>
+        
+        <div class="paragraph ly">
+          <div class="row">
+            <h3 class="label">LY 1</h3>
+          </div>
+          <div class="row">
+            <div class="literal">LY line 1</div>
+          </div>
+          <div class="row">
+            <div class="literal">LY line 2</div>
+          </div>
+        </div>
+        
         <div class="paragraph bridge">
           <div class="row">
             <h3 class="label">Bridge 1</h3>
@@ -127,22 +163,10 @@ describe('HtmlDivFormatter', () => {
             <h3 class="label">Grid 1</h3>
           </div>
           <div class="row">
-            <div class="column">
-              <div class="chord"></div>
-              <div class="lyrics">Grid line</div>
-            </div>
-          </div>
-        </div>
-        
-        <div class="paragraph tab">
-          <div class="row">
-            <h3 class="label">Tab 1</h3>
+            <div class="literal">Grid line 1</div>
           </div>
           <div class="row">
-            <div class="column">
-              <div class="chord"></div>
-              <div class="lyrics">Tab line</div>
-            </div>
+            <div class="literal">Grid line 2</div>
           </div>
         </div>
       </div>
@@ -253,6 +277,42 @@ describe('HtmlDivFormatter', () => {
           </div>
         </div>
         
+        <div class="paragraph tab">
+          <div class="row">
+            <h3 class="label">Tab 1</h3>
+          </div>
+          <div class="row">
+            <div class="literal">Tab line 1</div>
+          </div>
+          <div class="row">
+            <div class="literal">Tab line 2</div>
+          </div>
+        </div>
+        
+        <div class="paragraph abc">
+          <div class="row">
+            <h3 class="label">ABC 1</h3>
+          </div>
+          <div class="row">
+            <div class="literal">ABC line 1</div>
+          </div>
+          <div class="row">
+            <div class="literal">ABC line 2</div>
+          </div>
+        </div>
+        
+        <div class="paragraph ly">
+          <div class="row">
+            <h3 class="label">LY 1</h3>
+          </div>
+          <div class="row">
+            <div class="literal">LY line 1</div>
+          </div>
+          <div class="row">
+            <div class="literal">LY line 2</div>
+          </div>
+        </div>
+        
         <div class="paragraph bridge">
           <div class="row">
             <h3 class="label">Bridge 1</h3>
@@ -270,22 +330,10 @@ describe('HtmlDivFormatter', () => {
             <h3 class="label">Grid 1</h3>
           </div>
           <div class="row">
-            <div class="column">
-              <div class="chord"></div>
-              <div class="lyrics">Grid line</div>
-            </div>
-          </div>
-        </div>
-        
-        <div class="paragraph tab">
-          <div class="row">
-            <h3 class="label">Tab 1</h3>
+            <div class="literal">Grid line 1</div>
           </div>
           <div class="row">
-            <div class="column">
-              <div class="chord"></div>
-              <div class="lyrics">Tab line</div>
-            </div>
+            <div class="literal">Grid line 2</div>
           </div>
         </div>
       </div>
@@ -572,6 +620,42 @@ describe('HtmlDivFormatter', () => {
           </div>
         </div>
         
+        <div class="paragraph tab">
+          <div class="row">
+            <h3 class="label">Tab 1</h3>
+          </div>
+          <div class="row">
+            <div class="literal">Tab line 1</div>
+          </div>
+          <div class="row">
+            <div class="literal">Tab line 2</div>
+          </div>
+        </div>
+        
+        <div class="paragraph abc">
+          <div class="row">
+            <h3 class="label">ABC 1</h3>
+          </div>
+          <div class="row">
+            <div class="literal">ABC line 1</div>
+          </div>
+          <div class="row">
+            <div class="literal">ABC line 2</div>
+          </div>
+        </div>
+        
+        <div class="paragraph ly">
+          <div class="row">
+            <h3 class="label">LY 1</h3>
+          </div>
+          <div class="row">
+            <div class="literal">LY line 1</div>
+          </div>
+          <div class="row">
+            <div class="literal">LY line 2</div>
+          </div>
+        </div>
+        
         <div class="paragraph bridge">
           <div class="row">
             <h3 class="label">Bridge 1</h3>
@@ -583,26 +667,16 @@ describe('HtmlDivFormatter', () => {
             </div>
           </div>
         </div>
+        
         <div class="paragraph grid">
           <div class="row">
             <h3 class="label">Grid 1</h3>
           </div>
           <div class="row">
-            <div class="column">
-              <div class="chord"></div>
-              <div class="lyrics">Grid line</div>
-            </div>
-          </div>
-        </div>
-        <div class="paragraph tab">
-          <div class="row">
-            <h3 class="label">Tab 1</h3>
+            <div class="literal">Grid line 1</div>
           </div>
           <div class="row">
-            <div class="column">
-              <div class="chord"></div>
-              <div class="lyrics">Tab line</div>
-            </div>
+            <div class="literal">Grid line 2</div>
           </div>
         </div>
       </div>
@@ -714,6 +788,42 @@ describe('HtmlDivFormatter', () => {
           </div>
         </div>
         
+        <div class="paragraph tab">
+          <div class="row">
+            <h3 class="label">Tab 1</h3>
+          </div>
+          <div class="row">
+            <div class="literal">Tab line 1</div>
+          </div>
+          <div class="row">
+            <div class="literal">Tab line 2</div>
+          </div>
+        </div>
+        
+        <div class="paragraph abc">
+          <div class="row">
+            <h3 class="label">ABC 1</h3>
+          </div>
+          <div class="row">
+            <div class="literal">ABC line 1</div>
+          </div>
+          <div class="row">
+            <div class="literal">ABC line 2</div>
+          </div>
+        </div>
+        
+        <div class="paragraph ly">
+          <div class="row">
+            <h3 class="label">LY 1</h3>
+          </div>
+          <div class="row">
+            <div class="literal">LY line 1</div>
+          </div>
+          <div class="row">
+            <div class="literal">LY line 2</div>
+          </div>
+        </div>
+        
         <div class="paragraph bridge">
           <div class="row">
             <h3 class="label">Bridge 1</h3>
@@ -725,26 +835,16 @@ describe('HtmlDivFormatter', () => {
             </div>
           </div>
         </div>
+        
         <div class="paragraph grid">
           <div class="row">
             <h3 class="label">Grid 1</h3>
           </div>
           <div class="row">
-            <div class="column">
-              <div class="chord"></div>
-              <div class="lyrics">Grid line</div>
-            </div>
-          </div>
-        </div>
-        <div class="paragraph tab">
-          <div class="row">
-            <h3 class="label">Tab 1</h3>
+            <div class="literal">Grid line 1</div>
           </div>
           <div class="row">
-            <div class="column">
-              <div class="chord"></div>
-              <div class="lyrics">Tab line</div>
-            </div>
+            <div class="literal">Grid line 2</div>
           </div>
         </div>
       </div>

--- a/test/formatter/html_div_formatter.test.ts
+++ b/test/formatter/html_div_formatter.test.ts
@@ -3,7 +3,8 @@ import { exampleSongSolfege, exampleSongSymbol } from '../fixtures/song';
 
 import { scopedCss } from '../../src/formatter/html_div_formatter';
 import { stripHTML } from '../../src/template_helpers';
-import ChordSheetSerializer, { ContentType } from '../../src/chord_sheet_serializer';
+import ChordSheetSerializer from '../../src/chord_sheet_serializer';
+import { ContentType } from '../../src/serialized_types';
 import { GRID } from '../../src/constants';
 import Configuration from '../../src/formatter/configuration/configuration';
 

--- a/test/formatter/html_div_formatter.test.ts
+++ b/test/formatter/html_div_formatter.test.ts
@@ -113,36 +113,30 @@ describe('HtmlDivFormatter', () => {
         <div class="paragraph tab">
           <div class="row">
             <h3 class="label">Tab 1</h3>
-          </div>
-          <div class="row">
-            <div class="literal">Tab line 1</div>
-          </div>
-          <div class="row">
-            <div class="literal">Tab line 2</div>
+            <div class="literal">
+              Tab line 1<br>
+              Tab line 2
+            </div>
           </div>
         </div>
         
         <div class="paragraph abc">
           <div class="row">
             <h3 class="label">ABC 1</h3>
-          </div>
-          <div class="row">
-            <div class="literal">ABC line 1</div>
-          </div>
-          <div class="row">
-            <div class="literal">ABC line 2</div>
+            <div class="literal">
+              ABC line 1<br>
+              ABC line 2
+            </div>
           </div>
         </div>
         
         <div class="paragraph ly">
           <div class="row">
             <h3 class="label">LY 1</h3>
-          </div>
-          <div class="row">
-            <div class="literal">LY line 1</div>
-          </div>
-          <div class="row">
-            <div class="literal">LY line 2</div>
+            <div class="literal">
+              LY line 1<br>
+              LY line 2
+            </div>
           </div>
         </div>
         
@@ -161,12 +155,10 @@ describe('HtmlDivFormatter', () => {
         <div class="paragraph grid">
           <div class="row">
             <h3 class="label">Grid 1</h3>
-          </div>
-          <div class="row">
-            <div class="literal">Grid line 1</div>
-          </div>
-          <div class="row">
-            <div class="literal">Grid line 2</div>
+            <div class="literal">
+              Grid line 1<br>
+              Grid line 2
+            </div>
           </div>
         </div>
       </div>
@@ -280,36 +272,30 @@ describe('HtmlDivFormatter', () => {
         <div class="paragraph tab">
           <div class="row">
             <h3 class="label">Tab 1</h3>
-          </div>
-          <div class="row">
-            <div class="literal">Tab line 1</div>
-          </div>
-          <div class="row">
-            <div class="literal">Tab line 2</div>
+            <div class="literal">
+              Tab line 1<br>
+              Tab line 2
+            </div>
           </div>
         </div>
         
         <div class="paragraph abc">
           <div class="row">
             <h3 class="label">ABC 1</h3>
-          </div>
-          <div class="row">
-            <div class="literal">ABC line 1</div>
-          </div>
-          <div class="row">
-            <div class="literal">ABC line 2</div>
+            <div class="literal">
+              ABC line 1<br>
+              ABC line 2
+            </div>
           </div>
         </div>
         
         <div class="paragraph ly">
           <div class="row">
             <h3 class="label">LY 1</h3>
-          </div>
-          <div class="row">
-            <div class="literal">LY line 1</div>
-          </div>
-          <div class="row">
-            <div class="literal">LY line 2</div>
+            <div class="literal">
+              LY line 1<br>
+              LY line 2
+            </div>
           </div>
         </div>
         
@@ -328,12 +314,10 @@ describe('HtmlDivFormatter', () => {
         <div class="paragraph grid">
           <div class="row">
             <h3 class="label">Grid 1</h3>
-          </div>
-          <div class="row">
-            <div class="literal">Grid line 1</div>
-          </div>
-          <div class="row">
-            <div class="literal">Grid line 2</div>
+            <div class="literal">
+              Grid line 1<br>
+              Grid line 2
+            </div>
           </div>
         </div>
       </div>
@@ -623,36 +607,30 @@ describe('HtmlDivFormatter', () => {
         <div class="paragraph tab">
           <div class="row">
             <h3 class="label">Tab 1</h3>
-          </div>
-          <div class="row">
-            <div class="literal">Tab line 1</div>
-          </div>
-          <div class="row">
-            <div class="literal">Tab line 2</div>
+            <div class="literal">
+              Tab line 1<br>
+              Tab line 2
+            </div>
           </div>
         </div>
         
         <div class="paragraph abc">
           <div class="row">
             <h3 class="label">ABC 1</h3>
-          </div>
-          <div class="row">
-            <div class="literal">ABC line 1</div>
-          </div>
-          <div class="row">
-            <div class="literal">ABC line 2</div>
+            <div class="literal">
+              ABC line 1<br>
+              ABC line 2
+            </div>
           </div>
         </div>
         
         <div class="paragraph ly">
           <div class="row">
             <h3 class="label">LY 1</h3>
-          </div>
-          <div class="row">
-            <div class="literal">LY line 1</div>
-          </div>
-          <div class="row">
-            <div class="literal">LY line 2</div>
+            <div class="literal">
+              LY line 1<br>
+              LY line 2
+            </div>
           </div>
         </div>
         
@@ -671,12 +649,10 @@ describe('HtmlDivFormatter', () => {
         <div class="paragraph grid">
           <div class="row">
             <h3 class="label">Grid 1</h3>
-          </div>
-          <div class="row">
-            <div class="literal">Grid line 1</div>
-          </div>
-          <div class="row">
-            <div class="literal">Grid line 2</div>
+            <div class="literal">
+              Grid line 1<br>
+              Grid line 2
+            </div>
           </div>
         </div>
       </div>
@@ -791,36 +767,30 @@ describe('HtmlDivFormatter', () => {
         <div class="paragraph tab">
           <div class="row">
             <h3 class="label">Tab 1</h3>
-          </div>
-          <div class="row">
-            <div class="literal">Tab line 1</div>
-          </div>
-          <div class="row">
-            <div class="literal">Tab line 2</div>
+            <div class="literal">
+              Tab line 1<br>
+              Tab line 2
+            </div>
           </div>
         </div>
         
         <div class="paragraph abc">
           <div class="row">
             <h3 class="label">ABC 1</h3>
-          </div>
-          <div class="row">
-            <div class="literal">ABC line 1</div>
-          </div>
-          <div class="row">
-            <div class="literal">ABC line 2</div>
+            <div class="literal">
+              ABC line 1<br>
+              ABC line 2
+            </div>
           </div>
         </div>
         
         <div class="paragraph ly">
           <div class="row">
             <h3 class="label">LY 1</h3>
-          </div>
-          <div class="row">
-            <div class="literal">LY line 1</div>
-          </div>
-          <div class="row">
-            <div class="literal">LY line 2</div>
+            <div class="literal">
+              LY line 1<br>
+              LY line 2
+            </div>
           </div>
         </div>
         
@@ -839,12 +809,10 @@ describe('HtmlDivFormatter', () => {
         <div class="paragraph grid">
           <div class="row">
             <h3 class="label">Grid 1</h3>
-          </div>
-          <div class="row">
-            <div class="literal">Grid line 1</div>
-          </div>
-          <div class="row">
-            <div class="literal">Grid line 2</div>
+            <div class="literal">
+              Grid line 1<br>
+              Grid line 2
+            </div>
           </div>
         </div>
       </div>

--- a/test/formatter/html_table_formatter.test.ts
+++ b/test/formatter/html_table_formatter.test.ts
@@ -24,7 +24,9 @@ describe('HtmlTableFormatter', () => {
         <div class="paragraph verse">
           <table class="row">
             <tr>
-              <td><h3 class="label">Verse 1</h3></td>
+              <td>
+                <h3 class="label">Verse 1</h3>
+              </td>
             </tr>
           </table>
           <table class="row">
@@ -88,6 +90,66 @@ describe('HtmlTableFormatter', () => {
           </table>
         </div>
         
+        <div class="paragraph tab">
+          <table class="row">
+            <tr>
+              <td>
+                <h3 class="label">Tab 1</h3>
+              </td>
+            </tr>
+          </table>
+          <table class="row">
+            <tr>
+              <td class="literal">Tab line 1</td>
+            </tr>
+          </table>
+          <table class="row">
+            <tr>
+              <td class="literal">Tab line 2</td>
+            </tr>
+          </table>
+        </div>
+        
+        <div class="paragraph abc">
+          <table class="row">
+            <tr>
+              <td>
+                <h3 class="label">ABC 1</h3>
+              </td>
+            </tr>
+          </table>
+          <table class="row">
+            <tr>
+              <td class="literal">ABC line 1</td>
+            </tr>
+          </table>
+          <table class="row">
+            <tr>
+              <td class="literal">ABC line 2</td>
+            </tr>
+          </table>
+        </div>
+        
+        <div class="paragraph ly">
+          <table class="row">
+            <tr>
+              <td>
+                <h3 class="label">LY 1</h3>
+              </td>
+            </tr>
+          </table>
+          <table class="row">
+            <tr>
+              <td class="literal">LY line 1</td>
+            </tr>
+          </table>
+          <table class="row">
+            <tr>
+              <td class="literal">LY line 2</td>
+            </tr>
+          </table>
+        </div>
+        
         <div class="paragraph bridge">
           <table class="row">
             <tr>
@@ -96,6 +158,7 @@ describe('HtmlTableFormatter', () => {
               </td>
             </tr>
           </table>
+          
           <table class="row">
             <tr>
               <td class="lyrics">Bridge line</td>
@@ -113,22 +176,12 @@ describe('HtmlTableFormatter', () => {
           </table>
           <table class="row">
             <tr>
-              <td class="lyrics">Grid line</td>
-            </tr>
-          </table>
-        </div>
-        
-        <div class="paragraph tab">
-          <table class="row">
-            <tr>
-              <td>
-                <h3 class="label">Tab 1</h3>
-              </td>
+              <td class="literal">Grid line 1</td>
             </tr>
           </table>
           <table class="row">
             <tr>
-              <td class="lyrics">Tab line</td>
+              <td class="literal">Grid line 2</td>
             </tr>
           </table>
         </div>
@@ -218,36 +271,6 @@ describe('HtmlTableFormatter', () => {
           </table>
         </div>
         
-        <div class="paragraph bridge">
-          <table class="row">
-            <tr>
-              <td>
-                <h3 class="label">Bridge 1</h3>
-              </td>
-            </tr>
-          </table>
-          <table class="row">
-            <tr>
-              <td class="lyrics">Bridge line</td>
-            </tr>
-          </table>
-        </div>
-        
-        <div class="paragraph grid">
-          <table class="row">
-            <tr>
-              <td>
-                <h3 class="label">Grid 1</h3>
-              </td>
-            </tr>
-          </table>
-          <table class="row">
-            <tr>
-              <td class="lyrics">Grid line</td>
-            </tr>
-          </table>
-        </div>
-        
         <div class="paragraph tab">
           <table class="row">
             <tr>
@@ -258,11 +281,91 @@ describe('HtmlTableFormatter', () => {
           </table>
           <table class="row">
             <tr>
-              <td class="lyrics">Tab line</td>
+              <td class="literal">Tab line 1</td>
             </tr>
           </table>
+          <table class="row">
+            <tr>
+              <td class="literal">Tab line 2</td>
+              </tr>
+            </table>
+          </div>
+              
+          <div class="paragraph abc">
+            <table class="row">
+              <tr>
+                <td>
+                  <h3 class="label">ABC 1</h3>
+                </td>
+              </tr>
+            </table>
+            <table class="row">
+              <tr>
+                <td class="literal">ABC line 1</td>
+              </tr>
+            </table>
+            <table class="row">
+              <tr>
+                <td class="literal">ABC line 2</td>
+              </tr>
+            </table>
+          </div>
+          
+          <div class="paragraph ly">
+            <table class="row">
+              <tr>
+                <td>
+                  <h3 class="label">LY 1</h3>
+                </td>
+              </tr>
+            </table>
+            <table class="row">
+              <tr>
+                <td class="literal">LY line 1</td>
+              </tr>
+            </table>
+            <table class="row">
+              <tr>
+                <td class="literal">LY line 2</td>
+              </tr>
+            </table>
+          </div>
+          
+          <div class="paragraph bridge">
+            <table class="row">
+              <tr>
+                <td>
+                  <h3 class="label">Bridge 1</h3>
+                </td>
+              </tr>
+            </table>
+            <table class="row">
+              <tr>
+                <td class="lyrics">Bridge line</td>
+              </tr>
+            </table>
+          </div>
+          
+          <div class="paragraph grid">
+            <table class="row">
+              <tr>
+                <td>
+                  <h3 class="label">Grid 1</h3>
+                </td>
+              </tr>
+            </table>
+            <table class="row">
+              <tr>
+                <td class="literal">Grid line 1</td>
+              </tr>
+            </table>
+            <table class="row">
+              <tr>
+                <td class="literal">Grid line 2</td>
+              </tr>
+            </table>
+          </div>
         </div>
-      </div>
     `);
 
     expect(new HtmlTableFormatter().format(exampleSongSolfege)).toEqual(expectedChordSheet);
@@ -538,35 +641,7 @@ describe('HtmlTableFormatter', () => {
             </tr>
           </table>
         </div>
-        <div class="paragraph bridge">
-          <table class="row">
-            <tr>
-              <td>
-                <h3 class="label">Bridge 1</h3>
-              </td>
-            </tr>
-          </table>
-          
-          <table class="row">
-            <tr>
-              <td class="lyrics">Bridge line</td>
-            </tr>
-          </table>
-        </div>
-        <div class="paragraph grid">
-          <table class="row">
-            <tr>
-              <td>
-                <h3 class="label">Grid 1</h3>
-              </td>
-            </tr>
-          </table>
-          <table class="row">
-            <tr>
-              <td class="lyrics">Grid line</td>
-            </tr>
-          </table>
-        </div>
+        
         <div class="paragraph tab">
           <table class="row">
             <tr>
@@ -577,7 +652,87 @@ describe('HtmlTableFormatter', () => {
           </table>
           <table class="row">
             <tr>
-              <td class="lyrics">Tab line</td>
+              <td class="literal">Tab line 1</td>
+            </tr>
+          </table>
+          <table class="row">
+            <tr>
+              <td class="literal">Tab line 2</td>
+            </tr>
+          </table>
+        </div>
+        
+        <div class="paragraph abc">
+          <table class="row">
+            <tr>
+              <td>
+                <h3 class="label">ABC 1</h3>
+              </td>
+            </tr>
+          </table>
+          <table class="row">
+            <tr>
+              <td class="literal">ABC line 1</td>
+            </tr>
+          </table>
+          <table class="row">
+            <tr>
+              <td class="literal">ABC line 2</td>
+            </tr>
+          </table>
+        </div>
+        
+        <div class="paragraph ly">
+          <table class="row">
+            <tr>
+              <td>
+                <h3 class="label">LY 1</h3>
+              </td>
+            </tr>
+          </table>
+          <table class="row">
+            <tr>
+              <td class="literal">LY line 1</td>
+            </tr>
+          </table>
+          <table class="row">
+            <tr>
+              <td class="literal">LY line 2</td>
+            </tr>
+          </table>
+        </div>
+        
+        <div class="paragraph bridge">
+          <table class="row">
+            <tr>
+              <td>
+                <h3 class="label">Bridge 1</h3>
+              </td>
+            </tr>
+          </table>
+          <table class="row">
+            <tr>
+              <td class="lyrics">Bridge line</td>
+            </tr>
+          </table>
+        </div>
+        
+        <div class="paragraph grid">
+          <table class="row">
+            <tr>
+              <td>
+                <h3 class="label">Grid 1</h3>
+              </td>
+            </tr>
+          </table>
+          <table class="row">
+            <tr>
+              <td class="literal">Grid line 1</td>
+            </tr>
+          </table>
+          <table class="row">
+            <tr>
+              <td class="literal">Grid line 2</td>
             </tr>
           </table>
         </div>

--- a/test/formatter/html_table_formatter.test.ts
+++ b/test/formatter/html_table_formatter.test.ts
@@ -5,7 +5,8 @@ import '../matchers';
 import { exampleSongSolfege, exampleSongSymbol } from '../fixtures/song';
 import { scopedCss } from '../../src/formatter/html_table_formatter';
 import { stripHTML } from '../../src/template_helpers';
-import ChordSheetSerializer, { ContentType } from '../../src/chord_sheet_serializer';
+import ChordSheetSerializer from '../../src/chord_sheet_serializer';
+import { ContentType } from '../../src/serialized_types';
 
 import {
   chordLyricsPair, createSongFromAst, heredoc, html, section,

--- a/test/formatter/html_table_formatter.test.ts
+++ b/test/formatter/html_table_formatter.test.ts
@@ -91,61 +91,37 @@ describe('HtmlTableFormatter', () => {
         </div>
         
         <div class="paragraph tab">
-          <table class="row">
+          <table class="literal">
             <tr>
-              <td>
-                <h3 class="label">Tab 1</h3>
+              <td class="label">Tab 1</td>
+              <td class="contents">
+                Tab line 1<br>
+                Tab line 2
               </td>
-            </tr>
-          </table>
-          <table class="row">
-            <tr>
-              <td class="literal">Tab line 1</td>
-            </tr>
-          </table>
-          <table class="row">
-            <tr>
-              <td class="literal">Tab line 2</td>
             </tr>
           </table>
         </div>
         
         <div class="paragraph abc">
-          <table class="row">
+          <table class="literal">
             <tr>
-              <td>
-                <h3 class="label">ABC 1</h3>
+              <td class="label">ABC 1</td>
+              <td class="contents">
+                ABC line 1<br>
+                ABC line 2
               </td>
-            </tr>
-          </table>
-          <table class="row">
-            <tr>
-              <td class="literal">ABC line 1</td>
-            </tr>
-          </table>
-          <table class="row">
-            <tr>
-              <td class="literal">ABC line 2</td>
             </tr>
           </table>
         </div>
         
         <div class="paragraph ly">
-          <table class="row">
+          <table class="literal">
             <tr>
-              <td>
-                <h3 class="label">LY 1</h3>
+              <td class="label">LY 1</td>
+              <td class="contents">
+                LY line 1<br>
+                LY line 2
               </td>
-            </tr>
-          </table>
-          <table class="row">
-            <tr>
-              <td class="literal">LY line 1</td>
-            </tr>
-          </table>
-          <table class="row">
-            <tr>
-              <td class="literal">LY line 2</td>
             </tr>
           </table>
         </div>
@@ -158,35 +134,25 @@ describe('HtmlTableFormatter', () => {
               </td>
             </tr>
           </table>
-          
           <table class="row">
-            <tr>
-              <td class="lyrics">Bridge line</td>
-            </tr>
-          </table>
-        </div>
-        
-        <div class="paragraph grid">
-          <table class="row">
-            <tr>
-              <td>
-                <h3 class="label">Grid 1</h3>
-              </td>
-            </tr>
-          </table>
-          <table class="row">
-            <tr>
-              <td class="literal">Grid line 1</td>
-            </tr>
-          </table>
-          <table class="row">
-            <tr>
-              <td class="literal">Grid line 2</td>
-            </tr>
-          </table>
-        </div>
+          <tr>
+            <td class="lyrics">Bridge line</td>
+          </tr>
+        </table>
       </div>
-    `);
+      
+      <div class="paragraph grid">
+        <table class="literal">
+          <tr>
+            <td class="label">Grid 1</td>
+            <td class="contents">
+              Grid line 1<br>
+              Grid line 2
+            </td>
+          </tr>
+        </table>
+      </div>
+    </div>`);
 
     expect(new HtmlTableFormatter().format(exampleSongSymbol)).toEqual(expectedChordSheet);
   });
@@ -272,100 +238,68 @@ describe('HtmlTableFormatter', () => {
         </div>
         
         <div class="paragraph tab">
+          <table class="literal">
+            <tr>
+              <td class="label">Tab 1</td>
+              <td class="contents">
+                Tab line 1<br>
+                Tab line 2
+              </td>
+            </tr>
+          </table>
+        </div>
+        
+        <div class="paragraph abc">
+          <table class="literal">
+            <tr>
+              <td class="label">ABC 1</td>
+              <td class="contents">
+                ABC line 1<br>
+                ABC line 2
+              </td>
+            </tr>
+          </table>
+        </div>
+        
+        <div class="paragraph ly">
+          <table class="literal">
+            <tr>
+              <td class="label">LY 1</td>
+              <td class="contents">
+                LY line 1<br>
+                LY line 2
+              </td>
+            </tr>
+          </table>
+        </div>
+        
+        <div class="paragraph bridge">
           <table class="row">
             <tr>
               <td>
-                <h3 class="label">Tab 1</h3>
+                <h3 class="label">Bridge 1</h3>
               </td>
             </tr>
           </table>
           <table class="row">
             <tr>
-              <td class="literal">Tab line 1</td>
+              <td class="lyrics">Bridge line</td>
             </tr>
           </table>
-          <table class="row">
-            <tr>
-              <td class="literal">Tab line 2</td>
-              </tr>
-            </table>
-          </div>
-              
-          <div class="paragraph abc">
-            <table class="row">
-              <tr>
-                <td>
-                  <h3 class="label">ABC 1</h3>
-                </td>
-              </tr>
-            </table>
-            <table class="row">
-              <tr>
-                <td class="literal">ABC line 1</td>
-              </tr>
-            </table>
-            <table class="row">
-              <tr>
-                <td class="literal">ABC line 2</td>
-              </tr>
-            </table>
-          </div>
-          
-          <div class="paragraph ly">
-            <table class="row">
-              <tr>
-                <td>
-                  <h3 class="label">LY 1</h3>
-                </td>
-              </tr>
-            </table>
-            <table class="row">
-              <tr>
-                <td class="literal">LY line 1</td>
-              </tr>
-            </table>
-            <table class="row">
-              <tr>
-                <td class="literal">LY line 2</td>
-              </tr>
-            </table>
-          </div>
-          
-          <div class="paragraph bridge">
-            <table class="row">
-              <tr>
-                <td>
-                  <h3 class="label">Bridge 1</h3>
-                </td>
-              </tr>
-            </table>
-            <table class="row">
-              <tr>
-                <td class="lyrics">Bridge line</td>
-              </tr>
-            </table>
-          </div>
-          
-          <div class="paragraph grid">
-            <table class="row">
-              <tr>
-                <td>
-                  <h3 class="label">Grid 1</h3>
-                </td>
-              </tr>
-            </table>
-            <table class="row">
-              <tr>
-                <td class="literal">Grid line 1</td>
-              </tr>
-            </table>
-            <table class="row">
-              <tr>
-                <td class="literal">Grid line 2</td>
-              </tr>
-            </table>
-          </div>
         </div>
+        
+        <div class="paragraph grid">
+          <table class="literal">
+            <tr>
+              <td class="label">Grid 1</td>
+              <td class="contents">
+                Grid line 1<br>
+                Grid line 2
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
     `);
 
     expect(new HtmlTableFormatter().format(exampleSongSolfege)).toEqual(expectedChordSheet);
@@ -643,99 +577,66 @@ describe('HtmlTableFormatter', () => {
         </div>
         
         <div class="paragraph tab">
-          <table class="row">
+          <table class="literal">
             <tr>
-              <td>
-                <h3 class="label">Tab 1</h3>
+              <td class="label">Tab 1</td>
+              <td class="contents">
+                Tab line 1<br>
+                Tab line 2
               </td>
-            </tr>
-          </table>
-          <table class="row">
-            <tr>
-              <td class="literal">Tab line 1</td>
-            </tr>
-          </table>
-          <table class="row">
-            <tr>
-              <td class="literal">Tab line 2</td>
             </tr>
           </table>
         </div>
         
         <div class="paragraph abc">
-          <table class="row">
+          <table class="literal">
             <tr>
-              <td>
-                <h3 class="label">ABC 1</h3>
+              <td class="label">ABC 1</td>
+              <td class="contents">
+                ABC line 1<br>
+                ABC line 2
               </td>
-            </tr>
-          </table>
-          <table class="row">
-            <tr>
-              <td class="literal">ABC line 1</td>
-            </tr>
-          </table>
-          <table class="row">
-            <tr>
-              <td class="literal">ABC line 2</td>
             </tr>
           </table>
         </div>
         
         <div class="paragraph ly">
-          <table class="row">
+          <table class="literal">
             <tr>
-              <td>
-                <h3 class="label">LY 1</h3>
-              </td>
-            </tr>
-          </table>
-          <table class="row">
-            <tr>
-              <td class="literal">LY line 1</td>
-            </tr>
-          </table>
-          <table class="row">
-            <tr>
-              <td class="literal">LY line 2</td>
-            </tr>
-          </table>
-        </div>
-        
-        <div class="paragraph bridge">
-          <table class="row">
-            <tr>
-              <td>
-                <h3 class="label">Bridge 1</h3>
-              </td>
-            </tr>
-          </table>
-          <table class="row">
-            <tr>
-              <td class="lyrics">Bridge line</td>
-            </tr>
-          </table>
-        </div>
-        
-        <div class="paragraph grid">
-          <table class="row">
-            <tr>
-              <td>
-                <h3 class="label">Grid 1</h3>
-              </td>
-            </tr>
-          </table>
-          <table class="row">
-            <tr>
-              <td class="literal">Grid line 1</td>
-            </tr>
-          </table>
-          <table class="row">
-            <tr>
-              <td class="literal">Grid line 2</td>
-            </tr>
-          </table>
-        </div>
+              <td class="label">LY 1</td>
+              <td class="contents">
+                LY line 1<br>
+                LY line 2</td>
+              </tr>
+            </table>
+          </div>
+          
+          <div class="paragraph bridge">
+            <table class="row">
+              <tr>
+                <td>
+                  <h3 class="label">Bridge 1</h3>
+                </td>
+              </tr>
+            </table>
+            <table class="row">
+              <tr>
+                <td class="lyrics">Bridge line</td>
+              </tr>
+            </table>
+          </div>
+          
+          <div class="paragraph grid">
+            <table class="literal">
+              <tr>
+                <td class="label">Grid 1</td>
+                <td class="contents">
+                  Grid line 1<br>
+                  Grid line 2
+                </td>
+              </tr>
+            </table>
+          </div>
       </div>
     `);
 

--- a/test/formatter/text_formatter.test.ts
+++ b/test/formatter/text_formatter.test.ts
@@ -25,20 +25,30 @@ describe('TextFormatter', () => {
       Em               F              C  G
       Whisper words of wisdom, let it be
       
+      Tab 1
+      Tab line 1
+      Tab line 2
+      
+      ABC 1
+      ABC line 1
+      ABC line 2
+      
+      LY 1
+      LY line 1
+      LY line 2
+      
       Bridge 1
       Bridge line
       
       Grid 1
-      Grid line
-      
-      Tab 1
-      Tab line`;
+      Grid line 1
+      Grid line 2`;
 
     expect(new TextFormatter().format(exampleSongSymbol)).toEqual(expectedChordSheet);
   });
 
   it('formats a solfege song to a text chord sheet correctly', () => {
-    const expectedChordSheet = `
+    const expectedChordSheet = heredoc`
 LET IT BE
 ChordSheetJS example version
 
@@ -54,14 +64,24 @@ Breakdown
 Mim              Fa             Do Sol
 Whisper words of wisdom, let it be
 
+Tab 1
+Tab line 1
+Tab line 2
+
+ABC 1
+ABC line 1
+ABC line 2
+
+LY 1
+LY line 1
+LY line 2
+
 Bridge 1
 Bridge line
 
 Grid 1
-Grid line
-
-Tab 1
-Tab line`.substring(1);
+Grid line 1
+Grid line 2`;
 
     expect(new TextFormatter().format(exampleSongSolfege)).toEqual(expectedChordSheet);
   });
@@ -100,27 +120,37 @@ Let it be, let it be, let it be, let it be`;
     const expectedChordSheet = heredoc`
       LET IT BE
       ChordSheetJS example version
-      
+
       Written by: John Lennon,Paul McCartney
-      
+
       Verse 1
              Cm         Eb/Bb      Ab         Eb
       Let it be, let it be, let it be, let it be
       F       strong   Bb C           Bb F/A Gm F
       Whisper words of wisdom, let it be
-      
+
       Breakdown
       Gm               Ab             Eb Bb
       Whisper words of wisdom, let it be
-      
+
+      Tab 1
+      Tab line 1
+      Tab line 2
+
+      ABC 1
+      ABC line 1
+      ABC line 2
+
+      LY 1
+      LY line 1
+      LY line 2
+
       Bridge 1
       Bridge line
-      
+
       Grid 1
-      Grid line
-      
-      Tab 1
-      Tab line`;
+      Grid line 1
+      Grid line 2`;
 
     expect(new TextFormatter({ key: 'Eb' }).format(exampleSongSymbol)).toEqual(expectedChordSheet);
   });

--- a/test/formatter/text_formatter.test.ts
+++ b/test/formatter/text_formatter.test.ts
@@ -3,7 +3,7 @@ import { exampleSongSolfege, exampleSongSymbol } from '../fixtures/song';
 import songWithIntro from '../fixtures/song_with_intro';
 
 import { GRID } from '../../src/constants';
-import { ContentType } from '../../src/chord_sheet_serializer';
+import { ContentType } from '../../src/serialized_types';
 import Configuration from '../../src/formatter/configuration/configuration';
 
 import {

--- a/test/jest.d.ts
+++ b/test/jest.d.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars, no-undef, @typescript-eslint/no-unused-vars */
 import { TernaryProperties } from '../src/chord_sheet/chord_pro/ternary';
+import { ContentType } from '../src/chord_sheet_serializer';
 
 declare global {
   namespace jest {
@@ -8,7 +9,9 @@ declare global {
 
       toBeChordLyricsPair(chords: string, lyrics: string, annotation?: string): CustomMatcherResult;
 
-      toBeLiteral(contents: string): CustomMatcherResult;
+      toBeLiteral(string: string): CustomMatcherResult;
+
+      toBeSection(_type: ContentType, _contents: string): CustomMatcherResult;
 
       toBeTernary(properties: TernaryProperties): CustomMatcherResult;
 

--- a/test/matchers.ts
+++ b/test/matchers.ts
@@ -1,7 +1,11 @@
 import print from 'print';
 
 import {
-  ChordLyricsPair, Comment, Literal, Tag, Ternary,
+  ChordLyricsPair,
+  Comment,
+  Literal,
+  Tag,
+  Ternary,
 } from '../src';
 
 function typeRepresentation(type, value) {

--- a/test/parser/chord_pro_parser.test.ts
+++ b/test/parser/chord_pro_parser.test.ts
@@ -1,5 +1,12 @@
 import {
-  ChordProParser, CHORUS, NONE, TAB, Ternary, VERSE,
+  ABC,
+  ChordProParser,
+  CHORUS,
+  LILYPOND,
+  NONE,
+  TAB,
+  Ternary,
+  VERSE,
 } from '../../src';
 
 import '../matchers';
@@ -510,5 +517,71 @@ Let it [Am]be
     expect(line1Items[1]).toBeChordLyricsPair('F', 'be, ');
     expect(line1Items[2]).toBeChordLyricsPair('', 'let it ');
     expect(line1Items[3]).toBeChordLyricsPair('C', 'be');
+  });
+
+  it('parses tab sections', () => {
+    const chordSheet = heredoc`
+      {start_of_tab: Intro}
+      Tab line 1
+      Tab line 2
+      {end_of_tab}
+    `;
+
+    const parser = new ChordProParser();
+    const song = parser.parse(chordSheet);
+    const { paragraphs } = song;
+    const paragraph = paragraphs[0];
+    const { lines } = paragraph;
+
+    expect(paragraphs).toHaveLength(1);
+    expect(paragraph.type).toEqual(TAB);
+    expect(lines).toHaveLength(3);
+    expect(lines[0].items[0]).toBeTag('start_of_tab', 'Intro');
+    expect(lines[1].items[0]).toBeLiteral('Tab line 1');
+    expect(lines[2].items[0]).toBeLiteral('Tab line 2');
+  });
+
+  it('parses ABC sections', () => {
+    const chordSheet = heredoc`
+      {start_of_abc: Intro}
+      ABC line 1
+      ABC line 2
+      {end_of_abc}
+    `;
+
+    const parser = new ChordProParser();
+    const song = parser.parse(chordSheet);
+    const { paragraphs } = song;
+    const paragraph = paragraphs[0];
+    const { lines } = paragraph;
+
+    expect(paragraphs).toHaveLength(1);
+    expect(paragraph.type).toEqual(ABC);
+    expect(lines).toHaveLength(3);
+    expect(lines[0].items[0]).toBeTag('start_of_abc', 'Intro');
+    expect(lines[1].items[0]).toBeLiteral('ABC line 1');
+    expect(lines[2].items[0]).toBeLiteral('ABC line 2');
+  });
+
+  it('parses LY sections', () => {
+    const chordSheet = heredoc`
+      {start_of_ly: Intro}
+      LY line 1
+      LY line 2
+      {end_of_ly}
+    `;
+
+    const parser = new ChordProParser();
+    const song = parser.parse(chordSheet);
+    const { paragraphs } = song;
+    const paragraph = paragraphs[0];
+    const { lines } = paragraph;
+
+    expect(paragraphs).toHaveLength(1);
+    expect(paragraph.type).toEqual(LILYPOND);
+    expect(lines).toHaveLength(3);
+    expect(lines[0].items[0]).toBeTag('start_of_ly', 'Intro');
+    expect(lines[1].items[0]).toBeLiteral('LY line 1');
+    expect(lines[2].items[0]).toBeLiteral('LY line 2');
   });
 });

--- a/test/template_helpers.test.ts
+++ b/test/template_helpers.test.ts
@@ -119,13 +119,13 @@ describe('template_helpers', () => {
 
   describe('when', () => {
     it('returns the callback result when the condition is truthy', () => {
-      const callback = () => 'foobar!';
+      const callback = () => 'foobar';
 
-      expect(when(true, callback).toString()).toEqual('foobar!');
-      expect(when('string', callback).toString()).toEqual('foobar!');
-      expect(when({}, callback).toString()).toEqual('foobar!');
-      expect(when(25, callback).toString()).toEqual('foobar!');
-      expect(when([], callback).toString()).toEqual('foobar!');
+      expect(when(true, callback).toString()).toEqual('foobar');
+      expect(when('string', callback).toString()).toEqual('foobar');
+      expect(when({}, callback).toString()).toEqual('foobar');
+      expect(when(25, callback).toString()).toEqual('foobar');
+      expect(when([], callback).toString()).toEqual('foobar');
     });
 
     it('returns an empty string when the condition is falsy', () => {
@@ -139,17 +139,50 @@ describe('template_helpers', () => {
     });
 
     it('allows chaining with then', () => {
-      const callback = () => 'foobar!';
+      expect(when(true).then(() => 'foobar').toString()).toEqual('foobar');
+      expect(when(false).then(() => 'foobar').toString()).toEqual('');
+    });
 
-      expect(when(true).then(callback).toString()).toEqual('foobar!');
-      expect(when(false).then(callback).toString()).toEqual('');
+    it('allows chaining with elseWhen', () => {
+      expect(when(true).then(() => 'when').elseWhen(true, () => 'elseWhen').toString()).toEqual('when');
+      expect(when(false).then(() => 'when').elseWhen(true, () => 'elseWhen').toString()).toEqual('elseWhen');
+      expect(when(false).then(() => 'when').elseWhen(false, () => 'elseWhen').toString()).toEqual('');
+    });
+
+    it('allows chaining with elseWhen and else', () => {
+      expect(
+        when(false)
+          .then(() => 'when')
+          .elseWhen(false, () => 'elseWhen')
+          .else(() => 'else')
+          .toString(),
+      ).toEqual('else');
+    });
+
+    it('allows chaining with else then', () => {
+      expect(
+        when(false)
+          .then(() => 'when')
+          .elseWhen(true)
+          .then(() => 'elseThen')
+          .toString(),
+      ).toEqual('elseThen');
+    });
+
+    it('allows chaining with else then else', () => {
+      expect(
+        when(false)
+          .then(() => 'when')
+          .elseWhen(false)
+          .then(() => 'elseThen')
+          .else(() => 'else')
+          .toString(),
+      ).toEqual('else');
     });
 
     it('allows chaining with else', () => {
-      const elseCallback = () => 'else!';
-
-      expect(when(true).else(elseCallback).toString()).toEqual('');
-      expect(when(false).else(elseCallback).toString()).toEqual('else!');
+      expect(when(true).then(() => 'then').else(() => 'else').toString()).toEqual('then');
+      expect(when(false).then(() => 'then').else(() => 'else').toString()).toEqual('else');
     });
   });
 

--- a/test/template_helpers.test.ts
+++ b/test/template_helpers.test.ts
@@ -1,4 +1,5 @@
 import {
+  ABC,
   ChordLyricsPair,
   CHORUS,
   Comment,
@@ -14,6 +15,8 @@ import {
 import Configuration from '../src/formatter/configuration/configuration';
 import Font from '../src/chord_sheet/font';
 import FontSize from '../src/chord_sheet/font_size';
+import { newlinesToBreaks, renderSection } from '../src/template_helpers';
+import { createLine, createLiteral, createParagraph } from './utilities';
 
 const {
   isChordLyricsPair,
@@ -325,6 +328,33 @@ describe('template_helpers', () => {
       const font = new Font();
 
       expect(fontStyleTag(font)).toEqual('');
+    });
+  });
+
+  describe('#newlinesToBreaks', () => {
+    it('replaces newlines with break tags', () => {
+      const string = 'hello\nworld\n';
+      const expectedString = 'hello<br>world<br>';
+
+      expect(newlinesToBreaks(string)).toEqual(expectedString);
+    });
+  });
+
+  describe('#renderSection', () => {
+    it('returns the result of the delegate function', () => {
+      const paragraph = createParagraph([
+        createLine([createLiteral('hello world')], ABC),
+      ]);
+
+      const configuration = new Configuration(
+        {
+          delegates: {
+            abc: (string: string) => string.toUpperCase(),
+          },
+        },
+      );
+
+      expect(renderSection(paragraph, configuration)).toEqual('HELLO WORLD');
     });
   });
 });

--- a/test/utilities.ts
+++ b/test/utilities.ts
@@ -7,8 +7,9 @@ import { TernaryProperties } from '../src/chord_sheet/chord_pro/ternary';
 import Item from '../src/chord_sheet/item';
 import { ChordType, Modifier } from '../src/constants';
 import Key from '../src/key';
+import ChordSheetSerializer from '../src/chord_sheet_serializer';
 
-import ChordSheetSerializer, {
+import {
   ContentType,
   SerializedChordLyricsPair,
   SerializedComment,
@@ -17,7 +18,7 @@ import ChordSheetSerializer, {
   SerializedSong,
   SerializedTag,
   SerializedTernary,
-} from '../src/chord_sheet_serializer';
+} from '../src/serialized_types';
 
 import {
   ChordLyricsPair, Composite, Line, Literal, NONE, Paragraph, Song, Tag, Ternary,

--- a/test/utilities.ts
+++ b/test/utilities.ts
@@ -4,8 +4,11 @@ import { LineType } from '../src/chord_sheet/line';
 import Metadata from '../src/chord_sheet/metadata';
 import { TernaryProperties } from '../src/chord_sheet/chord_pro/ternary';
 import Item from '../src/chord_sheet/item';
+import { ChordType, Modifier } from '../src/constants';
+import Key from '../src/key';
 
 import ChordSheetSerializer, {
+  ContentType,
   SerializedChordLyricsPair,
   SerializedComment,
   SerializedComposite,
@@ -18,17 +21,9 @@ import ChordSheetSerializer, {
 import {
   ChordLyricsPair, Composite, Line, Literal, NONE, Paragraph, Song, Tag, Ternary,
 } from '../src';
-import { ChordType, Modifier } from '../src/constants';
-import Key from '../src/key';
 
 export function heredoc(strings: TemplateStringsArray, ...values: any[]): string {
   return theredoc(strings, ...values);
-}
-
-export function mark(str: string): string {
-  return str
-    .replace(/\n/g, '␊\n')
-    .replace(/\r/g, '␍\r');
 }
 
 export function createSong(lines, metadata: Record<string, string> = {}) {
@@ -93,6 +88,24 @@ export function createSongFromAst(lines: SerializedItem[][]): Song {
 
 export function tag(name: string, value: string = ''): SerializedTag {
   return { type: 'tag', name, value };
+}
+
+function splitContent(content: string | string[]): string[] {
+  return Array.isArray(content) ? content : content.split('\n');
+}
+
+export function section(
+  sectionType: ContentType,
+  tagValue: string,
+  content: string[] | string,
+  startTag: SerializedTag | null = null,
+  endTag: SerializedTag | null = null,
+): SerializedItem[][] {
+  return [
+    [startTag || tag(`start_of_${sectionType}`, tagValue)],
+    ...splitContent(content).map((line) => [line]),
+    [endTag || tag(`end_of_${sectionType}`)],
+  ];
 }
 
 export function chordLyricsPair(chords: string, lyrics: string, annotation: string = ''): SerializedChordLyricsPair {

--- a/test/utilities.ts
+++ b/test/utilities.ts
@@ -1,4 +1,5 @@
 import theredoc from 'theredoc';
+import { stripHTML } from '../src/template_helpers';
 
 import { LineType } from '../src/chord_sheet/line';
 import Metadata from '../src/chord_sheet/metadata';
@@ -24,6 +25,10 @@ import {
 
 export function heredoc(strings: TemplateStringsArray, ...values: any[]): string {
   return theredoc(strings, ...values);
+}
+
+export function html(strings: TemplateStringsArray, ...values: any[]): string {
+  return stripHTML(theredoc(strings, ...values));
 }
 
 export function createSong(lines, metadata: Record<string, string> = {}) {


### PR DESCRIPTION
Full support for tab, abc, ly (Lilypond) and grid sections.

For example, when encountering a section like:

    {start_of_tab}
    Tab line 1
    Tab line 2
    {end_of_tab}

the contents of the tab section will be parsed as two separate lines
having one item: a `Literal` with it's `string` being the line contents
(without trailing newline).

That also means, `Line`.`items` can not only be `ChordLyricsPair`,
`Comment`, `Tag` or `Ternary`, but also `Literal`.

The is a new template helper called `isLiteral` to check for literals
when rendering a template.

Custom functions or third-party libraries can be used to determine how these sections should be rendered. For example:

```js
new HtmlDivFormatter({
  delegates: {
    abc: (content) => ABCJS.renderAbc("paper", content),
  },
}).format(song);
```

See also:
- https://www.chordpro.org/chordpro/directives-env_tab/
- https://chordpro.org/chordpro/directives-env_abc/
- https://chordpro.org/chordpro/directives-env_ly/
- https://chordpro.org/chordpro/directives-env_grid/

Resolves #757 