### PR TITLE
Add section type support to UltimateGuitarParser

### DIFF
--- a/test/fixtures/ultimate_guitar_chordsheet_expected_chordpro_format.txt
+++ b/test/fixtures/ultimate_guitar_chordsheet_expected_chordpro_format.txt
@@ -22,12 +22,14 @@
 {end_of_chorus}
 
 
-{comment: Instrumental}
+{start_of_part: Instrumental}
 [F][C][Dm]
+{end_of_part}
 
 
-{comment: Solo}
+{start_of_part: Solo}
 [C][G][Am]
+{end_of_part}
 
 
 {start_of_chorus: Chorus}
@@ -36,5 +38,7 @@
 {end_of_chorus}
 
 
-{comment: Outro}
+{start_of_part: Outro}
 [F][C][Dm]
+
+{end_of_part}


### PR DESCRIPTION
## Summary
- Adds support for Bridge sections (`{start_of_bridge}/{end_of_bridge}`)
- Adds support for Intro, Outro, Instrumental, Interlude, Solo, Pre-Chorus as part sections (`{start_of_part}/{end_of_part}`)
- Adds support for numbered Chorus sections (`[Chorus 2]`)

**BREAKING CHANGE**: Section markers that were previously parsed as comments are now parsed as proper section tags. Code relying on these being comments will need updating.

Closes #1734 (partial)