### PR TITLE
Treat section end as paragraph end

### DIFF
--- a/src/chord_sheet/line.ts
+++ b/src/chord_sheet/line.ts
@@ -219,6 +219,28 @@ class Line {
       },
     );
   }
+
+  get _tag(): Tag | null {
+    if (this.items.length !== 1) {
+      return null;
+    }
+
+    const item = this.items[0];
+
+    if (!(item instanceof Tag)) {
+      return null;
+    }
+
+    return item;
+  }
+
+  isSectionStart(): boolean {
+    return this._tag?.isSectionStart() || false;
+  }
+
+  isSectionEnd(): boolean {
+    return this._tag?.isSectionEnd() || false;
+  }
 }
 
 export default Line;

--- a/src/chord_sheet/paragraph.ts
+++ b/src/chord_sheet/paragraph.ts
@@ -28,7 +28,7 @@ class Paragraph {
   isLiteral() {
     const { lines } = this;
 
-    if (lines.length === 0) {
+    if (this.isEmpty()) {
       return false;
     }
 
@@ -102,6 +102,10 @@ class Paragraph {
    */
   hasRenderableItems(): boolean {
     return this.lines.some((line) => line.hasRenderableItems());
+  }
+
+  isEmpty(): boolean {
+    return this.lines.length === 0;
   }
 }
 

--- a/src/chord_sheet/song.ts
+++ b/src/chord_sheet/song.ts
@@ -247,8 +247,10 @@ class Song extends MetadataAccessors {
     let currentParagraph = new Paragraph();
     const paragraphs = [currentParagraph];
 
-    lines.forEach((line) => {
-      if (line.isEmpty()) {
+    lines.forEach((line, index) => {
+      const nextLine: Line | null = lines[index + 1] || null;
+
+      if (line.isEmpty() || (line.isSectionEnd() && nextLine && !nextLine.isEmpty())) {
         currentParagraph = new Paragraph();
         paragraphs.push(currentParagraph);
       } else if (line.hasRenderableItems()) {

--- a/src/chord_sheet/tag.ts
+++ b/src/chord_sheet/tag.ts
@@ -312,21 +312,24 @@ export const META_TAGS = [
 
 export const READ_ONLY_TAGS = [_KEY];
 
-const SECTION_DELIMITERS = [
-  START_OF_ABC,
+const SECTION_END_TAGS = [
   END_OF_ABC,
-  START_OF_BRIDGE,
   END_OF_BRIDGE,
-  START_OF_CHORUS,
   END_OF_CHORUS,
-  START_OF_GRID,
   END_OF_GRID,
-  START_OF_LY,
   END_OF_LY,
-  START_OF_TAB,
   END_OF_TAB,
-  START_OF_VERSE,
   END_OF_VERSE,
+];
+
+export const SECTION_START_TAGS = [
+  START_OF_ABC,
+  START_OF_BRIDGE,
+  START_OF_CHORUS,
+  START_OF_GRID,
+  START_OF_LY,
+  START_OF_TAB,
+  START_OF_VERSE,
 ];
 
 const INLINE_FONT_TAGS = [
@@ -457,7 +460,15 @@ class Tag extends AstComponent {
   }
 
   isSectionDelimiter(): boolean {
-    return SECTION_DELIMITERS.includes(this.name);
+    return this.isSectionStart() || this.isSectionEnd();
+  }
+
+  isSectionStart(): boolean {
+    return SECTION_START_TAGS.includes(this.name);
+  }
+
+  isSectionEnd(): boolean {
+    return SECTION_END_TAGS.includes(this.name);
   }
 
   isInlineFontTag(): boolean {

--- a/test/chord_sheet/line.test.ts
+++ b/test/chord_sheet/line.test.ts
@@ -128,4 +128,90 @@ describe('Line', () => {
       });
     });
   });
+
+  describe('#isSectionEnd', () => {
+    describe('when the line is a section end', () => {
+      it('returns true', () => {
+        const line = createLine([
+          createTag('end_of_chorus'),
+        ]);
+
+        expect(line.isSectionEnd()).toBe(true);
+      });
+    });
+
+    describe('when the line is not a section end', () => {
+      it('returns false', () => {
+        const line = createLine([
+          createTag('start_of_chorus'),
+        ]);
+
+        expect(line.isSectionEnd()).toBe(false);
+      });
+    });
+
+    describe('when the line is no section delimiter', () => {
+      it('returns false', () => {
+        const line = createLine([
+          createTag('foo'),
+        ]);
+
+        expect(line.isSectionEnd()).toBe(false);
+      });
+    });
+
+    describe('when the line contains multiple items', () => {
+      it('returns false', () => {
+        const line = createLine([
+          createTag('end_of_chorus'),
+          createTag('start_of_chorus'),
+        ]);
+
+        expect(line.isSectionEnd()).toBe(false);
+      });
+    });
+  });
+
+  describe('#isSectionStart', () => {
+    describe('when the line is a section start', () => {
+      it('returns true', () => {
+        const line = createLine([
+          createTag('start_of_chorus'),
+        ]);
+
+        expect(line.isSectionStart()).toBe(true);
+      });
+    });
+
+    describe('when the line is not a section start', () => {
+      it('returns false', () => {
+        const line = createLine([
+          createTag('end_of_chorus'),
+        ]);
+
+        expect(line.isSectionStart()).toBe(false);
+      });
+    });
+
+    describe('when the line is no section delimiter', () => {
+      it('returns false', () => {
+        const line = createLine([
+          createTag('foo'),
+        ]);
+
+        expect(line.isSectionStart()).toBe(false);
+      });
+    });
+
+    describe('when the line contains multiple items', () => {
+      it('returns false', () => {
+        const line = createLine([
+          createTag('end_of_chorus'),
+          createTag('start_of_chorus'),
+        ]);
+
+        expect(line.isSectionStart()).toBe(false);
+      });
+    });
+  });
 });

--- a/test/chord_sheet/paragraph.test.ts
+++ b/test/chord_sheet/paragraph.test.ts
@@ -135,4 +135,26 @@ describe('Paragraph', () => {
       });
     });
   });
+
+  describe('#isEmpty', () => {
+    describe('when the paragraph is empty', () => {
+      it('returns true', () => {
+        const paragraph = createParagraph([]);
+
+        expect(paragraph.isEmpty()).toBe(true);
+      });
+    });
+
+    describe('when the paragraph is not empty', () => {
+      it('returns false', () => {
+        const paragraph = createParagraph([
+          createLine([
+            createLiteral('Tab line 1'),
+          ]),
+        ]);
+
+        expect(paragraph.isEmpty()).toBe(false);
+      });
+    });
+  });
 });

--- a/test/chord_sheet/tag.test.ts
+++ b/test/chord_sheet/tag.test.ts
@@ -1,4 +1,19 @@
 import { Tag } from '../../src';
+import {
+  END_OF_ABC,
+  END_OF_BRIDGE,
+  END_OF_CHORUS,
+  END_OF_GRID,
+  END_OF_LY,
+  END_OF_TAB,
+  END_OF_VERSE,
+  START_OF_ABC,
+  START_OF_BRIDGE,
+  START_OF_CHORUS,
+  START_OF_GRID,
+  START_OF_LY,
+  START_OF_TAB, START_OF_VERSE,
+} from '../../src/chord_sheet/tag';
 
 describe('Tag', () => {
   const expectedAliases = {
@@ -120,6 +135,62 @@ describe('Tag', () => {
 
       expect(tag.name).toEqual('foo');
       expect(tag.value).toEqual('bar ber');
+    });
+  });
+
+  const sectionEndTags = [
+    END_OF_ABC,
+    END_OF_BRIDGE,
+    END_OF_CHORUS,
+    END_OF_GRID,
+    END_OF_LY,
+    END_OF_TAB,
+    END_OF_VERSE,
+  ];
+
+  const sectionStartTags = [
+    START_OF_ABC,
+    START_OF_BRIDGE,
+    START_OF_CHORUS,
+    START_OF_GRID,
+    START_OF_LY,
+    START_OF_TAB,
+    START_OF_VERSE,
+  ];
+
+  describe('#isSectionDelimiter', () => {
+    [...sectionStartTags, ...sectionEndTags].forEach((tag) => {
+      it(`returns true for ${tag}`, () => {
+        expect(new Tag(tag, 'value').isSectionDelimiter()).toBe(true);
+      });
+    });
+
+    it('returns false for other tags', () => {
+      expect(new Tag('foo', 'value').isSectionDelimiter()).toBe(false);
+    });
+  });
+
+  describe('#isSectionEnd', () => {
+    sectionEndTags.forEach((tag) => {
+      it(`returns true for ${tag}`, () => {
+        expect(new Tag(tag, 'value').isSectionEnd()).toBe(true);
+      });
+    });
+
+    it('returns false for other tags', () => {
+      expect(new Tag('foo', 'value').isSectionEnd()).toBe(false);
+    });
+  });
+
+  describe('#isSectionStart', () => {
+    sectionStartTags.forEach((tag) => {
+      it(`returns true for ${tag}`, () => {
+        expect(new Tag(tag, 'value').isSectionStart()).toBe(true);
+      });
+    });
+
+    it('returns false for other tags', () => {
+      expect(new Tag('foo', 'value').isSectionStart()).toBe(false);
     });
   });
 });

--- a/test/formatter/html_table_formatter.test.ts
+++ b/test/formatter/html_table_formatter.test.ts
@@ -661,6 +661,8 @@ describe('HtmlTableFormatter', () => {
       [],
     ]);
 
+    expect(song.bodyParagraphs).toHaveLength(3);
+
     const expectedOutput = html`
       <div class="chord-sheet">
         <div class="paragraph">

--- a/test/matchers.ts
+++ b/test/matchers.ts
@@ -113,7 +113,7 @@ function toBeChordLyricsPair(received, chords, lyrics, annotation = '') {
   return toBeClassInstanceWithProperties(received, ChordLyricsPair, { chords, lyrics, annotation });
 }
 
-function toBeTag(received, name, value) {
+function toBeTag(received, name, value = '') {
   return toBeClassInstanceWithProperties(received, Tag, { name, value });
 }
 

--- a/test/parser/chord_pro_parser.test.ts
+++ b/test/parser/chord_pro_parser.test.ts
@@ -525,20 +525,23 @@ Let it [Am]be
       Tab line 1
       Tab line 2
       {end_of_tab}
+      {c:Verse}
     `;
 
     const parser = new ChordProParser();
     const song = parser.parse(chordSheet);
     const { paragraphs } = song;
-    const paragraph = paragraphs[0];
+    const [paragraph, secondParagraph] = paragraphs;
     const { lines } = paragraph;
 
-    expect(paragraphs).toHaveLength(1);
+    expect(paragraphs).toHaveLength(2);
     expect(paragraph.type).toEqual(TAB);
     expect(lines).toHaveLength(3);
     expect(lines[0].items[0]).toBeTag('start_of_tab', 'Intro');
     expect(lines[1].items[0]).toBeLiteral('Tab line 1');
     expect(lines[2].items[0]).toBeLiteral('Tab line 2');
+
+    expect(secondParagraph.lines[0].items[0]).toBeTag('comment', 'Verse');
   });
 
   it('parses ABC sections', () => {


### PR DESCRIPTION
Start new paragraphs when encountering a section end tag (in addition to new lines)

Related to https://github.com/martijnversluis/ChordSheetJS/issues/1189