### PR TITLE
Metadata always returns strings

### DIFF
--- a/src/chord_sheet/metadata.ts
+++ b/src/chord_sheet/metadata.ts
@@ -132,7 +132,7 @@ class Metadata extends MetadataAccessors {
       return value[0];
     }
 
-    return value as string;
+    return value ?? '';
   }
 
   parseArrayKey(prop: string): [string, number] | null {

--- a/test/integration/setting_key.test.ts
+++ b/test/integration/setting_key.test.ts
@@ -33,7 +33,7 @@ describe('setting the key of an existing song', () => {
     expect(new ChordProFormatter().format(updatedSong)).toEqual(changedSheet);
   });
 
-  it('removes the key directive when passing null', () => {
+  it('uses an empty string for the key directive when passing null', () => {
     const chordpro = heredoc`
       {key: C}
       Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be`;
@@ -44,7 +44,7 @@ describe('setting the key of an existing song', () => {
     const song = new ChordProParser().parse(chordpro);
     const updatedSong = song.setKey(null);
 
-    expect(updatedSong.key).toEqual(undefined);
+    expect(updatedSong.key).toEqual('');
     expect(new ChordProFormatter().format(updatedSong)).toEqual(changedSheet);
   });
 });


### PR DESCRIPTION
Right now the metadata on a song says that every property is always a `string`
https://github.com/martijnversluis/ChordSheetJS/blob/8a4bce85b6e94dd2aab2ae642eead8b44314c802/src/chord_sheet/metadata_accessors.ts#L18-L46

however, if nothing is provided for that piece of metadata, it actually returns `undefined` which disagrees with the typedefs that were set up. This will throw unexpected errors for anyone using this! Here's a simple test of this:

```ts
import { ChordProParser } from 'chordsheetjs';

const testSongNoTitle = `
Verse 1:
[E]I know a p[Bm7]lace
A w[A]onderful p[E]lace
`;

const parser = new ChordProParser();
const doc = parser.parse(testSongNoTitle );
console.log(doc.title.toUpperCase()); //TypeError: Cannot read properties of undefined (reading 'toUpperCase')
```

So there are two possible solutions for this. Either:

- Change all the return types to `string | undefined`
- Always return the type that is says it will by providing a default/blank value of that type - This is what this PR does


I tried that first way, but then a lot of other places would need to be touched to deal with possibly undefined situations in the logic and unit tests. Just having something that says it always returns a string actually returning a string seems much simpler, and I would imagine this would be less headache for anyone using this so that they don't have to deal with possibly undefined properties. Strings are always strings