### PR TITLE
Set metadata conditionally based on selector

### DIFF
--- a/src/formatter/chord_pro_formatter.ts
+++ b/src/formatter/chord_pro_formatter.ts
@@ -21,7 +21,8 @@ class ChordProFormatter extends Formatter {
    * @returns {string} The ChordPro string
    */
   format(song: Song): string {
-    const { lines, metadata } = song;
+    const { lines } = song;
+    const metadata = song.getMetadata(this.configuration);
     const { metadataLines, contentLines } = this.separateMetadataFromContent(lines);
     const formattedMetadataLines = this.formatMetadataSection(metadataLines);
     const formattedContentLines = this.formatContentSection(contentLines, metadata);

--- a/src/formatter/chords_over_words_formatter.ts
+++ b/src/formatter/chords_over_words_formatter.ts
@@ -48,7 +48,8 @@ class ChordsOverWordsFormatter extends Formatter {
 
   formatHeader(): string {
     // Process metadata according to configuration
-    const orderedMetadata = processMetadata(this.song.metadata.all(), this.configuration.metadata);
+    const songMetadata = this.song.getMetadata(this.configuration);
+    const orderedMetadata = processMetadata(songMetadata.all(), this.configuration.metadata);
 
     const metadata = orderedMetadata
       .map(([key, value]) => {
@@ -66,7 +67,8 @@ class ChordsOverWordsFormatter extends Formatter {
   }
 
   formatParagraphs(): string {
-    const { bodyParagraphs, bodyParagraphs: { length: count }, metadata } = this.song;
+    const { bodyParagraphs, bodyParagraphs: { length: count } } = this.song;
+    const metadata = this.song.getMetadata(this.configuration);
 
     const formattedParagraphs = bodyParagraphs.map((paragraph) => this.formatParagraph(paragraph, metadata));
     const combined = formattedParagraphs.join('\n\n');

--- a/src/formatter/html_formatter.ts
+++ b/src/formatter/html_formatter.ts
@@ -1,4 +1,5 @@
 import Formatter from './formatter';
+import Metadata from '../chord_sheet/metadata';
 import Paragraph from '../chord_sheet/paragraph';
 import Song from '../chord_sheet/song';
 import { getHTMLDefaultConfig } from './configuration';
@@ -8,6 +9,7 @@ import { HTMLFormatterConfiguration, HtmlTemplateCssClasses } from './configurat
 export interface HtmlTemplateArgs {
   configuration: HTMLFormatterConfiguration;
   song: Song;
+  metadata: Metadata;
   renderBlankLines?: boolean;
   bodyParagraphs: Paragraph[],
 }
@@ -57,6 +59,7 @@ abstract class HtmlFormatter extends Formatter<HTMLFormatterConfiguration> {
     return this.template(
       {
         song,
+        metadata: song.getMetadata(this.configuration),
         configuration: this.configuration,
         bodyParagraphs: this.configuration.expandChorusDirective ? expandedBodyParagraphs : bodyParagraphs,
       },

--- a/src/formatter/templates/html_div_formatter.ts
+++ b/src/formatter/templates/html_div_formatter.ts
@@ -25,11 +25,11 @@ export default (
       cssClasses: c,
     },
     song,
+    metadata,
     renderBlankLines = false,
     song: {
       title,
       subtitle,
-      metadata,
     },
     bodyParagraphs,
   }: HtmlTemplateArgs,

--- a/src/formatter/templates/html_table_formatter.ts
+++ b/src/formatter/templates/html_table_formatter.ts
@@ -25,12 +25,12 @@ export default (
       cssClasses: c,
     },
     song,
+    metadata,
     renderBlankLines = false,
     song: {
       title,
       subtitle,
       bodyLines,
-      metadata,
     },
     bodyParagraphs,
   }: HtmlTemplateArgs,

--- a/src/formatter/text_formatter.ts
+++ b/src/formatter/text_formatter.ts
@@ -27,7 +27,7 @@ class TextFormatter extends Formatter {
    */
   format(song: Song, metadata?: Metadata): string {
     this.song = song;
-    this.metadata = metadata || song.metadata;
+    this.metadata = metadata || song.getMetadata(this.configuration);
 
     return [
       this.formatHeader(),

--- a/test/chord_sheet/song.test.ts
+++ b/test/chord_sheet/song.test.ts
@@ -422,6 +422,76 @@ describe('Song', () => {
     });
   });
 
+  describe('#getMetadata', () => {
+    it('returns all metadata when no configuration is provided', () => {
+      const song = createSong([
+        createLine([createTag('artist', 'John')]),
+        createLine([createTag('title', 'My Song')]),
+      ]);
+
+      const metadata = song.getMetadata();
+
+      expect(metadata.getSingle('artist')).toEqual('John');
+      expect(metadata.getSingle('title')).toEqual('My Song');
+    });
+
+    it('leaves out metadata with non-matching selector', () => {
+      const configuration = configure({ instrument: { type: 'ukulele' } });
+
+      const song = createSong([
+        createLine([createTag('artist', 'John', null, 'guitar')]),
+        createLine([createTag('title', 'My Song')]),
+      ]);
+
+      const metadata = song.getMetadata(configuration);
+
+      expect(metadata.getSingle('artist')).toBeNull();
+      expect(metadata.getSingle('title')).toEqual('My Song');
+    });
+
+    it('includes metadata with matching selector', () => {
+      const configuration = configure({ instrument: { type: 'guitar' } });
+
+      const song = createSong([
+        createLine([createTag('artist', 'John', null, 'guitar')]),
+        createLine([createTag('title', 'My Song')]),
+      ]);
+
+      const metadata = song.getMetadata(configuration);
+
+      expect(metadata.getSingle('artist')).toEqual('John');
+      expect(metadata.getSingle('title')).toEqual('My Song');
+    });
+
+    it('leaves out metadata with a negated matching selector', () => {
+      const configuration = configure({ instrument: { type: 'guitar' } });
+
+      const song = createSong([
+        createLine([createTag('artist', 'John', null, 'guitar', true)]),
+        createLine([createTag('title', 'My Song')]),
+      ]);
+
+      const metadata = song.getMetadata(configuration);
+
+      expect(metadata.getSingle('artist')).toBeNull();
+      expect(metadata.getSingle('title')).toEqual('My Song');
+    });
+
+    it('includes metadata with a negated non-matching selector', () => {
+      const configuration = configure({ instrument: { type: 'ukulele' } });
+
+      const song = createSong([
+        createLine([createTag('artist', 'John', null, 'guitar', true)]),
+        createLine([createTag('title', 'My Song')]),
+      ]);
+
+      const metadata = song.getMetadata(configuration);
+
+      expect(metadata.getSingle('artist')).toEqual('John');
+      expect(metadata.getSingle('title')).toEqual('My Song');
+    });
+  });
+
   describe('#chordDefinitions', () => {
     it('returns the unique chord definitions in a song', () => {
       const cm7 = createChordDefinition('CM7', 3, ['x', 0, 1]);

--- a/test/formatter/chords_over_words_formatter.test.ts
+++ b/test/formatter/chords_over_words_formatter.test.ts
@@ -7,7 +7,7 @@ import { GRID } from '../../src/constants';
 import { exampleSongSolfege, exampleSongSymbol } from '../fixtures/song';
 
 import {
-  ABC, ChordsOverWordsFormatter, LILYPOND, TAB,
+  ABC, ChordProParser, ChordsOverWordsFormatter, LILYPOND, TAB,
 } from '../../src';
 
 import {
@@ -147,6 +147,39 @@ Grid line 2`;
       Let it be`;
 
     expect(formatter.format(song)).toEqual(expectedChordSheet);
+  });
+
+  describe('conditional metadata', () => {
+    it('excludes metadata with a non-matching selector', () => {
+      const song = new ChordProParser().parse(heredoc`
+        {title: My Song}
+        {artist-guitar: Guitar John}
+        {artist: Generic Jane}
+
+        [Am]Hello
+      `);
+
+      const formatter = new ChordsOverWordsFormatter({ instrument: { type: 'ukulele' } });
+      const result = formatter.format(song);
+
+      expect(result).toContain('artist: Generic Jane');
+      expect(result).not.toContain('Guitar John');
+    });
+
+    it('includes metadata with a matching selector', () => {
+      const song = new ChordProParser().parse(heredoc`
+        {title: My Song}
+        {artist-guitar: Guitar John}
+        {artist: Generic Jane}
+
+        [Am]Hello
+      `);
+
+      const formatter = new ChordsOverWordsFormatter({ instrument: { type: 'guitar' } });
+      const result = formatter.format(song);
+
+      expect(result).toContain('artist: Guitar John,Generic Jane');
+    });
   });
 
   describe('delegates', () => {

--- a/test/formatter/text_formatter.test.ts
+++ b/test/formatter/text_formatter.test.ts
@@ -256,6 +256,37 @@ Let it be, let it be, let it be, let it be`;
     expect(rendered).toEqual('Composers: John and Jane');
   });
 
+  describe('conditional metadata', () => {
+    it('excludes metadata with a non-matching selector from ternary expressions', () => {
+      const song = new ChordProParser().parse(heredoc`
+        {composer-guitar: Guitar John}
+        {composer: Generic Jane}
+
+        Composer: %{composer}
+      `);
+
+      const rendered = new TextFormatter({ instrument: { type: 'ukulele' } }).format(song);
+
+      expect(rendered).toEqual('Composer: Generic Jane');
+    });
+
+    it('includes metadata with a matching selector in ternary expressions', () => {
+      const song = new ChordProParser().parse(heredoc`
+        {composer-guitar: Guitar John}
+        {composer: Generic Jane}
+
+        Composer: %{composer}
+      `);
+
+      const rendered = new TextFormatter({
+        instrument: { type: 'guitar' },
+        metadata: { separator: ' and ' },
+      }).format(song);
+
+      expect(rendered).toEqual('Composer: Guitar John and Generic Jane');
+    });
+  });
+
   describe('delegates', () => {
     [ABC, GRID, LILYPOND, TAB].forEach((type) => {
       describe(`for ${type}`, () => {


### PR DESCRIPTION
## Summary

- Formatters now use `song.getMetadata(configuration)` instead of `song.metadata`, so that meta tags with selectors (e.g. `{artist-guitar: John}`) are evaluated against the configured `instrument.type` / `user.name`
- Affects TextFormatter, ChordsOverWordsFormatter, ChordProFormatter, HtmlDivFormatter, and HtmlTableFormatter
- Adds tests for `Song#getMetadata` with selectors and for conditional metadata rendering in formatters

Partial fix for #983 (set metadata conditionally based on selector)