### PR TITLE
Return null for missing metadata

### DIFF
--- a/src/chord_sheet/metadata.ts
+++ b/src/chord_sheet/metadata.ts
@@ -75,11 +75,11 @@ class Metadata extends MetadataAccessors {
     }
   }
 
-  getMetadata(name: string): string | string[] | undefined {
+  getMetadata(name: string): string | string[] | null {
     return this.get(name);
   }
 
-  getSingleMetadata(name: string): string {
+  getSingleMetadata(name: string): string | null {
     return this.getSingle(name);
   }
 
@@ -106,7 +106,7 @@ class Metadata extends MetadataAccessors {
    * @returns {Array<String>|String} the metadata value(s). If there is only one value, it will return a String,
    * else it returns an array of strings.
    */
-  get(prop: string): string | string[] | undefined {
+  get(prop: string): string | string[] | null {
     if (prop === _KEY) {
       return this.calculateKeyFromCapo();
     }
@@ -125,14 +125,14 @@ class Metadata extends MetadataAccessors {
    * @param {string} prop the property name
    * @returns {String} The metadata value
    */
-  getSingle(prop: string): string {
+  getSingle(prop: string): string | null {
     const value = this.get(prop);
 
     if (Array.isArray(value)) {
       return value[0];
     }
 
-    return value as string;
+    return value;
   }
 
   parseArrayKey(prop: string): [string, number] | null {
@@ -147,11 +147,11 @@ class Metadata extends MetadataAccessors {
     return [key, index];
   }
 
-  getArrayItem(prop: string): string | undefined {
+  getArrayItem(prop: string): string | null {
     const parsedKey = this.parseArrayKey(prop);
 
     if (parsedKey === null) {
-      return undefined;
+      return null;
     }
 
     const [key, index] = parsedKey;
@@ -175,9 +175,9 @@ class Metadata extends MetadataAccessors {
     return new Metadata(this.metadata);
   }
 
-  calculateKeyFromCapo(): string | undefined {
-    const capoString: string = this.getSingle(CAPO);
-    const keyString: string = this.getSingle(KEY);
+  calculateKeyFromCapo(): string | null {
+    const capoString = this.getSingle(CAPO);
+    const keyString = this.getSingle(KEY);
 
     if (capoString && keyString) {
       const key: Key | null = Key.parse(keyString);
@@ -190,7 +190,7 @@ class Metadata extends MetadataAccessors {
       return key.transpose(capo).normalize().toString();
     }
 
-    return undefined;
+    return null;
   }
 
   private assign(metadata: Record<string, string | string[]>): void {

--- a/src/chord_sheet/metadata_accessors.ts
+++ b/src/chord_sheet/metadata_accessors.ts
@@ -15,35 +15,35 @@ import {
 } from './tag';
 
 abstract class MetadataAccessors {
-  abstract getMetadata(_name: string): string | string[] | undefined;
+  abstract getMetadata(_name: string): string | string[] | null;
 
-  abstract getSingleMetadata(_name: string): string;
+  abstract getSingleMetadata(_name: string): string | null;
 
-  get key(): string { return this.getSingleMetadata(KEY); }
+  get key(): string | null { return this.getSingleMetadata(KEY); }
 
-  get title(): string { return this.getSingleMetadata(TITLE); }
+  get title(): string | null { return this.getSingleMetadata(TITLE); }
 
-  get subtitle(): string { return this.getSingleMetadata(SUBTITLE); }
+  get subtitle(): string | null { return this.getSingleMetadata(SUBTITLE); }
 
-  get capo(): string | string[] | undefined { return this.getMetadata(CAPO); }
+  get capo(): string | string[] | null { return this.getMetadata(CAPO); }
 
-  get duration(): string { return this.getSingleMetadata(DURATION); }
+  get duration(): string | null { return this.getSingleMetadata(DURATION); }
 
-  get tempo(): string { return this.getSingleMetadata(TEMPO); }
+  get tempo(): string | null { return this.getSingleMetadata(TEMPO); }
 
-  get time(): string | string[] | undefined { return this.getMetadata(TIME); }
+  get time(): string | string[] | null { return this.getMetadata(TIME); }
 
-  get year(): string { return this.getSingleMetadata(YEAR); }
+  get year(): string | null { return this.getSingleMetadata(YEAR); }
 
-  get album(): string | string[] | undefined { return this.getMetadata(ALBUM); }
+  get album(): string | string[] | null { return this.getMetadata(ALBUM); }
 
-  get copyright(): string { return this.getSingleMetadata(COPYRIGHT); }
+  get copyright(): string | null { return this.getSingleMetadata(COPYRIGHT); }
 
-  get lyricist(): string | string[] | undefined { return this.getMetadata(LYRICIST); }
+  get lyricist(): string | string[] | null { return this.getMetadata(LYRICIST); }
 
-  get artist(): string | string[] | undefined { return this.getMetadata(ARTIST); }
+  get artist(): string | string[] | null { return this.getMetadata(ARTIST); }
 
-  get composer(): string | string[] | undefined { return this.getMetadata(COMPOSER); }
+  get composer(): string | string[] | null { return this.getMetadata(COMPOSER); }
 }
 
 export default MetadataAccessors;

--- a/src/chord_sheet/song.ts
+++ b/src/chord_sheet/song.ts
@@ -355,11 +355,11 @@ class Song extends MetadataAccessors {
     this.metadata.add(name, value);
   }
 
-  getMetadata(name: string): string | string[] | undefined {
+  getMetadata(name: string): string | string[] | null {
     return this.metadata.getMetadata(name);
   }
 
-  getSingleMetadata(name: string): string {
+  getSingleMetadata(name: string): string | null {
     return this.metadata.getSingleMetadata(name);
   }
 

--- a/src/formatter/text_formatter.ts
+++ b/src/formatter/text_formatter.ts
@@ -75,7 +75,7 @@ class TextFormatter extends Formatter {
       .join('\n');
   }
 
-  formatTitle(title: string): string {
+  formatTitle(title: string | null): string {
     if (title) {
       return `${title.toUpperCase()}\n`;
     }
@@ -83,7 +83,7 @@ class TextFormatter extends Formatter {
     return '';
   }
 
-  formatSubTitle(subtitle: string): string {
+  formatSubTitle(subtitle: string | null): string {
     if (subtitle) {
       return `${subtitle}\n`;
     }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -14,9 +14,9 @@ export function transposeDistance(transposeKey: string, songKey: string): number
 }
 
 function chordTransposeDistance(
-  capo: number,
+  capo: number | null,
   transposeKey: string | null,
-  songKey: string,
+  songKey: string | null,
   renderKey: Key | null | undefined,
 ) {
   let transpose = -1 * (capo || 0);
@@ -71,7 +71,8 @@ export function renderChord(
 ): string {
   const chord = Chord.parse(chordString);
   const songKey = song.key;
-  const capo = parseInt(song.metadata.getSingle(CAPO), 10);
+  const capoString = song.metadata.getSingle(CAPO);
+  const capo = capoString ? parseInt(capoString, 10) : null;
   const chordStyle = song.metadata.getSingle(CHORD_STYLE) as ChordType;
 
   if (!chord) {

--- a/test/chord_sheet/metadata.test.ts
+++ b/test/chord_sheet/metadata.test.ts
@@ -62,7 +62,7 @@ describe('Metadata', () => {
     describe('when a single value does not exist', () => {
       it('returns undefined', () => {
         const metadata = new Metadata({});
-        expect(metadata.get('author')).toBeUndefined();
+        expect(metadata.get('author')).toBeNull();
       });
     });
 
@@ -81,19 +81,19 @@ describe('Metadata', () => {
 
       it('returns undefined when when key or capo is undefined', () => {
         const metadata = new Metadata({ key: 'Bb' });
-        expect(metadata.get('_key')).toBe(undefined);
+        expect(metadata.get('_key')).toBeNull();
       });
 
       it('is readonly on initialisation', () => {
         const metadata = new Metadata({ _key: 'E' });
-        expect(metadata.get('_key')).toBe(undefined);
+        expect(metadata.get('_key')).toBeNull();
       });
 
       it('is readonly', () => {
         const emptyMetadata = new Metadata();
         const metadata = new Metadata();
         metadata.add('_key', 'G');
-        expect(metadata.get('_key')).toBe(undefined);
+        expect(metadata.get('_key')).toBeNull();
         expect(metadata).toEqual(emptyMetadata);
       });
     });

--- a/test/integration/setting_key.test.ts
+++ b/test/integration/setting_key.test.ts
@@ -44,7 +44,7 @@ describe('setting the key of an existing song', () => {
     const song = new ChordProParser().parse(chordpro);
     const updatedSong = song.setKey(null);
 
-    expect(updatedSong.key).toEqual(undefined);
+    expect(updatedSong.key).toBeNull();
     expect(new ChordProFormatter().format(updatedSong)).toEqual(changedSheet);
   });
 });


### PR DESCRIPTION
The return value for missing metadata was not consistent. According to the type docs `Metadata#getSingle()` would always return a `string`. However, when the metadata entry was missing it would actually return `undefined`.

Explicitly returning `undefined` is not recommended. This PR fixes the type annotation and changes the value for 'none' to `null`.

Related to #1161
Thanks to @ChrisMBarr for reporting