### PR TITLE
Allow contribution from people using Windows (V2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "peggy": "^2.0.1",
     "pinst": "^3.0.0",
     "print": "^1.2.0",
+    "shx": "^0.3.4",
     "theredoc": "^1.0.0",
     "ts-jest": "^27.1.4",
     "ts-node": "^10.7.0",
@@ -59,7 +60,7 @@
     "typescript": "^4.6.3"
   },
   "scripts": {
-    "build:suffix-normalize": "rm -rf src/normalize_mappings/suffix-normalize-mapping.ts && ts-node src/normalize_mappings/generate-suffix-normalize-mapping.ts",
+    "build:suffix-normalize": "shx rm -rf src/normalize_mappings/suffix-normalize-mapping.ts && ts-node src/normalize_mappings/generate-suffix-normalize-mapping.ts",
     "build:chord-suffix-grammar": "ts-node script/generate_chord_suffix_grammar.ts",
     "build:pegjs:chordpro": "peggy --plugin ts-pegjs -o src/parser/chord_pro_peg_parser.ts src/parser/chord_pro_grammar.pegjs",
     "build:pegjs:chords-over-words": "ts-node script/generate_parser.ts chords_over_words",
@@ -83,7 +84,7 @@
     "prelint": "yarn build:code-generate",
     "lint": "yarn prelint && yarn eslint .",
     "lint:fix": "yarn prelint && yarn eslint:fix .",
-    "clean": "rm -rf node_modules && rm -rf lib",
+    "clean": "shx rm -rf node_modules && shx rm -rf lib",
     "readme": "node_modules/.bin/jsdoc2md -f src/**/*.ts -f src/*.ts --configure ./jsdoc2md.json --template doc/README.hbs > README.md",
     "prepublish": "pinst --disable && yarn install && yarn test && yarn build",
     "postpublish": "pinst --enable",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4456,6 +4456,7 @@ __metadata:
     peggy: "npm:^2.0.1"
     pinst: "npm:^3.0.0"
     print: "npm:^1.2.0"
+    shx: "npm:^0.3.4"
     theredoc: "npm:^1.0.0"
     ts-jest: "npm:^27.1.4"
     ts-node: "npm:^10.7.0"
@@ -5995,7 +5996,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.1.1, glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6, glob@npm:^7.2.0":
+"glob@npm:^7.0.0, glob@npm:^7.1.1, glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6, glob@npm:^7.2.0":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
   dependencies:
@@ -6393,6 +6394,13 @@ __metadata:
     has: "npm:^1.0.3"
     side-channel: "npm:^1.0.4"
   checksum: 10c0/66d8a66b4b5310c042e8ad00ce895dc55cb25165a3a7da0d7862ca18d69d3b1ba86511b4bf3baf4273d744d3f6e9154574af45189ef11135a444945309e39e4a
+  languageName: node
+  linkType: hard
+
+"interpret@npm:^1.0.0":
+  version: 1.4.0
+  resolution: "interpret@npm:1.4.0"
+  checksum: 10c0/08c5ad30032edeec638485bc3f6db7d0094d9b3e85e0f950866600af3c52e9fd69715416d29564731c479d9f4d43ff3e4d302a178196bdc0e6837ec147640450
   languageName: node
   linkType: hard
 
@@ -7946,6 +7954,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimist@npm:^1.2.3":
+  version: 1.2.8
+  resolution: "minimist@npm:1.2.8"
+  checksum: 10c0/19d3fcdca050087b84c2029841a093691a91259a47def2f18222f41e7645a0b7c44ef4b40e88a1e58a40c84d2ef0ee6047c55594d298146d0eb3f6b737c20ce6
+  languageName: node
+  linkType: hard
+
 "minipass-collect@npm:^2.0.1":
   version: 2.0.1
   resolution: "minipass-collect@npm:2.0.1"
@@ -8817,6 +8832,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rechoir@npm:^0.6.2":
+  version: 0.6.2
+  resolution: "rechoir@npm:0.6.2"
+  dependencies:
+    resolve: "npm:^1.1.6"
+  checksum: 10c0/22c4bb32f4934a9468468b608417194f7e3ceba9a508512125b16082c64f161915a28467562368eeb15dc16058eb5b7c13a20b9eb29ff9927d1ebb3b5aa83e84
+  languageName: node
+  linkType: hard
+
 "reduce-extract@npm:^1.0.0":
   version: 1.0.0
   resolution: "reduce-extract@npm:1.0.0"
@@ -9018,6 +9042,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve@npm:^1.1.6, resolve@npm:^1.22.4":
+  version: 1.22.8
+  resolution: "resolve@npm:1.22.8"
+  dependencies:
+    is-core-module: "npm:^2.13.0"
+    path-parse: "npm:^1.0.7"
+    supports-preserve-symlinks-flag: "npm:^1.0.0"
+  bin:
+    resolve: bin/resolve
+  checksum: 10c0/07e179f4375e1fd072cfb72ad66d78547f86e6196c4014b31cb0b8bb1db5f7ca871f922d08da0fbc05b94e9fd42206f819648fa3b5b873ebbc8e1dc68fec433a
+  languageName: node
+  linkType: hard
+
 "resolve@npm:^1.14.2, resolve@npm:^1.20.0":
   version: 1.22.3
   resolution: "resolve@npm:1.22.3"
@@ -9031,16 +9068,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.22.4":
+"resolve@patch:resolve@npm%3A^1.1.6#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>":
   version: 1.22.8
-  resolution: "resolve@npm:1.22.8"
+  resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
   dependencies:
     is-core-module: "npm:^2.13.0"
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/07e179f4375e1fd072cfb72ad66d78547f86e6196c4014b31cb0b8bb1db5f7ca871f922d08da0fbc05b94e9fd42206f819648fa3b5b873ebbc8e1dc68fec433a
+  checksum: 10c0/0446f024439cd2e50c6c8fa8ba77eaa8370b4180f401a96abf3d1ebc770ac51c1955e12764cde449fde3fff480a61f84388e3505ecdbab778f4bef5f8212c729
   languageName: node
   linkType: hard
 
@@ -9054,19 +9091,6 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: 10c0/6267bdbbbb1da23975463e979dadf5135fcc40c4b9281c5af4581afa848ced98090ab4e2dbc9085e58f8ea48c0eb7c4fe94b1e8f55ebdd17a725d86982eb5288
-  languageName: node
-  linkType: hard
-
-"resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>":
-  version: 1.22.8
-  resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
-  dependencies:
-    is-core-module: "npm:^2.13.0"
-    path-parse: "npm:^1.0.7"
-    supports-preserve-symlinks-flag: "npm:^1.0.0"
-  bin:
-    resolve: bin/resolve
-  checksum: 10c0/0446f024439cd2e50c6c8fa8ba77eaa8370b4180f401a96abf3d1ebc770ac51c1955e12764cde449fde3fff480a61f84388e3505ecdbab778f4bef5f8212c729
   languageName: node
   linkType: hard
 
@@ -9231,6 +9255,31 @@ __metadata:
   version: 3.0.0
   resolution: "shebang-regex@npm:3.0.0"
   checksum: 10c0/1dbed0726dd0e1152a92696c76c7f06084eb32a90f0528d11acd764043aacf76994b2fb30aa1291a21bd019d6699164d048286309a278855ee7bec06cf6fb690
+  languageName: node
+  linkType: hard
+
+"shelljs@npm:^0.8.5":
+  version: 0.8.5
+  resolution: "shelljs@npm:0.8.5"
+  dependencies:
+    glob: "npm:^7.0.0"
+    interpret: "npm:^1.0.0"
+    rechoir: "npm:^0.6.2"
+  bin:
+    shjs: bin/shjs
+  checksum: 10c0/feb25289a12e4bcd04c40ddfab51aff98a3729f5c2602d5b1a1b95f6819ec7804ac8147ebd8d9a85dfab69d501bcf92d7acef03247320f51c1552cec8d8e2382
+  languageName: node
+  linkType: hard
+
+"shx@npm:^0.3.4":
+  version: 0.3.4
+  resolution: "shx@npm:0.3.4"
+  dependencies:
+    minimist: "npm:^1.2.3"
+    shelljs: "npm:^0.8.5"
+  bin:
+    shx: lib/cli.js
+  checksum: 10c0/83251fb09314682f5a192f0249a4be68c755933313a41b5152b11c19fc0a68311954d3ca971a0cbae05815786a893c59b82f356484d8eeb009c84f4066b3fa31
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resubmitting #1160 due to git issues with rebasing...

This should be simple but I have never used Yarn before and I'm finding it very strange.  you'd think that just adding one package wouldn't make such a massive change in the lockfile.  I've now put the changes to yarn as a separate commit so it can be more easily undone if needed. 

The ACTUAL changes I am making for this PR are just adding a package and using it in the package file, this should be very simple and Yarn seems to be making it very difficult. After installing it also added a `.yarnrc.yml` file and I have no idea what this is.

Below is my original PR:

---

I installed yarn, and ran `yarn install` on this project. Per [the contributing guideline](https://github.com/martijnversluis/ChordSheetJS/blob/master/CONTRIBUTING.md) I ran `yarn test` next, which gave me this error

```
'rm' is not recognized as an internal or external command,
```

I assume you are on a Mac or Linux, I am on Windows 11, and `rm` is not something that can be run on the command line, so to work around that I've added [the `shx` package](https://www.npmjs.com/package/shx) to help normalize these commands across platforms. I've used this on past projects and it works quite well! This is only needed for the few times in the package file where `rm` is used, so now it's just prefixed with `shx rm` and it should work the same for you, but now it should work for anyone on Windows too!

all tests pass, and here's the proof with my version numbers
![image](https://github.com/martijnversluis/ChordSheetJS/assets/463685/d82273b5-ed2d-4aa5-a648-ad164b8be20b)


I also noticed a ton of uncommitted files in the `.yarn` directory, so I added that to the `.gitignore` file. I typically use NPM instead of Yarn, so I assume this was just not an issue for you due to some global setting.

It appears your `yarn.lock` file was using the version 1 syntax, so when I installed this package it seemed to auto-upgrade this. I don't see a way around this except for me uninstalling yarn and then installing at at version 1.x. The yarn website recommends upgrading anyway: https://yarnpkg.com/migration/overview