### PR TITLE
Soft line break support for ChordsOverWordsParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1295,7 +1295,7 @@ PDF conversion.</p>
 
 * [ChordProParser](#ChordProParser)
     * [.warnings](#ChordProParser+warnings) : [<code>Array.&lt;ParserWarning&gt;</code>](#ParserWarning)
-    * [.parse(chordSheet)](#ChordProParser+parse) ⇒ [<code>Song</code>](#Song)
+    * [.parse(chordSheet, options)](#ChordProParser+parse) ⇒ [<code>Song</code>](#Song)
 
 <a name="ChordProParser+warnings"></a>
 
@@ -1305,15 +1305,18 @@ PDF conversion.</p>
 **Kind**: instance property of [<code>ChordProParser</code>](#ChordProParser)  
 <a name="ChordProParser+parse"></a>
 
-### chordProParser.parse(chordSheet) ⇒ [<code>Song</code>](#Song)
+### chordProParser.parse(chordSheet, options) ⇒ [<code>Song</code>](#Song)
 <p>Parses a ChordPro chord sheet into a song</p>
 
 **Kind**: instance method of [<code>ChordProParser</code>](#ChordProParser)  
 **Returns**: [<code>Song</code>](#Song) - <p>The parsed song</p>  
+**See**: https://peggyjs.org/documentation.html#using-the-parser  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| chordSheet | <code>string</code> | <p>the ChordPro chord sheet</p> |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| chordSheet | <code>string</code> |  | <p>the ChordPro chord sheet</p> |
+| options | <code>ChordProParserOptions</code> |  | <p>Parser options.</p> |
+| options.softLineBreaks | <code>ChordProParserOptions.softLineBreaks</code> | <code>false</code> | <p>If true, a backslash followed by * a space is treated as a soft line break</p> |
 
 <a name="ChordSheetParser"></a>
 
@@ -1414,10 +1417,11 @@ Whisper words of wisdom, let it be
 **Returns**: [<code>Song</code>](#Song) - <p>The parsed song</p>  
 **See**: https://peggyjs.org/documentation.html#using-the-parser  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| chordSheet | <code>string</code> | <p>the chords over words sheet</p> |
-| options | <code>ParseOptions</code> | <p>Parser options.</p> |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| chordSheet | <code>string</code> |  | <p>the chords over words sheet</p> |
+| options | <code>ChordsOverWordsParserOptions</code> |  | <p>Parser options.</p> |
+| options.softLineBreaks | <code>ChordsOverWordsParserOptions.softLineBreaks</code> | <code>false</code> | <p>If true, a backslash followed by a space is treated as a soft line break</p> |
 
 <a name="ParserWarning"></a>
 

--- a/src/parser/chord_pro_parser.ts
+++ b/src/parser/chord_pro_parser.ts
@@ -26,6 +26,10 @@ class ChordProParser {
   /**
    * Parses a ChordPro chord sheet into a song
    * @param {string} chordSheet the ChordPro chord sheet
+   * @param {ChordProParserOptions} options Parser options.
+   * @param {ChordProParserOptions.softLineBreaks} options.softLineBreaks=false If true, a backslash
+   * followed by * a space is treated as a soft line break
+   * @see https://peggyjs.org/documentation.html#using-the-parser
    * @returns {Song} The parsed song
    */
   parse(chordSheet: string, options?: ChordProParserOptions): Song {

--- a/src/parser/chords_over_words_grammar.pegjs
+++ b/src/parser/chords_over_words_grammar.pegjs
@@ -27,47 +27,6 @@ ChordSheetLine
   / &(ChordsLine !WordChar) line:ChordsLine { return line; }
   / line:LyricsLine { return line; }
 
-ChordLyricsLines
-  = chordsLine:ChordsLine NewLine lyrics:NonEmptyLyrics {
-      const chords = chordsLine.items;
-
-      const chordLyricsPairs = chords.map((chord, i) => {
-        const nextChord = chords[i + 1];
-        const start = chord.column - 1;
-        const end = nextChord ? nextChord.column - 1 : lyrics.length;
-        const pairLyrics = lyrics.substring(start, end);
-
-        const [firstWord, rest] = chopFirstWord(pairLyrics);
-
-        const chordData = (chord.type === "chord") ? { chord } : { chords: chord.value };
-
-        if (rest) {
-          return [
-            { type: "chordLyricsPair", ...chordData, lyrics: `${firstWord} ` },
-            { type: "chordLyricsPair", chords: "", lyrics: rest },
-          ];
-        }
-
-        return { type: "chordLyricsPair", ...chordData, lyrics: firstWord };
-      }).flat();
-
-      const firstChord = chords[0];
-
-      if (firstChord && firstChord.column > 1) {
-      	const firstChordPosition = firstChord.column;
-
-        if (firstChordPosition > 0) {
-          chordLyricsPairs.unshift({
-            type: "chordLyricsPair",
-            chords: "",
-            lyrics: lyrics.substring(0, firstChordPosition - 1),
-          });
-        }
-      }
-
-      return { type: "line", items: chordLyricsPairs };
-    }
-
 SingleChordsLine
   = chordsLine:ChordsLine & (NewLine ChordsLine) {
       return chordsLine;

--- a/src/parser/chords_over_words_header.ts
+++ b/src/parser/chords_over_words_header.ts
@@ -5,6 +5,15 @@ function combineChordSheetLines(newLine: string | null, lines, trailingLine): an
   return [...emptyLines, ...lines, trailingLine];
 }
 
+function applySoftLineBreaks(line) {
+  return line
+    .split(/\\\s+/)
+    .flatMap((lyric, index) => ([
+      index === 0 ? null : { type: 'softLineBreak' },
+      lyric.length === 0 ? null : { type: 'chordLyricsPair', chords: '', lyrics: lyric },
+    ]));
+}
+
 function constructChordLyricsPairs(chords, lyrics) {
   return chords.map((chord, i) => {
     const nextChord = chords[i + 1];
@@ -17,8 +26,8 @@ function constructChordLyricsPairs(chords, lyrics) {
     if (rest) {
       return [
         { type: 'chordLyricsPair', ...chordData, lyrics: `${firstWord} ` },
-        { type: 'chordLyricsPair', chords: '', lyrics: rest },
-      ];
+        ...applySoftLineBreaks(rest),
+      ].filter(x => x);
     }
 
     return { type: 'chordLyricsPair', ...chordData, lyrics: firstWord };

--- a/src/parser/chords_over_words_parser.ts
+++ b/src/parser/chords_over_words_parser.ts
@@ -1,9 +1,12 @@
-import { parse } from './chords_over_words_peg_parser';
 import Song from '../chord_sheet/song';
 import ParserWarning from './parser_warning';
-import { ParseOptions } from './chord_pro_peg_parser';
+import { parse, ParseOptions } from './chords_over_words_peg_parser';
 import { normalizeLineEndings } from '../utilities';
 import ChordSheetSerializer from '../chord_sheet_serializer';
+
+export type ChordsOverWordsParserOptions = ParseOptions & {
+  softLineBreaks?: boolean;
+};
 
 /**
  * Parses a chords over words sheet into a song
@@ -58,11 +61,13 @@ class ChordsOverWordsParser {
   /**
    * Parses a chords over words sheet into a song
    * @param {string} chordSheet the chords over words sheet
-   * @param {ParseOptions} options Parser options.
+   * @param {ChordsOverWordsParserOptions} options Parser options.
+   * @param {ChordsOverWordsParserOptions.softLineBreaks} options.softLineBreaks=false If true, a backslash
+   * followed by a space is treated as a soft line break
    * @see https://peggyjs.org/documentation.html#using-the-parser
    * @returns {Song} The parsed song
    */
-  parse(chordSheet: string, options?: ParseOptions): Song {
+  parse(chordSheet: string, options?: ChordsOverWordsParserOptions): Song {
     const ast = parse(normalizeLineEndings(chordSheet), options);
     this.song = new ChordSheetSerializer().deserialize(ast);
     return this.song;

--- a/test/parser/chords_over_words_parser.test.ts
+++ b/test/parser/chords_over_words_parser.test.ts
@@ -569,4 +569,29 @@ describe('ChordsOverWordsParser', () => {
     expect(line1Items[2]).toBeChordLyricsPair('', 'let it ');
     expect(line1Items[3]).toBeChordLyricsPair('C', 'be');
   });
+
+  describe('with option softLineBreaks=true', () => {
+    it('parses soft line breaks', () => {
+      const chordOverWords = heredoc`
+               Am         C/G          F          C
+        Let it be, let it be, let it \\ be, let it be
+      `;
+
+      const parser = new ChordsOverWordsParser();
+      const song = parser.parse(chordOverWords, { softLineBreaks: true });
+      const { lines } = song;
+
+      const lineItems = lines[0].items;
+
+      expect(lineItems[0]).toBeChordLyricsPair('', 'Let it ');
+      expect(lineItems[1]).toBeChordLyricsPair('Am', 'be, ');
+      expect(lineItems[2]).toBeChordLyricsPair('', 'let it ');
+      expect(lineItems[3]).toBeChordLyricsPair('C/G', 'be, ');
+      expect(lineItems[4]).toBeChordLyricsPair('', 'let it ');
+      expect(lineItems[5]).toBeSoftLineBreak();
+      expect(lineItems[6]).toBeChordLyricsPair('F', 'be, ');
+      expect(lineItems[7]).toBeChordLyricsPair('', 'let it ');
+      expect(lineItems[8]).toBeChordLyricsPair('C', 'be');
+    });
+  });
 });


### PR DESCRIPTION
When lyrics include a backslash, it results in `ChordLyricsPair`s separated by a `SoftLineBreak`.