### PR TITLE
Group Parcel dependencies in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      parcel:
+        patterns:
+          - "parcel"
+          - "@parcel/*"


### PR DESCRIPTION
Configure Dependabot to combine all Parcel-related dependency updates (`parcel`, `@parcel/*`) into a single PR instead of creating separate ones.