### PR TITLE
Fix parsing section whitespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,5 +76,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Enable Corepack
+        run: corepack enable
       - name: Verify install
         run: npm install "https://github.com/martijnversluis/ChordSheetJS/tree/$GITHUB_SHA"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,4 +79,4 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
       - name: Verify install
-        run: npm install "https://github.com/martijnversluis/ChordSheetJS/tree/$GITHUB_SHA"
+        run: YARN_ENABLE_IMMUTABLE_INSTALLS=false npm install "https://github.com/martijnversluis/ChordSheetJS/tree/$GITHUB_SHA"

--- a/src/chord_sheet_serializer.ts
+++ b/src/chord_sheet_serializer.ts
@@ -170,10 +170,6 @@ class ChordSheetSerializer {
     const { items } = astComponent;
     this.song.addLine();
 
-    if (typeof items.forEach !== 'function') {
-      console.log('items:', items);
-    }
-
     items.forEach((item) => {
       const parsedItem = this.parseAstComponent(item) as Item;
       this.song.addItem(parsedItem);

--- a/src/chord_sheet_serializer.ts
+++ b/src/chord_sheet_serializer.ts
@@ -134,7 +134,6 @@ class ChordSheetSerializer {
 
   parseAstComponent(astComponent: SerializedComponent)
     : null | ChordLyricsPair | Tag | Comment | Ternary | Literal | SoftLineBreak {
-    if (!astComponent) return null;
     if (typeof astComponent === 'string') return new Literal(astComponent);
 
     switch (astComponent.type) {

--- a/test/parser/chord_pro_parser.test.ts
+++ b/test/parser/chord_pro_parser.test.ts
@@ -563,6 +563,29 @@ Let it [Am]be
     expect(lines[2].items[0]).toBeLiteral('ABC line 2');
   });
 
+  it('allows trailing spaces in ABC sections', () => {
+    const chordSheet = heredoc`
+      {start_of_abc: Intro}
+      e3 B| g>B f>B| ef| eB F>B| E4:|
+
+      {end_of_abc}
+    `;
+
+    const parser = new ChordProParser();
+    const song = parser.parse(chordSheet);
+    const { paragraphs, bodyParagraphs } = song;
+    const paragraph = paragraphs[0];
+    const { lines } = paragraph;
+
+    expect(paragraphs).toHaveLength(1);
+    expect(paragraph.type).toEqual(ABC);
+    expect(lines).toHaveLength(3);
+    expect(lines[0].items[0]).toBeTag('start_of_abc', 'Intro');
+    expect(lines[1].items[0]).toBeLiteral('e3 B| g>B f>B| ef| eB F>B| E4:|');
+    expect(lines[2].items[0]).toBeLiteral('');
+    expect(bodyParagraphs).toHaveLength(1);
+  });
+
   it('parses LY sections', () => {
     const chordSheet = heredoc`
       {start_of_ly: Intro}


### PR DESCRIPTION
Parsing a blank section line would result in a `null`, instead of an `Item`.

Fixes #1155