### PR TITLE
Expose package version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ src/normalize_mappings/suffix-normalize-mapping.ts
 src/parser/chord/combined_grammer.pegjs
 src/parser/chord/suffix_grammar.pegjs
 src/parser/chord_pro/sections_grammar.pegjs
+src/version.ts
 tmp

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import Tag from './chord_sheet/tag';
 import Ternary from './chord_sheet/chord_pro/ternary';
 import TextFormatter from './formatter/text_formatter';
 import UltimateGuitarParser from './parser/ultimate_guitar_parser';
+import version from './version';
 
 import {
   each,
@@ -76,6 +77,7 @@ export { default as Ternary } from './chord_sheet/chord_pro/ternary';
 export { default as TextFormatter } from './formatter/text_formatter';
 export { default as UltimateGuitarParser } from './parser/ultimate_guitar_parser';
 export { default as templateHelpers } from './template_helpers';
+export { default as version } from './version';
 
 export {
   ABC,
@@ -122,6 +124,7 @@ export default {
   TextFormatter,
   UltimateGuitarParser,
   VERSE,
+  version,
   templateHelpers: {
     isEvaluatable,
     isChordLyricsPair,

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -7,32 +7,35 @@ import ChordSheetJS, {
   ChordSheetParser,
   ChordSheetSerializer,
   ChordsOverWordsParser,
+  CHORUS,
   Comment,
   Composite,
   Formatter,
-  HtmlFormatter,
   HtmlDivFormatter,
+  HtmlFormatter,
   HtmlTableFormatter,
+  INDETERMINATE,
   Key,
   Line,
   Literal,
   Metadata,
+  NONE,
+  NUMERIC,
   Paragraph,
+  SOLFEGE,
   Song,
+  SYMBOL,
+  TAB,
   Tag,
+  templateHelpers,
   Ternary,
   TextFormatter,
   UltimateGuitarParser,
-  CHORUS,
-  INDETERMINATE,
-  NONE,
-  NUMERIC,
-  SOLFEGE,
-  SYMBOL,
-  TAB,
   VERSE,
-  templateHelpers,
+  version,
 } from '../src';
+
+import packageJSON from '../package.json';
 
 const {
   isEvaluatable,
@@ -87,6 +90,7 @@ describe('exports', () => {
     expect(TAB).toBeDefined();
     expect(VERSE).toBeDefined();
     expect(templateHelpers).toBeDefined();
+    expect(version).toEqual(packageJSON.version);
   });
 
   it('supplies all template helpers', () => {
@@ -133,6 +137,7 @@ describe('exports', () => {
     expect(ChordSheetJS.NONE).toBeDefined();
     expect(ChordSheetJS.TAB).toBeDefined();
     expect(ChordSheetJS.VERSE).toBeDefined();
+    expect(ChordSheetJS.version).toEqual(packageJSON.version);
   });
 
   it('supplies template helpers on the default export', () => {

--- a/unibuild.ts
+++ b/unibuild.ts
@@ -1,3 +1,4 @@
+import os from 'os';
 import peggy from 'peggy';
 import process from 'process';
 import tspegjs from 'ts-pegjs';
@@ -11,7 +12,7 @@ import buildScales from './script/build_scales';
 import buildChordProSectionGrammar from './script/build_chord_pro_section_grammar';
 
 const {
-  main, types, bundle,
+  main, types, bundle, version,
 } = packageJSON;
 
 interface BuildOptions {
@@ -113,6 +114,12 @@ unibuild((u: Builder) => {
     chordsOverWordsParser,
     chordDefinitionParser,
   ];
+
+  u.asset('versionFile', {
+    input: 'package.json',
+    outfile: 'src/version.ts',
+    build: () => `export default '${version}';${os.EOL}`,
+  });
 
   const jsBuild = u.asset('sources', {
     input: codeGeneratedAssets,


### PR DESCRIPTION
```js
import { version } from 'chordsheetjs';
console.log(version);

// or:

import ChordSheetJS from 'chordsheetjs';
console.log(ChordSheetJS.version);
```