### PR TITLE
Add support for consecutive chord lines in UltimateGuitarParser

### DIFF
--- a/src/parser/ultimate_guitar_parser.ts
+++ b/src/parser/ultimate_guitar_parser.ts
@@ -108,7 +108,7 @@ class UltimateGuitarParser extends ChordSheetParser {
   private parseChordLineWithNextLine(chordsLine: string): void {
     const nextLine = this.readLine();
 
-    if (this.isDirectiveLine(nextLine)) {
+    if (this.isNonLyricsLine(nextLine)) {
       this.parseChordsOnly(chordsLine);
       this.unreadLine();
     } else {
@@ -120,12 +120,13 @@ class UltimateGuitarParser extends ChordSheetParser {
     this.currentLine -= 1;
   }
 
-  private isDirectiveLine(line: string): boolean {
+  private isNonLyricsLine(line: string): boolean {
     return VERSE_LINE_REGEX.test(line) ||
       CHORUS_LINE_REGEX.test(line) ||
       BRIDGE_LINE_REGEX.test(line) ||
       PART_LINE_REGEX.test(line) ||
       OTHER_METADATA_LINE_REGEX.test(line) ||
+      CHORD_LINE_REGEX.test(line) ||
       line.trim().length === 0;
   }
 

--- a/test/parser/ultimate_guitar_parser.test.ts
+++ b/test/parser/ultimate_guitar_parser.test.ts
@@ -446,4 +446,35 @@ describe('UltimateGuitarParser', () => {
     expect(line0Items[2]).toBeChordLyricsPair('Am', '');
     expect(line0Items[3]).toBeChordLyricsPair('F', 'x3');
   });
+
+  it('parses consecutive chord lines without lyrics', () => {
+    const chordSheet = heredoc`
+      [Intro]
+      D A Bm G
+      D A Bm G`;
+
+    const parser = new UltimateGuitarParser({ preserveWhitespace: false });
+    const song = parser.parse(chordSheet);
+    const { lines } = song;
+
+    expect(lines.length).toEqual(4);
+
+    const line0Items = lines[0].items;
+    expect(line0Items[0]).toBeTag('start_of_part', 'Intro');
+
+    const line1Items = lines[1].items;
+    expect(line1Items[0]).toBeChordLyricsPair('D', '');
+    expect(line1Items[1]).toBeChordLyricsPair('A', '');
+    expect(line1Items[2]).toBeChordLyricsPair('Bm', '');
+    expect(line1Items[3]).toBeChordLyricsPair('G', '');
+
+    const line2Items = lines[2].items;
+    expect(line2Items[0]).toBeChordLyricsPair('D', '');
+    expect(line2Items[1]).toBeChordLyricsPair('A', '');
+    expect(line2Items[2]).toBeChordLyricsPair('Bm', '');
+    expect(line2Items[3]).toBeChordLyricsPair('G', '');
+
+    const line3Items = lines[3].items;
+    expect(line3Items[0]).toBeTag('end_of_part', '');
+  });
 });


### PR DESCRIPTION
## Summary
- Parser now correctly handles multiple consecutive chord lines without lyrics
- Chord lines followed by another chord line are parsed as chord-only
- Enables proper parsing of instrumental sections with repeated chord patterns

Addresses point 4 of #1734