### PR TITLE
Support custom start/end tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "ci": "yarn install && yarn unibuild lint && yarn unibuild test && yarn build:release",
     "debug:chordpro": "yarn build && tsx script/debug_parser.ts chord_pro --skip-chord-grammar",
     "eslint": "node_modules/.bin/eslint",
+    "lint": "yarn unibuild lint",
     "prepare": "yarn install && yarn build",
     "prepublishOnly": "yarn install && yarn test && yarn build:release",
     "readme": "yarn unibuild build readme -f",

--- a/src/chord_sheet/line.ts
+++ b/src/chord_sheet/line.ts
@@ -30,10 +30,21 @@ class Line {
 
   /**
    * The line type, This is set by the ChordProParser when it read tags like {start_of_chorus} or {start_of_verse}
-   * Values can be {@link VERSE}, {@link CHORUS} or {@link NONE}
+   * It uses the following mapping to determine the line type from directives:
+   * - `start_of_abc` => {@link ABC}
+   * - `start_of_bridge` => {@link BRIDGE}
+   * - `start_of_chorus` => {@link CHORUS}
+   * - `start_of_grid` => {@link GRID}
+   * - `start_of_ly` => {@link LILYPOND}
+   * - `start_of_tab` => {@link TAB}
+   * - `start_of_verse` => {@link VERSE}
+   *
+   * There are two special cases:
+   * - {@link INDETERMINATE} when the paragraph lines do not have a consistent type
+   * - {@link NONE} when no type is derived
    * @type {string}
    */
-  type: LineType = NONE;
+  type: string = NONE;
 
   currentChordLyricsPair: ChordLyricsPair = new ChordLyricsPair();
 
@@ -59,7 +70,7 @@ class Line {
    */
   chordFont: Font = new Font();
 
-  constructor({ type, items }: { type: LineType, items: Item[] } = { type: NONE, items: [] }) {
+  constructor({ type, items }: { type: string, items: Item[] } = { type: NONE, items: [] }) {
     this.type = type;
     this.items = items;
   }
@@ -210,7 +221,7 @@ class Line {
     return comment;
   }
 
-  set(properties: { type?: LineType, items?: Item[] }): Line {
+  set(properties: { type?: string, items?: Item[] }): Line {
     return new Line(
       {
         type: this.type,

--- a/src/chord_sheet/paragraph.ts
+++ b/src/chord_sheet/paragraph.ts
@@ -1,5 +1,5 @@
 import { INDETERMINATE } from '../constants';
-import Line, { LineType } from './line';
+import Line from './line';
 import Literal from './chord_pro/literal';
 import Tag from './tag';
 import Item from './item';
@@ -82,9 +82,10 @@ class Paragraph {
   /**
    * Tries to determine the common type for all lines. If the types for all lines are equal, it returns that type.
    * If not, it returns {@link INDETERMINATE}
+   * For the possible values, see {@link Line.type}
    * @returns {string}
    */
-  get type(): LineType {
+  get type(): string {
     const types = this.lines.map((line) => line.type);
     const uniqueTypes = [...new Set(types)];
 

--- a/test/parser/chord_pro_parser.test.ts
+++ b/test/parser/chord_pro_parser.test.ts
@@ -231,6 +231,35 @@ describe('ChordProParser', () => {
     expect(parser.warnings).toHaveLength(0);
   });
 
+  it('supports custom section types', () => {
+    const markedChordSheet = heredoc`
+      {start_of_coda: Coda 1}
+      Let it [Am]be
+      {end_of_coda}
+    `;
+
+    const parser = new ChordProParser();
+    const { lines } = parser.parse(markedChordSheet);
+    expect(lines[0].type).toEqual('coda');
+    expect(parser.warnings).toHaveLength(0);
+  });
+
+  it('is forgiving to unended custom sections', () => {
+    const markedChordSheet = heredoc`
+      {start_of_coda}
+      Let it [Am]be
+      
+      {start_of_interlude}
+      [C]Speaking words of [G]wisdom
+    `;
+
+    const parser = new ChordProParser();
+    const { lines } = parser.parse(markedChordSheet);
+    const lineTypes = lines.map((line) => line.type);
+    expect(lineTypes).toEqual(['coda', 'coda', 'coda', 'interlude', 'interlude']);
+    expect(parser.warnings).toHaveLength(1);
+  });
+
   it('adds the transposeKey to lines', () => {
     const chordSheetWithTranspose = `
 {key: A}


### PR DESCRIPTION
For example:

```
{start_of_coda}
Let it [C]be
{end_of_coda}
```

will result in the line types and paragraph type being `coda`.

_NOTE_: this will loosen type restrictions: `Paragraph.type` is `string` instead of `ParagraphType` and `Line.type` is `string` instead of `LineType`.

Resolves #1473

Thanks to @edonv for requesting