### PR TITLE
Don't treat an empty paragraph as literal

### DIFF
--- a/src/chord_sheet/paragraph.ts
+++ b/src/chord_sheet/paragraph.ts
@@ -26,19 +26,23 @@ class Paragraph {
    * @returns {boolean}
    */
   isLiteral() {
-    return this
-      .lines
-      .every((line) => line.items.every((item) => {
-        if (item instanceof Literal) {
-          return true;
-        }
+    const { lines } = this;
 
-        if (item instanceof Tag && (item as Tag).isSectionDelimiter()) {
-          return true;
-        }
+    if (lines.length === 0) {
+      return false;
+    }
 
-        return false;
-      }));
+    return lines.every((line) => line.items.every((item) => {
+      if (item instanceof Literal) {
+        return true;
+      }
+
+      if (item instanceof Tag && (item as Tag).isSectionDelimiter()) {
+        return true;
+      }
+
+      return false;
+    }));
   }
 
   /**

--- a/test/chord_sheet/paragraph.test.ts
+++ b/test/chord_sheet/paragraph.test.ts
@@ -70,6 +70,14 @@ describe('Paragraph', () => {
         expect(paragraph.isLiteral()).toBe(false);
       });
     });
+
+    describe('when the paragraph is empty', () => {
+      it('returns false', () => {
+        const paragraph = createParagraph([]);
+
+        expect(paragraph.isLiteral()).toBe(false);
+      });
+    });
   });
 
   describe('#contents', () => {

--- a/test/formatter/html_table_formatter.test.ts
+++ b/test/formatter/html_table_formatter.test.ts
@@ -654,6 +654,34 @@ describe('HtmlTableFormatter', () => {
     expect(new HtmlTableFormatter({ key: 'Eb' }).format(exampleSongSymbol)).toEqual(expectedChordSheet);
   });
 
+  it('correctly renders blank lines', () => {
+    const song = createSongFromAst([
+      [chordLyricsPair('C', 'Whisper words of wisdom')],
+      [],
+      [],
+    ]);
+
+    const expectedOutput = html`
+      <div class="chord-sheet">
+        <div class="paragraph">
+          <table class="row">
+            <tr>
+              <td class="chord">C</td>
+            </tr>
+            <tr>
+              <td class="lyrics">Whisper words of wisdom</td>
+            </tr>
+          </table>
+        </div>
+        <div class="paragraph"></div>
+        <div class="paragraph"></div>
+      </div>
+    `;
+
+    const output = new HtmlTableFormatter().format(song);
+    expect(output).toEqual(expectedOutput);
+  });
+
   describe('with option useUnicodeModifiers:true', () => {
     it('replaces # with unicode sharp', () => {
       const songWithSharps = createSongFromAst([


### PR DESCRIPTION
`Paragraph#isLiteral()` would return `true` for empty paragraphs, which caused formatters to render a literal section with a label containing `"null"`.

Fixes https://github.com/martijnversluis/ChordSheetJS/issues/1163

Thanks to @gpr19 for reporting