### PR TITLE
Supply standard metadata (#1470)

### DIFF
--- a/src/chord_sheet/metadata.ts
+++ b/src/chord_sheet/metadata.ts
@@ -3,6 +3,8 @@ import MetadataAccessors from './metadata_accessors';
 import { isReadonlyTag } from './tag';
 import { CAPO, KEY, _KEY } from './tags';
 
+type MetadataProvider = () => string | null;
+
 function appendValue(array: string[], value: string): void {
   if (!array.includes(value)) {
     array.push(value);
@@ -19,6 +21,8 @@ function appendValue(array: string[], value: string): void {
  */
 class Metadata extends MetadataAccessors implements Iterable<[string, string | string[]]> {
   metadata: Record<string, string | string[]> = {};
+
+  providers = new Map<string, MetadataProvider>();
 
   constructor(metadata: Record<string, string | string[]> | Metadata = {}) {
     super();
@@ -72,6 +76,10 @@ class Metadata extends MetadataAccessors implements Iterable<[string, string | s
     this.metadata[key] = [currentValue, value];
   }
 
+  setProvider(key: string, provider: MetadataProvider): void {
+    this.providers.set(key, provider);
+  }
+
   set(key: string, value: string | null): void {
     if (value) {
       this.metadata[key] = value;
@@ -119,14 +127,42 @@ class Metadata extends MetadataAccessors implements Iterable<[string, string | s
       return this.metadata[prop];
     }
 
+    const provider = this.providers.get(prop);
+
+    if (provider) {
+      return provider();
+    }
+
     return this.getArrayItem(prop);
   }
 
   /**
-   * Returns all metadata values, including generated values like `_key`.
+   * Returns all metadata values, including provider values and generated values like `_key`.
    * @returns {Object.<string, string|string[]>} the metadata values
    */
   all(): Record<string, string | string[]> {
+    const all: Record<string, string | string[]> = {};
+
+    this.providers.forEach((provider, providerKey) => {
+      const value = provider();
+
+      if (value !== null) {
+        all[providerKey] = value;
+      }
+    });
+
+    Object.assign(all, this.metadata);
+
+    const key = this.calculateKeyFromCapo();
+
+    if (key) {
+      all[_KEY] = key;
+    }
+
+    return all;
+  }
+
+  ownMetadata(): Record<string, string | string[]> {
     const all = { ...this.metadata };
     const key = this.calculateKeyFromCapo();
 
@@ -138,7 +174,7 @@ class Metadata extends MetadataAccessors implements Iterable<[string, string | s
   }
 
   [Symbol.iterator](): IterableIterator<[string, string | string[]]> {
-    return Object.entries(this.all())[Symbol.iterator]();
+    return Object.entries(this.ownMetadata())[Symbol.iterator]();
   }
 
   /**
@@ -195,7 +231,9 @@ class Metadata extends MetadataAccessors implements Iterable<[string, string | s
    * @returns {Metadata} the cloned Metadata object
    */
   clone(): Metadata {
-    return new Metadata(this.metadata);
+    const cloned = new Metadata(this.metadata);
+    this.providers.forEach((provider, key) => cloned.setProvider(key, provider));
+    return cloned;
   }
 
   calculateKeyFromCapo(): string | null {

--- a/src/chord_sheet/song.ts
+++ b/src/chord_sheet/song.ts
@@ -20,6 +20,7 @@ import Tag from './tag';
 import { Accidental } from '../constants';
 import { testSelector } from '../helpers';
 import { CAPO, KEY } from './tags';
+import { configurationProviders, staticProviders } from './standard_metadata_providers';
 import { deprecate, filterObject } from '../utilities';
 
 type MapItemsCallback = (_item: Item) => Item | Item[] | null;
@@ -605,6 +606,15 @@ Or set the song key before changing key:
 
   getMetadata(configuration?: Configuration): Metadata {
     const metadata = new Metadata();
+
+    const providers = configuration ? configurationProviders(configuration) : staticProviders();
+    providers.forEach((provider, key) => metadata.setProvider(key, provider));
+
+    const chords = () => this.getChords();
+    metadata.setProvider('chords', () => { const c = chords(); return c.length ? c.join(', ') : null; });
+    metadata.setProvider('numchords', () => chords().length.toString());
+    metadata.setProvider('key_actual', () => metadata.getSingle('_key') ?? metadata.getSingle('key'));
+    metadata.setProvider('key_from', () => metadata.getSingle('key'));
 
     this.foreachItem((item: Item) => {
       if (!(item instanceof Tag)) {

--- a/src/chord_sheet/standard_metadata_providers.ts
+++ b/src/chord_sheet/standard_metadata_providers.ts
@@ -1,0 +1,33 @@
+import Configuration from '../formatter/configuration';
+
+type Provider = () => string | null;
+
+function formatDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function staticProviders(): Map<string, Provider> {
+  const providers = new Map<string, Provider>();
+  providers.set('chordpro', () => 'ChordPro');
+  providers.set('chordpro.version', () => '14.0.0');
+  providers.set('today', () => formatDate(new Date()));
+  return providers;
+}
+
+export function configurationProviders(configuration: Configuration): Map<string, Provider> {
+  const providers = staticProviders();
+  const { instrument, user } = configuration;
+
+  providers.set('instrument', () => instrument?.type ?? null);
+  providers.set('instrument.type', () => instrument?.type ?? null);
+  providers.set('instrument.description', () => instrument?.description ?? null);
+  providers.set('tuning', () => instrument?.tuning ?? null);
+  providers.set('user', () => user?.name ?? null);
+  providers.set('user.name', () => user?.name ?? null);
+  providers.set('user.fullname', () => user?.fullname ?? null);
+
+  return providers;
+}

--- a/src/formatter/chords_over_words_formatter.ts
+++ b/src/formatter/chords_over_words_formatter.ts
@@ -49,7 +49,7 @@ class ChordsOverWordsFormatter extends Formatter {
   formatHeader(): string {
     // Process metadata according to configuration
     const songMetadata = this.song.getMetadata(this.configuration);
-    const orderedMetadata = processMetadata(songMetadata.all(), this.configuration.metadata);
+    const orderedMetadata = processMetadata(songMetadata.ownMetadata(), this.configuration.metadata);
 
     const metadata = orderedMetadata
       .map(([key, value]) => {

--- a/src/formatter/configuration/base_configuration.ts
+++ b/src/formatter/configuration/base_configuration.ts
@@ -20,6 +20,7 @@ export interface MetadataConfiguration {
 export interface InstrumentConfiguration {
   type?: string;
   description?: string;
+  tuning?: string;
 }
 
 export interface UserConfigurationProperties {

--- a/src/rendering/shared/layout_section_renderer.ts
+++ b/src/rendering/shared/layout_section_renderer.ts
@@ -113,10 +113,10 @@ export class LayoutSectionRenderer {
       return true;
     }
 
-    const metadata = {
-      ...this.context.metadata.all(),
-      ...this.context.extraMetadata,
-    };
+    const { metadata: songMetadata, extraMetadata } = this.context;
+    const metadata = new Proxy({} as Record<string, any>, {
+      get: (_, prop: string) => extraMetadata?.[prop] ?? songMetadata.get(prop),
+    });
     return new Condition(contentItem.condition as ConditionalRule, metadata).evaluate();
   }
 

--- a/test/chord_sheet/metadata.test.ts
+++ b/test/chord_sheet/metadata.test.ts
@@ -21,7 +21,7 @@ describe('Metadata', () => {
     it('sets a value', () => {
       const metadata = new Metadata();
       metadata.add('artist', 'Steve');
-      expect(Object.keys(metadata)).toHaveLength(1);
+      expect(Object.keys(metadata.metadata)).toHaveLength(1);
       expect(metadata.metadata).toEqual({ artist: 'Steve' });
       expect(metadata.artist).toEqual('Steve');
     });
@@ -123,6 +123,77 @@ describe('Metadata', () => {
       expect(merged.key).toEqual('Ab');
       expect(merged.capo).toEqual('3');
       expect(merged.get('_key')).toEqual('B');
+    });
+  });
+
+  describe('providers', () => {
+    describe('get', () => {
+      it('returns provider value when key is not in explicit metadata', () => {
+        const metadata = new Metadata();
+        metadata.setProvider('chordpro', () => 'ChordPro');
+
+        expect(metadata.get('chordpro')).toEqual('ChordPro');
+      });
+
+      it('returns explicit metadata over provider value', () => {
+        const metadata = new Metadata({ title: 'Explicit Title' });
+        metadata.setProvider('title', () => 'Provider Title');
+
+        expect(metadata.get('title')).toEqual('Explicit Title');
+      });
+
+      it('supports dotted keys', () => {
+        const metadata = new Metadata();
+        metadata.setProvider('instrument.type', () => 'guitar');
+
+        expect(metadata.get('instrument.type')).toEqual('guitar');
+      });
+
+      it('returns null when provider returns null', () => {
+        const metadata = new Metadata();
+        metadata.setProvider('instrument', () => null);
+
+        expect(metadata.get('instrument')).toBeNull();
+      });
+    });
+
+    describe('all', () => {
+      it('includes provider values', () => {
+        const metadata = new Metadata({ artist: 'John' });
+        metadata.setProvider('chordpro', () => 'ChordPro');
+
+        const all = metadata.all();
+
+        expect(all.artist).toEqual('John');
+        expect(all.chordpro).toEqual('ChordPro');
+      });
+
+      it('does not override explicit metadata with provider values', () => {
+        const metadata = new Metadata({ title: 'Explicit' });
+        metadata.setProvider('title', () => 'Provider');
+
+        expect(metadata.all().title).toEqual('Explicit');
+      });
+    });
+
+    describe('clone', () => {
+      it('preserves providers', () => {
+        const metadata = new Metadata();
+        metadata.setProvider('chordpro', () => 'ChordPro');
+
+        const cloned = metadata.clone();
+
+        expect(cloned.get('chordpro')).toEqual('ChordPro');
+      });
+    });
+
+    describe('contains', () => {
+      it('returns false for provider-only keys', () => {
+        const metadata = new Metadata();
+        metadata.setProvider('chordpro', () => 'ChordPro');
+
+        expect(metadata.contains('chordpro')).toBe(false);
+      });
     });
   });
 

--- a/test/chord_sheet/song.test.ts
+++ b/test/chord_sheet/song.test.ts
@@ -492,6 +492,116 @@ describe('Song', () => {
     });
   });
 
+  describe('standard metadata', () => {
+    it('provides chordpro metadata without configuration', () => {
+      const song = createSong([]);
+      const metadata = song.getMetadata();
+
+      expect(metadata.get('chordpro')).toEqual('ChordPro');
+    });
+
+    it('provides today metadata', () => {
+      const song = createSong([]);
+      const metadata = song.getMetadata();
+
+      expect(metadata.get('today')).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    it('provides instrument.type from configuration', () => {
+      const configuration = configure({ instrument: { type: 'guitar' } });
+      const song = createSong([]);
+      const metadata = song.getMetadata(configuration);
+
+      expect(metadata.get('instrument.type')).toEqual('guitar');
+    });
+
+    it('provides user.name from configuration', () => {
+      const configuration = configure({ user: { name: 'johndoe' } });
+      const song = createSong([]);
+      const metadata = song.getMetadata(configuration);
+
+      expect(metadata.get('user.name')).toEqual('johndoe');
+    });
+
+    it('allows explicit directive to override standard metadata', () => {
+      const song = createSong([
+        createLine([createTag('title', 'My Song')]),
+      ]);
+
+      song.getMetadata();
+
+      // title doesn't have a standard provider, but chordpro does
+      // verify explicit metadata is preferred
+      const metadata = song.getMetadata();
+      expect(metadata.get('title')).toEqual('My Song');
+    });
+
+    it('provides chords as comma-separated list', () => {
+      const song = createSong([
+        createLine([createChordLyricsPair('Am', 'let it '), createChordLyricsPair('C', 'be')]),
+      ]);
+      const metadata = song.getMetadata();
+
+      expect(metadata.get('chords')).toEqual('Am, C');
+    });
+
+    it('provides numchords as count of unique chords', () => {
+      const song = createSong([
+        createLine([createChordLyricsPair('Am', 'let it '), createChordLyricsPair('C', 'be')]),
+      ]);
+      const metadata = song.getMetadata();
+
+      expect(metadata.get('numchords')).toEqual('2');
+    });
+
+    it('returns null for chords when song has no chords', () => {
+      const song = createSong([
+        createLine([createTag('title', 'No Chords')]),
+      ]);
+      const metadata = song.getMetadata();
+
+      expect(metadata.get('chords')).toBeNull();
+      expect(metadata.get('numchords')).toEqual('0');
+    });
+
+    it('provides key_actual as key when no capo is set', () => {
+      const song = createSong([
+        createLine([createTag('key', 'C')]),
+      ]);
+      const metadata = song.getMetadata();
+
+      expect(metadata.get('key_actual')).toEqual('C');
+    });
+
+    it('provides key_actual as transposed key when capo is set', () => {
+      const song = createSong([
+        createLine([createTag('key', 'C')]),
+        createLine([createTag('capo', '2')]),
+      ]);
+      const metadata = song.getMetadata();
+
+      expect(metadata.get('key_actual')).toEqual('D');
+    });
+
+    it('provides key_from as the original key', () => {
+      const song = createSong([
+        createLine([createTag('key', 'C')]),
+        createLine([createTag('capo', '2')]),
+      ]);
+      const metadata = song.getMetadata();
+
+      expect(metadata.get('key_from')).toEqual('C');
+    });
+
+    it('returns null for key_actual and key_from when no key is set', () => {
+      const song = createSong([]);
+      const metadata = song.getMetadata();
+
+      expect(metadata.get('key_actual')).toBeNull();
+      expect(metadata.get('key_from')).toBeNull();
+    });
+  });
+
   describe('#chordDefinitions', () => {
     it('returns the unique chord definitions in a song', () => {
       const cm7 = createChordDefinition('CM7', 3, ['x', 0, 1]);

--- a/test/chord_sheet/standard_metadata_providers.test.ts
+++ b/test/chord_sheet/standard_metadata_providers.test.ts
@@ -1,0 +1,89 @@
+import { configure } from '../../src/formatter/configuration';
+import { configurationProviders, staticProviders } from '../../src/chord_sheet/standard_metadata_providers';
+
+describe('standard metadata providers', () => {
+  describe('staticProviders', () => {
+    const providers = staticProviders();
+
+    it('provides chordpro', () => {
+      expect(providers.get('chordpro')!()).toEqual('ChordPro');
+    });
+
+    it('provides chordpro.version', () => {
+      expect(providers.get('chordpro.version')!()).toMatch(/^\d+\.\d+\.\d+$/);
+    });
+
+    it('provides today as current date', () => {
+      const today = providers.get('today')!();
+      expect(today).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+      const now = new Date();
+      const expected = [
+        now.getFullYear(),
+        String(now.getMonth() + 1).padStart(2, '0'),
+        String(now.getDate()).padStart(2, '0'),
+      ].join('-');
+
+      expect(today).toEqual(expected);
+    });
+  });
+
+  describe('configurationProviders', () => {
+    it('includes static providers', () => {
+      const configuration = configure({});
+      const providers = configurationProviders(configuration);
+
+      expect(providers.get('chordpro')!()).toEqual('ChordPro');
+    });
+
+    it('provides instrument values from configuration', () => {
+      const configuration = configure({
+        instrument: { type: 'guitar', description: 'Guitar, 6 strings, standard tuning' },
+      });
+      const providers = configurationProviders(configuration);
+
+      expect(providers.get('instrument')!()).toEqual('guitar');
+      expect(providers.get('instrument.type')!()).toEqual('guitar');
+      expect(providers.get('instrument.description')!()).toEqual('Guitar, 6 strings, standard tuning');
+    });
+
+    it('provides tuning from configuration', () => {
+      const configuration = configure({
+        instrument: { type: 'guitar', tuning: 'E2 A2 D3 G3 B3 E4' },
+      });
+      const providers = configurationProviders(configuration);
+
+      expect(providers.get('tuning')!()).toEqual('E2 A2 D3 G3 B3 E4');
+    });
+
+    it('provides user values from configuration', () => {
+      const configuration = configure({
+        user: { name: 'johndoe', fullname: 'John Doe' },
+      });
+      const providers = configurationProviders(configuration);
+
+      expect(providers.get('user')!()).toEqual('johndoe');
+      expect(providers.get('user.name')!()).toEqual('johndoe');
+      expect(providers.get('user.fullname')!()).toEqual('John Doe');
+    });
+
+    it('returns null for missing instrument configuration', () => {
+      const configuration = configure({});
+      const providers = configurationProviders(configuration);
+
+      expect(providers.get('instrument')!()).toBeNull();
+      expect(providers.get('instrument.type')!()).toBeNull();
+      expect(providers.get('instrument.description')!()).toBeNull();
+      expect(providers.get('tuning')!()).toBeNull();
+    });
+
+    it('returns null for missing user configuration', () => {
+      const configuration = configure({});
+      const providers = configurationProviders(configuration);
+
+      expect(providers.get('user')!()).toBeNull();
+      expect(providers.get('user.name')!()).toBeNull();
+      expect(providers.get('user.fullname')!()).toBeNull();
+    });
+  });
+});

--- a/test/integration/standard_metadata.test.ts
+++ b/test/integration/standard_metadata.test.ts
@@ -1,0 +1,117 @@
+import { ChordProParser } from '../../src';
+import { configure } from '../../src/formatter/configuration';
+import { heredoc } from '../util/utilities';
+
+describe('standard metadata', () => {
+  it('provides chordpro and today from a parsed song', () => {
+    const song = new ChordProParser().parse(heredoc`
+      {title: My Song}
+      {artist: John}
+      Let it [Am]be`);
+
+    expect(song.metadata.get('chordpro')).toEqual('ChordPro');
+    expect(song.metadata.get('chordpro.version')).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(song.metadata.get('today')).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('evaluates today lazily at access time', () => {
+    const song = new ChordProParser().parse('{title: Test}');
+    const metadata = song.getMetadata();
+
+    const today1 = metadata.get('today');
+    const today2 = metadata.get('today');
+
+    expect(today1).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(today1).toEqual(today2);
+  });
+
+  it('provides instrument metadata via configuration', () => {
+    const song = new ChordProParser().parse(heredoc`
+      {title: My Song}
+      Let it [Am]be`);
+
+    const configuration = configure({
+      instrument: { type: 'guitar', description: 'Guitar, 6 strings', tuning: 'E2 A2 D3 G3 B3 E4' },
+    });
+
+    const metadata = song.getMetadata(configuration);
+
+    expect(metadata.get('instrument')).toEqual('guitar');
+    expect(metadata.get('instrument.type')).toEqual('guitar');
+    expect(metadata.get('instrument.description')).toEqual('Guitar, 6 strings');
+    expect(metadata.get('tuning')).toEqual('E2 A2 D3 G3 B3 E4');
+  });
+
+  it('provides user metadata via configuration', () => {
+    const song = new ChordProParser().parse('{title: Test}');
+
+    const configuration = configure({
+      user: { name: 'johndoe', fullname: 'John Doe' },
+    });
+
+    const metadata = song.getMetadata(configuration);
+
+    expect(metadata.get('user')).toEqual('johndoe');
+    expect(metadata.get('user.name')).toEqual('johndoe');
+    expect(metadata.get('user.fullname')).toEqual('John Doe');
+  });
+
+  it('lets explicit directives override standard metadata', () => {
+    const song = new ChordProParser().parse(heredoc`
+      {title: My Song}
+      {artist: John}`);
+
+    const metadata = song.getMetadata();
+
+    expect(metadata.get('title')).toEqual('My Song');
+    expect(metadata.get('artist')).toEqual('John');
+    expect(metadata.get('chordpro')).toEqual('ChordPro');
+  });
+
+  it('provides chords and numchords from a parsed song', () => {
+    const song = new ChordProParser().parse(heredoc`
+      {title: Let It Be}
+      Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be`);
+
+    const metadata = song.getMetadata();
+
+    expect(metadata.get('chords')).toEqual('Am, C/G, F, C');
+    expect(metadata.get('numchords')).toEqual('4');
+  });
+
+  it('provides key_actual and key_from from a parsed song', () => {
+    const song = new ChordProParser().parse(heredoc`
+      {key: C}
+      {capo: 2}
+      Let it [Am]be`);
+
+    const metadata = song.getMetadata();
+
+    expect(metadata.get('key_from')).toEqual('C');
+    expect(metadata.get('key_actual')).toEqual('D');
+  });
+
+  it('includes standard metadata in all()', () => {
+    const song = new ChordProParser().parse(heredoc`
+      {title: My Song}
+      {artist: John}`);
+
+    const metadata = song.getMetadata();
+    const all = metadata.all();
+
+    expect(all.chordpro).toEqual('ChordPro');
+    expect(all.today).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(all.title).toEqual('My Song');
+  });
+
+  it('does not include standard metadata in iteration', () => {
+    const song = new ChordProParser().parse(heredoc`
+      {title: My Song}
+      {artist: John}`);
+
+    const entries = [...song.getMetadata()];
+
+    expect(entries.find(([key]) => key === 'chordpro')).toBeUndefined();
+    expect(entries.map(([key]) => key)).toEqual(['title', 'artist']);
+  });
+});


### PR DESCRIPTION
## Summary

- Add lazy metadata providers to `Metadata` class, evaluated on-demand via `get()` only (not in `all()` or iteration)
- Supply standard ChordPro metadata: `chordpro`, `chordpro.version`, `today`, `instrument.*`, `user.*`, `tuning`
- Add `tuning` to `InstrumentConfiguration`

Closes #1470