### PR TITLE
Fix chord pro parser chopFirstWord issue

### DIFF
--- a/src/parser/chord_pro/helpers.ts
+++ b/src/parser/chord_pro/helpers.ts
@@ -128,7 +128,7 @@ export function combineChordLyricsPairs(items: SerializedItem[], chopFirstWord?:
   const combinedItems: SerializedItem[] = [];
 
   for (let i = 0, { length } = items; i < length; i += 1) {
-    if (combinableChordLyricsPairs(items[i], items[i + 1])) {
+    if (items[i + 1] && combinableChordLyricsPairs(items[i], items[i + 1])) {
       combinedItems.push(
         combineLyrics(
           items[i] as SerializedChordLyricsPair as SerializedChordLyricsPair,

--- a/test/parser/chord_pro_parser.test.ts
+++ b/test/parser/chord_pro_parser.test.ts
@@ -452,13 +452,25 @@ This part is [G]key
     expect(song.lines[0].items[0]).toBeChordLyricsPair('', '|: Let it be :|');
   });
 
-  it('does not chop off the first word when chopFirstWord is false', () => {
-    const chordSheet = '[Am]Whisper words of ';
+  describe('when chopFirstWord is false', () => {
+    it('does not chop off the first word', () => {
+      const chordSheet = '[Am]Whisper words of ';
 
-    const parser = new ChordProParser();
-    const song = parser.parse(chordSheet, { chopFirstWord: false });
+      const parser = new ChordProParser();
+      const song = parser.parse(chordSheet, { chopFirstWord: false });
 
-    expect(song.lines[0].items[0]).toBeChordLyricsPair('Am', 'Whisper words of ');
+      expect(song.lines[0].items[0]).toBeChordLyricsPair('Am', 'Whisper words of ');
+    });
+
+    it('parses odd item at the end of line', () => {
+      const chordSheet = '[Am]Whisper words of [G]wisdom';
+
+      const parser = new ChordProParser();
+      const song = parser.parse(chordSheet, { chopFirstWord: false });
+
+      expect(song.lines[0].items[0]).toBeChordLyricsPair('Am', 'Whisper words of ');
+      expect(song.lines[0].items[1]).toBeChordLyricsPair('G', 'wisdom');
+    });
   });
 
   describe('it is forgiving to syntax errors', () => {


### PR DESCRIPTION
When using parsing options `chopFirstWord: false` each line that ended with a single chord and single chord was crashing the parser.

Example `items` entering `combineChordLyricsPairs()`:
```json
[{"type":"chordLyricsPair","chords":"Am","lyrics":"Whisper"}]
```

`items[i+1]` would evaluate to `undefined`

The crash was occurring here:
```ts
function isChordLyricsPair(item: SerializedItem): boolean {
  return typeof item !== 'string' && item.type === 'chordLyricsPair';
                                      // ^ Cannot read properties of undefined
}
```