### PR TITLE
Implement chopFirstWord for ChordProParser

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,10 +54,9 @@
     "ts-jest": "^29.2.3",
     "ts-node": "^10.9.2",
     "ts-pegjs": "^3.0.0",
-    "tsc": "^2.0.4",
     "tsx": "^4.10.5",
     "typedoc": "^0.27.1",
-    "typescript": "^5.6.2",
+    "typescript": "^5.7.3",
     "typescript-eslint": "^8.6.0"
   },
   "scripts": {

--- a/src/parser/chord_pro/grammar.pegjs
+++ b/src/parser/chord_pro/grammar.pegjs
@@ -23,10 +23,10 @@ Line
   = lyrics:$(Lyrics?) tokens:Token* chords:Chord? comment:Comment? Space* {
       return helpers.buildLine([
           lyrics ? { type: 'chordLyricsPair', chords: '', lyrics } : null,
-          ...tokens.flat(),
+          ...helpers.combineChordLyricsPairs(tokens.flat(), options.chopFirstWord),
           chords ? { type: 'chordLyricsPair', chords, lyrics: '' } : null,
           comment ? { type: 'comment', comment } : null,
-        ].filter(x => x),
+        ].filter(x => x !== null),
       );
     }
 

--- a/src/parser/chord_pro_parser.ts
+++ b/src/parser/chord_pro_parser.ts
@@ -31,7 +31,7 @@ class ChordProParser {
    * @param {ChordProParserOptions} options Parser options.
    * @param {ChordProParserOptions.softLineBreaks} options.softLineBreaks=false If true, a backslash
    * followed by * a space is treated as a soft line break
-   * @param {ChordProParserOptions.chopFirstWord} options.chopFirstWord=false If true, only the first lyric
+   * @param {ChordProParserOptions.chopFirstWord} options.chopFirstWord=true If true, only the first lyric
    * word is paired with the chord, the rest of the lyric is put in a separate chord lyric pair
    * @see https://peggyjs.org/documentation.html#using-the-parser
    * @returns {Song} The parsed song

--- a/src/parser/chord_pro_parser.ts
+++ b/src/parser/chord_pro_parser.ts
@@ -7,6 +7,7 @@ import NullTracer from './null_tracer';
 
 export type ChordProParserOptions = ParseOptions & {
   softLineBreaks?: boolean;
+  chopFirstWord?: boolean;
 };
 
 /**
@@ -30,6 +31,8 @@ class ChordProParser {
    * @param {ChordProParserOptions} options Parser options.
    * @param {ChordProParserOptions.softLineBreaks} options.softLineBreaks=false If true, a backslash
    * followed by * a space is treated as a soft line break
+   * @param {ChordProParserOptions.chopFirstWord} options.chopFirstWord=false If true, only the first lyric
+   * word is paired with the chord, the rest of the lyric is put in a separate chord lyric pair
    * @see https://peggyjs.org/documentation.html#using-the-parser
    * @returns {Song} The parsed song
    */

--- a/src/parser/chords_over_words_parser.ts
+++ b/src/parser/chords_over_words_parser.ts
@@ -66,7 +66,7 @@ class ChordsOverWordsParser {
    * @param {ChordsOverWordsParserOptions} options Parser options.
    * @param {ChordsOverWordsParserOptions.softLineBreaks} options.softLineBreaks=false If true, a backslash
    * followed by a space is treated as a soft line break
-   * @param {ChordsOverWordsParserOptions.chopFirstWord} options.chopFirstWord=false If true, only the first lyric
+   * @param {ChordsOverWordsParserOptions.chopFirstWord} options.chopFirstWord=true If true, only the first lyric
    * word is paired with the chord, the rest of the lyric is put in a separate chord lyric pair
    * @see https://peggyjs.org/documentation.html#using-the-parser
    * @returns {Song} The parsed song

--- a/test/parser/chord_pro_parser.test.ts
+++ b/test/parser/chord_pro_parser.test.ts
@@ -447,6 +447,15 @@ This part is [G]key
     expect(song.lines[0].items[0]).toBeChordLyricsPair('', '|: Let it be :|');
   });
 
+  it('does not chop off the first word when chopFirstWord is false', () => {
+    const chordSheet = '[Am]Whisper words of ';
+
+    const parser = new ChordProParser();
+    const song = parser.parse(chordSheet, { chopFirstWord: false });
+
+    expect(song.lines[0].items[0]).toBeChordLyricsPair('Am', 'Whisper words of ');
+  });
+
   describe('it is forgiving to syntax errors', () => {
     it('allows dangling ]', () => {
       const chordSheetWithError = `

--- a/yarn.lock
+++ b/yarn.lock
@@ -3606,10 +3606,9 @@ __metadata:
     ts-jest: "npm:^29.2.3"
     ts-node: "npm:^10.9.2"
     ts-pegjs: "npm:^3.0.0"
-    tsc: "npm:^2.0.4"
     tsx: "npm:^4.10.5"
     typedoc: "npm:^0.27.1"
-    typescript: "npm:^5.6.2"
+    typescript: "npm:^5.7.3"
     typescript-eslint: "npm:^8.6.0"
   languageName: unknown
   linkType: soft
@@ -9263,15 +9262,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsc@npm:^2.0.4":
-  version: 2.0.4
-  resolution: "tsc@npm:2.0.4"
-  bin:
-    tsc: bin/tsc
-  checksum: 10c0/4651d344891d995e62ab7ca64ce0a8597bbdc2d392886c9956d15caab4dc9bfe86e759d3385b3f97c49fb5294194a161d6812673e3f51e46357c82482f32c3ab
-  languageName: node
-  linkType: hard
-
 "tslib@npm:^2.0.1, tslib@npm:^2.8.0":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
@@ -9460,7 +9450,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.6.2":
+"typescript@npm:^5.7.3":
   version: 5.7.3
   resolution: "typescript@npm:5.7.3"
   bin:
@@ -9470,7 +9460,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.6.2#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A^5.7.3#optional!builtin<compat/typescript>":
   version: 5.7.3
   resolution: "typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>::version=5.7.3&hash=b45daf"
   bin:


### PR DESCRIPTION
For chords over words, the chord is by default paired with the first lyric word, the rest of the lyrics up to the next chord is put in a separate chord lyrics pair.

This change allows disabling that behaviour by passing `{ chopFirstWord: false }`

Thanks to @kriztho / @adriaanzon for requesting this

Related to #1267
Resolves #1481