### PR TITLE
Ensure Song#getChords() returns unique chords

### DIFF
--- a/src/chord_sheet/song.ts
+++ b/src/chord_sheet/song.ts
@@ -17,6 +17,7 @@ import Tag, {
 } from './tag';
 import SongBuilder from '../song_builder';
 import ChordDefinition from './chord_pro/chord_definition';
+import Chord from '../chord';
 
 type EachItemCallback = (_item: Item) => void;
 
@@ -435,7 +436,11 @@ Or set the song key before changing key:
       const itemChords = (item as ChordLyricsPair).chords;
 
       if (itemChords && itemChords.length > 0) {
-        chords.add(itemChords);
+        const parsedChord = Chord.parse(itemChords);
+
+        if (parsedChord) {
+          chords.add(parsedChord.toString());
+        }
       }
     });
 

--- a/test/chord_sheet/song.test.ts
+++ b/test/chord_sheet/song.test.ts
@@ -308,15 +308,18 @@ describe('Song', () => {
           createChordLyricsPair('CM7', 'let'),
           createChordLyricsPair('', 'it'),
           createChordLyricsPair('Dm7', ''),
+          createChordLyricsPair('Dm7   ', ''),
         ]),
         createLine([]),
         createLine([
           createChordLyricsPair('F#', 'be'),
+          createChordLyricsPair('d#', 'be'),
+          createChordLyricsPair('     F#', 'be'),
           createChordLyricsPair('', 'changed'),
         ]),
       ]);
 
-      expect(song.getChords()).toEqual(['CM7', 'Dm7', 'F#']);
+      expect(song.getChords()).toEqual(['CM7', 'Dm7', 'F#', 'D#']);
     });
 
     it('returns an empty array if there are no chords in the song', () => {


### PR DESCRIPTION
Parse chords and return the stringified version so whitespace is ignored and similar chords are grouped.

Related to https://github.com/martijnversluis/ChordSheetJS/issues/1446