### PR TITLE
Add Chord to default export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import Chord from './chord';
 import ChordLyricsPair from './chord_sheet/chord_lyrics_pair';
 import ChordProFormatter from './formatter/chord_pro_formatter';
 import ChordProParser from './parser/chord_pro_parser';
@@ -71,6 +72,7 @@ export {
 
 export default {
   CHORUS,
+  Chord,
   ChordLyricsPair,
   ChordProFormatter,
   ChordProParser,

--- a/test/default_export.test.ts
+++ b/test/default_export.test.ts
@@ -2,6 +2,7 @@ import chordsheetjs from '../src';
 
 describe('default export', () => {
   [
+    'Chord',
     'ChordProParser',
     'ChordSheetParser',
     'UltimateGuitarParser',


### PR DESCRIPTION
Allows for:

```js
import ChordSheetJS from 'chordsheets';
const { Chord } = ChordSheetJS;
```