### PR TITLE
allow measured HTML formatter to use config template header and footer 

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "dev:pdf": "parcel test/formatter/pdf/index.html --port=3302",
     "dev:html": "parcel test/formatter/pdf/html-test.html --port=3301",
     "eslint": "node_modules/.bin/eslint",
-    "jest": "node --no-experimental-webstorage ./node_modules/jest/bin/jest.js",
     "lint": "yarn unibuild lint",
     "lint:fix": "yarn unibuild lint --fix",
     "postversion": "yarn build:release",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "dev:pdf": "parcel test/formatter/pdf/index.html --port=3302",
     "dev:html": "parcel test/formatter/pdf/html-test.html --port=3301",
     "eslint": "node_modules/.bin/eslint",
+    "jest": "node --no-experimental-webstorage ./node_modules/jest/bin/jest.js",
     "lint": "yarn unibuild lint",
     "lint:fix": "yarn unibuild lint --fix",
     "postversion": "yarn build:release",

--- a/playground/fixtures/configs/measured-html-formatter-configs.ts
+++ b/playground/fixtures/configs/measured-html-formatter-configs.ts
@@ -4,71 +4,210 @@ export const measuredHtmlConfigs = [
     content: {
       fonts: {
         title: {
-          name: '"Atkinson Hyperlegible Next"',
+          name: 'Arial',
           style: 'bold',
-          weight: 900,
-          size: 28,
-          color: 'black',
-        },
-        subtitle: {
-          name: '"Atkinson Hyperlegible Next"',
-          style: 'normal',
-          size: 10,
-          color: 100,
-        },
-        metadata: {
-          name: '"Atkinson Hyperlegible Next"',
-          style: 'normal',
-          size: 10,
-          color: 100,
-        },
-        text: {
-          name: '"Atkinson Hyperlegible Next"',
-          style: 'normal',
-          size: 18,
-          color: 'black',
-        },
-        chord: {
-          name: '"Atkinson Hyperlegible Next"',
-          style: 'bold',
-          weight: 500,
-          size: 16,
-          color: '#ed6e6e',
-        },
-        sectionLabel: {
-          name: '"Atkinson Hyperlegible Next"',
           weight: 700,
           size: 19,
-          color: 'black',
+          color: '#151515',
+        },
+        subtitle: {
+          name: 'Arial',
+          style: 'normal',
+          size: 11,
+          color: '#6f6f6f',
+        },
+        metadata: {
+          name: 'Arial',
+          style: 'normal',
+          size: 11,
+          color: '#6f6f6f',
+        },
+        text: {
+          name: 'Arial',
+          style: 'normal',
+          size: 18,
+          color: '#232323',
+        },
+        chord: {
+          name: 'Arial',
+          style: 'bold',
+          weight: 700,
+          size: 16,
+          color: '#2f2f2f',
+        },
+        sectionLabel: {
+          name: 'Arial',
+          weight: 700,
+          size: 15,
+          color: '#a1312d',
           lineHeight: 1.2,
         },
         comment: {
-          name: '"Atkinson Hyperlegible Next"',
+          name: 'Arial',
           weight: 700,
-          size: 19,
-          color: 'black',
+          size: 15,
+          color: '#232323',
           underline: true,
           lineHeight: 1.2,
         },
         annotation: {
-          name: '"Atkinson Hyperlegible Next"',
+          name: 'Arial',
           style: 'normal',
           size: 10,
-          color: 'black',
+          color: '#232323',
         },
       },
       layout: {
         global: {
           margins: {
-            top: 5,
+            top: 12,
             bottom: 10,
             left: 15,
             right: 15,
           },
         },
         header: {
-          height: 0,
+          height: 72,
           content: [
+            {
+              type: 'text',
+              template: '%{title}',
+              style: {
+                name: 'Arial', style: 'bold', size: 19, color: '#151515', weight: 700,
+              },
+              position: {
+                x: 'left', y: 0, width: 'auto', clip: true, ellipsis: true,
+              },
+              condition: {
+                page: { first: true },
+              },
+            },
+            {
+              type: 'text',
+              template: '%{artist}',
+              style: {
+                name: 'Arial', style: 'normal', size: 11, color: '#6f6f6f',
+              },
+              position: {
+                x: 'left', y: 25, width: 'auto', clip: true, ellipsis: true,
+              },
+              condition: {
+                page: { first: true },
+              },
+            },
+            {
+              type: 'text',
+              template: '%{tempo|%{} BPM}%{time| \u00b7 %{}}%{capo| \u00b7 Capo %{}}',
+              style: {
+                name: 'Arial', style: 'normal', size: 11, color: '#6f6f6f',
+              },
+              position: {
+                x: 'left', y: 40, width: 240, clip: true, ellipsis: true,
+              },
+              condition: {
+                page: { first: true },
+              },
+            },
+            {
+              type: 'line',
+              style: { width: 1, color: '#d7d7d7' },
+              position: {
+                x: 0, y: 60, width: 'auto', height: 0,
+              },
+              condition: {
+                page: { first: true },
+              },
+            },
+            {
+              type: 'text',
+              template: '%{key}',
+              cssClass: 'measured-html-key-badge',
+              elementStyle: {
+                width: '28px',
+                height: '28px',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                borderRadius: '999px',
+                backgroundColor: '#a1312d',
+                textAlign: 'center',
+                boxSizing: 'border-box',
+              },
+              style: {
+                name: 'Arial', style: 'bold', size: 12, color: '#ffffff', weight: 700,
+              },
+              position: {
+                x: 'right', y: 12, width: 28, offsetX: -2,
+              },
+              condition: {
+                and: [
+                  { page: { first: true } },
+                  { key: { exists: true } },
+                ],
+              },
+            },
+            {
+              type: 'text',
+              template: '%{title}',
+              style: {
+                name: 'Arial', style: 'bold', size: 12, color: '#151515', weight: 700,
+              },
+              position: {
+                x: 'left', y: 0, width: 'auto', clip: true, ellipsis: true,
+              },
+              condition: {
+                page: { greater_than: 1 },
+              },
+            },
+            {
+              type: 'text',
+              template: '%{page}/%{pages}',
+              style: {
+                name: 'Arial', style: 'normal', size: 10, color: '#9a9a9a',
+              },
+              position: { x: 'right', y: 4, offsetX: -38 },
+              condition: {
+                page: { greater_than: 1 },
+              },
+            },
+            {
+              type: 'text',
+              template: '%{key}',
+              cssClass: 'measured-html-key-badge',
+              elementStyle: {
+                width: '28px',
+                height: '28px',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                borderRadius: '999px',
+                backgroundColor: '#a1312d',
+                textAlign: 'center',
+                boxSizing: 'border-box',
+              },
+              style: {
+                name: 'Arial', style: 'bold', size: 12, color: '#ffffff', weight: 700,
+              },
+              position: {
+                x: 'right', y: 2, width: 28, offsetX: -2,
+              },
+              condition: {
+                and: [
+                  { page: { greater_than: 1 } },
+                  { key: { exists: true } },
+                ],
+              },
+            },
+            {
+              type: 'line',
+              style: { width: 1, color: '#d7d7d7' },
+              position: {
+                x: 0, y: 32, width: 'auto', height: 0,
+              },
+              condition: {
+                page: { greater_than: 1 },
+              },
+            },
           ],
         },
         footer: {
@@ -134,13 +273,13 @@ export const measuredHtmlConfigs = [
           },
           fonts: {
             title: {
-              name: 'NimbusSansL-Bol', style: 'bold', size: 9, color: 'black',
+              name: 'Arial', style: 'bold', size: 9, color: '#232323',
             },
             fingerings: {
-              name: 'NimbusSansL-Bol', style: 'bold', size: 6, color: 'black',
+              name: 'Arial', style: 'bold', size: 6, color: '#232323',
             },
             baseFret: {
-              name: 'NimbusSansL-Bol', style: 'bold', size: 6, color: 'black',
+              name: 'Arial', style: 'bold', size: 6, color: '#232323',
             },
           },
         },

--- a/playground/fixtures/index.ts
+++ b/playground/fixtures/index.ts
@@ -9,11 +9,9 @@ import { pdfFormatterConfigs } from './configs/pdf-formatter-configs';
 import {
   getDefaultConfig,
   getHTMLDefaultConfig,
+  getMeasuredHtmlDefaultConfig,
   getPDFDefaultConfig,
 } from '../../src/formatter/configuration';
-
-// Define base config for all formatters
-const baseConfig = getDefaultConfig('base');
 
 // Create default configs for each formatter
 const formatterDefaultConfigs = {
@@ -21,6 +19,7 @@ const formatterDefaultConfigs = {
   'ChordPro': getDefaultConfig('base'),
   'ChordsOverWords': getDefaultConfig('base'),
   'HTML': getHTMLDefaultConfig(),
+  'MeasuredHTML': getMeasuredHtmlDefaultConfig(),
 };
 
 // Prepare array of config examples for each formatter
@@ -44,7 +43,7 @@ const formatterConfigExamples = {
   ],
   'MeasuredHTML': [
     ...measuredHtmlConfigs,
-    { name: 'Default Configuration', content: baseConfig },
+    { name: 'Default Configuration', content: formatterDefaultConfigs.MeasuredHTML },
   ],
 };
 

--- a/src/formatter/configuration/index.ts
+++ b/src/formatter/configuration/index.ts
@@ -77,6 +77,7 @@ import {
   getBaseDefaultConfig,
   getDefaultConfig,
   getHTMLDefaultConfig,
+  getMeasuredHtmlDefaultConfig,
   getPDFDefaultConfig,
 } from './default_config_manager';
 
@@ -161,6 +162,7 @@ export {
   Configuration,
   getDefaultConfig,
   getHTMLDefaultConfig,
+  getMeasuredHtmlDefaultConfig,
   getPDFDefaultConfig,
 };
 

--- a/src/formatter/configuration/measured_html_configuration.ts
+++ b/src/formatter/configuration/measured_html_configuration.ts
@@ -57,79 +57,192 @@ export const measuredHtmlSpecificDefaults: Partial<MeasuredHtmlFormatterConfigur
   },
   fonts: {
     title: {
-      name: 'NimbusSansL-Bol', style: 'bold', size: 24, color: 'black',
+      name: 'Arial', style: 'bold', size: 22, color: '#151515',
     },
     subtitle: {
-      name: 'NimbusSansL-Reg', style: 'normal', size: 10, color: 100,
+      name: 'Arial', style: 'normal', size: 11, color: '#6f6f6f',
     },
     metadata: {
-      name: 'NimbusSansL-Reg', style: 'normal', size: 10, color: 100,
+      name: 'Arial', style: 'normal', size: 10, color: '#8b8b8b',
     },
     text: {
-      name: 'NimbusSansL-Reg', style: 'normal', size: 10, color: 'black',
+      name: 'Arial', style: 'normal', size: 10, color: '#232323',
     },
     chord: {
-      name: 'NimbusSansL-Bol', style: 'bold', size: 9, color: 'black',
+      name: 'Arial', style: 'bold', size: 9, color: '#232323',
     },
     comment: {
-      name: 'NimbusSansL-Bol', style: 'bold', size: 10, color: 'black',
+      name: 'Arial', style: 'bold', size: 10, color: '#232323',
     },
     sectionLabel: {
-      name: 'NimbusSansL-Bol', style: 'bold', size: 10, color: 'black',
+      name: 'Arial', style: 'bold', size: 10, color: '#a1312d',
     },
     annotation: {
-      name: 'NimbusSansL-Reg', style: 'normal', size: 10, color: 'black',
+      name: 'Arial', style: 'normal', size: 10, color: '#232323',
     },
   },
   layout: {
     global: {
       margins: {
-        top: 35,
-        bottom: 10,
+        top: 14,
+        bottom: 12,
         left: 45,
         right: 45,
       },
     },
     header: {
-      height: 60,
+      height: 72,
       content: [
         {
           type: 'text',
           template: '%{title}',
           style: {
-            name: 'NimbusSansL-Bol', style: 'bold', size: 24, color: 'black',
+            name: 'Arial', style: 'bold', size: 19, color: '#151515', weight: 700,
           },
-          position: { x: 'left', y: 15 },
+          position: {
+            x: 'left', y: 0, clip: true, ellipsis: true,
+          },
+          condition: {
+            page: { first: true },
+          },
         },
         {
           type: 'text',
-          template: 'Key of %{key} - BPM %{tempo} - Time %{time}',
+          template: '%{artist}',
           style: {
-            name: 'NimbusSansL-Reg', style: 'normal', size: 12, color: 100,
+            name: 'Arial', style: 'normal', size: 11, color: '#6f6f6f',
           },
-          position: { x: 'left', y: 28 },
+          position: {
+            x: 'left', y: 25, clip: true, ellipsis: true,
+          },
+          condition: {
+            page: { first: true },
+          },
         },
         {
           type: 'text',
-          template: 'By %{artist} %{subtitle}',
+          template: '%{tempo|%{} BPM}%{time| \u00b7 %{}}%{capo| \u00b7 Capo %{}}',
           style: {
-            name: 'NimbusSansL-Reg', style: 'normal', size: 10, color: 100,
+            name: 'Arial', style: 'normal', size: 11, color: '#6f6f6f',
           },
-          position: { x: 'left', y: 38 },
+          position: {
+            x: 'left', y: 40, width: 240, clip: true, ellipsis: true,
+          },
+          condition: {
+            page: { first: true },
+          },
+        },
+        {
+          type: 'line',
+          style: { width: 1, color: '#d7d7d7' },
+          position: {
+            x: 0, y: 60, width: 'auto', height: 0,
+          },
+          condition: {
+            page: { first: true },
+          },
+        },
+        {
+          type: 'text',
+          template: '%{key}',
+          cssClass: 'measured-html-key-badge',
+          elementStyle: {
+            width: '28px',
+            height: '28px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderRadius: '999px',
+            backgroundColor: '#a1312d',
+            textAlign: 'center',
+            boxSizing: 'border-box',
+          },
+          style: {
+            name: 'Arial', style: 'bold', size: 12, color: '#ffffff', weight: 700,
+          },
+          position: {
+            x: 'right',
+            y: 12,
+            width: 28,
+            offsetX: -2,
+          },
+          condition: {
+            and: [
+              { page: { first: true } },
+              { key: { exists: true } },
+            ],
+          },
+        },
+        {
+          type: 'text',
+          template: '%{title}',
+          style: {
+            name: 'Arial', style: 'bold', size: 12, color: '#151515', weight: 700,
+          },
+          position: {
+            x: 'left', y: 0, clip: true, ellipsis: true,
+          },
+          condition: {
+            page: { greater_than: 1 },
+          },
+        },
+        {
+          type: 'text',
+          template: '%{page}/%{pages}',
+          style: {
+            name: 'Arial', style: 'normal', size: 10, color: '#9a9a9a',
+          },
+          position: { x: 'right', y: 4, offsetX: -38 },
+          condition: {
+            page: { greater_than: 1 },
+          },
+        },
+        {
+          type: 'text',
+          template: '%{key}',
+          cssClass: 'measured-html-key-badge',
+          elementStyle: {
+            width: '28px',
+            height: '28px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderRadius: '999px',
+            backgroundColor: '#a1312d',
+            textAlign: 'center',
+            boxSizing: 'border-box',
+          },
+          style: {
+            name: 'Arial', style: 'bold', size: 12, color: '#ffffff', weight: 700,
+          },
+          position: {
+            x: 'right',
+            y: 2,
+            width: 28,
+            offsetX: -2,
+          },
+          condition: {
+            and: [
+              { page: { greater_than: 1 } },
+              { key: { exists: true } },
+            ],
+          },
+        },
+        {
+          type: 'line',
+          style: { width: 1, color: '#d7d7d7' },
+          position: {
+            x: 0, y: 32, width: 'auto', height: 0,
+          },
+          condition: {
+            page: { greater_than: 1 },
+          },
         },
       ],
     },
     footer: {
-      height: 30,
+      height: 0,
       content: [
-        {
-          type: 'text',
-          value: '©2024 My Music Publishing',
-          style: {
-            name: 'NimbusSansL-Reg', style: 'normal', size: 10, color: 'black',
-          },
-          position: { x: 'left', y: 0 },
-        },
       ],
     },
     sections: {
@@ -178,13 +291,13 @@ export const measuredHtmlSpecificDefaults: Partial<MeasuredHtmlFormatterConfigur
       },
       fonts: {
         title: {
-          name: 'NimbusSansL-Bol', style: 'bold', size: 9, color: 'black',
+          name: 'Arial', style: 'bold', size: 9, color: '#232323',
         },
         fingerings: {
-          name: 'NimbusSansL-Bol', style: 'bold', size: 6, color: 'black',
+          name: 'Arial', style: 'bold', size: 6, color: '#232323',
         },
         baseFret: {
-          name: 'NimbusSansL-Bol', style: 'bold', size: 6, color: 'black',
+          name: 'Arial', style: 'bold', size: 6, color: '#232323',
         },
       },
     },

--- a/src/formatter/configuration/measurement_based_configuration.ts
+++ b/src/formatter/configuration/measurement_based_configuration.ts
@@ -32,7 +32,7 @@ export type FontSection =
   'sectionLabel';
 
 export type LayoutSection = 'header' | 'footer';
-export type Alignment = 'left' | 'center' | 'right';
+export type Alignment = 'left' | 'center' | 'right' | number;
 export type MeasurerType = 'canvas' | 'dom' | 'jspdf';
 
 // Condition rules for conditional rendering
@@ -66,6 +66,7 @@ export interface Position {
   y: number,
   width?: number,
   height?: number,
+  offsetX?: number,
   clip?: boolean,
   ellipsis?: boolean,
 }
@@ -198,6 +199,8 @@ export interface LayoutContentItemWithText extends ILayoutContentItem {
   style: FontConfiguration,
   value?: string,
   template?: string,
+  cssClass?: string,
+  elementStyle?: Record<string, string>,
 }
 
 export interface LayoutContentItemWithValue extends LayoutContentItemWithText {

--- a/src/rendering/html/html_element_styler.ts
+++ b/src/rendering/html/html_element_styler.ts
@@ -58,12 +58,12 @@ export class HtmlElementStyler {
    * Gets conditional CSS styles from font configuration
    */
   getConditionalStyles(style: FontConfiguration): Partial<CSSStyleDeclaration> {
+    const normalizedFontStyles = this.getNormalizedFontStyles(style);
+
     return {
       ...(style.name && { fontFamily: style.name }),
       ...(style.size && { fontSize: `${style.size}px` }),
-      ...(style.weight && { fontWeight: style.weight }),
-      ...(style.style && { fontStyle: style.style }),
-      ...(style.color && { color: style.color }),
+      ...normalizedFontStyles,
       ...(style.underline && { textDecoration: 'underline' }),
       ...(style.textTransform && { textTransform: style.textTransform }),
       ...(style.textDecoration && { textDecoration: style.textDecoration }),
@@ -109,13 +109,13 @@ export class HtmlElementStyler {
    * Applies font styles to an HTML element
    */
   applyFontStyle(element: HTMLElement, style: FontConfiguration): void {
+    const normalizedFontStyles = this.getNormalizedFontStyles(style);
+
     const styles = {
       whiteSpace: 'pre',
       ...(style.name && { fontFamily: `${style.name}` }),
       ...(style.size && { fontSize: `${style.size}px` }),
-      ...(style.weight && { fontWeight: style.weight }),
-      ...(style.style && { fontStyle: style.style }),
-      ...(style.color && { color: style.color }),
+      ...normalizedFontStyles,
       ...(style.underline && { textDecoration: 'underline' }),
       ...(style.lineHeight && { lineHeight: `${style.lineHeight}` }),
     };
@@ -147,6 +147,30 @@ export class HtmlElementStyler {
    */
   getCustomClass(elementType: string): string | undefined {
     return this.config.cssClasses?.[elementType];
+  }
+
+  private getNormalizedFontStyles(style: FontConfiguration): Partial<CSSStyleDeclaration> {
+    const fontWeight = style.weight ?? (style.style === 'bold' ? 'bold' : undefined);
+    const fontStyle = style.style && style.style !== 'bold' ? style.style : undefined;
+    const color = this.normalizeColor(style.color);
+
+    return {
+      ...(fontWeight && { fontWeight }),
+      ...(fontStyle && { fontStyle }),
+      ...(color && { color }),
+    };
+  }
+
+  private normalizeColor(color: FontConfiguration['color']): string | undefined {
+    if (typeof color === 'number') {
+      return `rgb(${color}, ${color}, ${color})`;
+    }
+
+    if (typeof color === 'string' && /^\d+$/.test(color)) {
+      return `rgb(${color}, ${color}, ${color})`;
+    }
+
+    return color;
   }
 }
 

--- a/src/rendering/html/positioned_html_renderer.ts
+++ b/src/rendering/html/positioned_html_renderer.ts
@@ -15,6 +15,9 @@ import Renderer, { ParagraphLayout, PositionedElement } from '../renderer';
 
 import {
   FontConfiguration,
+  LayoutContentItemWithText,
+  LayoutItem,
+  LineStyle,
   MeasuredHtmlFormatterConfiguration,
 } from '../../formatter/configuration';
 
@@ -32,6 +35,14 @@ interface Bounds {
  */
 class PositionedHtmlRenderer extends Renderer {
   private configuration: MeasuredHtmlFormatterConfiguration;
+
+  private currentLayoutFontStyle: FontConfiguration | null = null;
+
+  private currentLayoutSection: 'header' | 'footer' | null = null;
+
+  private currentLayoutTextItem: LayoutContentItemWithText | null = null;
+
+  private currentLineStyle: LineStyle | null = null;
 
   private _dimensions: Dimensions | null = null;
 
@@ -130,42 +141,64 @@ class PositionedHtmlRenderer extends Renderer {
   }
 
   protected renderHeadersAndFooters(): void {
-    const layoutRenderer = this.createLayoutRenderer();
+    const headerConfig = this.getHeaderConfig();
+    const footerConfig = this.getFooterConfig();
 
-    if (this.getHeaderConfig()) {
-      this.doc.eachPage(() => {
-        layoutRenderer.renderLayout(this.getHeaderConfig()!, 'header');
-      });
+    if (headerConfig) {
+      this.renderLayoutForEachPage(headerConfig, 'header');
     }
-    if (this.getFooterConfig()) {
-      this.doc.eachPage(() => {
-        layoutRenderer.renderLayout(this.getFooterConfig()!, 'footer');
-      });
+
+    if (footerConfig) {
+      this.renderLayoutForEachPage(footerConfig, 'footer');
     }
+
+    this.resetLayoutRenderingState();
   }
 
-  private createLayoutRenderer(): LayoutSectionRenderer {
-    const backend = this.createLayoutBackend();
-    return new LayoutSectionRenderer(backend, {
-      metadata: this.song.metadata,
-      margins: this.dimensions.margins,
-      extraMetadata: this.getExtraMetadata(this.doc.currentPage, this.doc.totalPages),
+  private renderLayoutForEachPage(layoutConfig: LayoutItem, section: 'header' | 'footer'): void {
+    this.doc.eachPage((_page, index) => {
+      this.currentLayoutSection = section;
+      this.resetLayoutRenderingState(section);
+      this.createLayoutRenderer(index + 1, this.doc.totalPages).renderLayout(layoutConfig, section);
     });
   }
 
-  private createLayoutBackend(): LayoutRenderingBackend {
+  private resetLayoutRenderingState(section: 'header' | 'footer' | null = null): void {
+    this.currentLayoutSection = section;
+    this.currentLayoutFontStyle = null;
+    this.currentLayoutTextItem = null;
+    this.currentLineStyle = null;
+  }
+
+  private createLayoutRenderer(page: number, totalPages: number): LayoutSectionRenderer {
+    const backend = this.createLayoutBackend(page, totalPages);
+    return new LayoutSectionRenderer(backend, {
+      metadata: this.song.metadata,
+      margins: this.dimensions.margins,
+      extraMetadata: this.getExtraMetadata(page, totalPages),
+    });
+  }
+
+  private createLayoutBackend(page: number, totalPages: number): LayoutRenderingBackend {
     return {
       pageSize: this.doc.pageSize,
-      currentPage: this.doc.currentPage,
-      totalPages: this.doc.totalPages,
+      currentPage: page,
+      totalPages,
       text: (content, x, y) => this.renderHtmlText(content, x, y),
       getTextWidth: (text, font) => this.doc.getTextWidth(text, font!),
       splitTextToSize: (text, maxWidth, font) => this.doc.splitTextToSize(text, maxWidth, font!),
-      setFontStyle: () => { /* no-op for HTML */ },
+      setFontStyle: (style) => {
+        this.currentLayoutFontStyle = style;
+      },
+      setTextItem: (item) => {
+        this.currentLayoutTextItem = item;
+      },
       addElement: (element, x, y) => this.doc.addElement(element, x, y),
       addImage: (src, _format, x, y, width, height) => this.renderHtmlImage(src, x, y, width, height),
       line: (x1, y1, x2, y2) => this.renderHtmlLine(x1, y1, x2, y2),
-      setLineStyle: () => { /* no-op for HTML */ },
+      setLineStyle: (style) => {
+        this.currentLineStyle = style;
+      },
       resetDash: () => { /* no-op for HTML */ },
     };
   }
@@ -173,8 +206,33 @@ class PositionedHtmlRenderer extends Renderer {
   private renderHtmlText(content: string, x: number, y: number): void {
     const element = document.createElement('div');
     element.className = `${this.styler.prefix}header-text`;
+    this.applyLayoutTextClasses(element);
+
     element.textContent = content;
+    this.applyLayoutTextStyles(element);
+
     this.doc.addElement(element, x, y);
+  }
+
+  private applyLayoutTextClasses(element: HTMLDivElement): void {
+    const sectionClass = this.currentLayoutSection ? this.styler.getCustomClass(this.currentLayoutSection) : undefined;
+    if (sectionClass) {
+      element.classList.add(sectionClass);
+    }
+
+    if (this.currentLayoutTextItem?.cssClass) {
+      element.classList.add(this.currentLayoutTextItem.cssClass);
+    }
+  }
+
+  private applyLayoutTextStyles(element: HTMLDivElement): void {
+    if (this.currentLayoutTextItem?.elementStyle) {
+      Object.assign(element.style, this.currentLayoutTextItem.elementStyle);
+    }
+
+    if (this.currentLayoutFontStyle) {
+      this.styler.applyFontStyle(element, this.currentLayoutFontStyle);
+    }
   }
 
   private renderHtmlImage(src: string, x: number, y: number, width: number, height: number): void {
@@ -189,11 +247,12 @@ class PositionedHtmlRenderer extends Renderer {
   private renderHtmlLine(x1: number, y1: number, x2: number, _y2: number): void {
     const lineElement = document.createElement('div');
     lineElement.className = `${this.styler.prefix}line`;
+    const lineStyle = this.currentLineStyle;
     lineElement.style.width = `${x2 - x1}px`;
-    lineElement.style.height = '1px';
-    lineElement.style.borderBottomWidth = '1px';
-    lineElement.style.borderBottomStyle = 'solid';
-    lineElement.style.borderBottomColor = '#000000';
+    lineElement.style.height = '0';
+    lineElement.style.borderBottomWidth = `${lineStyle?.width ?? 1}px`;
+    lineElement.style.borderBottomStyle = lineStyle?.dash?.length ? 'dashed' : 'solid';
+    lineElement.style.borderBottomColor = lineStyle?.color ?? '#000000';
     this.doc.addElement(lineElement, x1, y1);
   }
 

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -426,8 +426,6 @@ abstract class Renderer {
   protected recordRenderingTime(): void {
     const endTime = performance.now();
     this.renderTime = (endTime - this.startTime) / 1000;
-    // eslint-disable-next-line no-console
-    console.log(`Rendered in ${this.renderTime.toFixed(2)} seconds`);
   }
 
   /**

--- a/src/rendering/shared/layout_section_renderer.ts
+++ b/src/rendering/shared/layout_section_renderer.ts
@@ -32,6 +32,7 @@ export interface LayoutRenderingBackend {
   getTextWidth(text: string, font?: FontConfiguration): number;
   splitTextToSize(text: string, maxWidth: number, font?: FontConfiguration): string[];
   setFontStyle(style: FontConfiguration): void;
+  setTextItem?(item: LayoutContentItemWithText): void;
 
   // Element operations (HTML-specific, PDF uses text directly)
   addElement?(element: any, x: number, y: number): void;
@@ -115,7 +116,18 @@ export class LayoutSectionRenderer {
 
     const { metadata: songMetadata, extraMetadata } = this.context;
     const metadata = new Proxy({} as Record<string, any>, {
-      get: (_, prop: string) => extraMetadata?.[prop] ?? songMetadata.get(prop),
+      get: (_, prop: string) => {
+        const value = extraMetadata?.[prop] ?? songMetadata.get(prop);
+
+        if ((prop === 'page' || prop === 'pages' || prop === 'renderTime') && typeof value === 'string') {
+          const numericValue = Number(value);
+          if (!Number.isNaN(numericValue)) {
+            return numericValue;
+          }
+        }
+
+        return value;
+      },
     });
     return new Condition(contentItem.condition as ConditionalRule, metadata).evaluate();
   }
@@ -140,9 +152,9 @@ export class LayoutSectionRenderer {
     const y = sectionY + position.y;
 
     if (position.clip) {
-      this.renderClippedText(textValue, position, availableWidth, y, style);
+      this.renderClippedText(textValue, textItem, availableWidth, y, style);
     } else {
-      this.renderMultilineText(textValue, position, availableWidth, y, style);
+      this.renderMultilineText(textValue, textItem, availableWidth, y, style);
     }
   }
 
@@ -151,16 +163,19 @@ export class LayoutSectionRenderer {
    */
   private renderClippedText(
     textValue: string,
-    position: any,
+    textItem: LayoutContentItemWithText,
     availableWidth: number,
     y: number,
     style: FontConfiguration,
   ): void {
+    const { position } = textItem;
     const clippedText = position.ellipsis ?
       this.clipTextWithEllipsis(textValue, availableWidth, style) :
       this.clipText(textValue, availableWidth, style);
     const textWidth = this.backend.getTextWidth(clippedText, style);
-    const x = this.calculateX(position.x, textWidth);
+    const alignmentWidth = position.width ?? textWidth;
+    this.backend.setTextItem?.(textItem);
+    const x = this.calculateX(position.x, alignmentWidth, position.offsetX);
     this.backend.text(clippedText, x, y);
   }
 
@@ -191,17 +206,20 @@ export class LayoutSectionRenderer {
    */
   private renderMultilineText(
     textValue: string,
-    position: any,
+    textItem: LayoutContentItemWithText,
     availableWidth: number,
     y: number,
     style: FontConfiguration,
   ): void {
+    const { position } = textItem;
     const lines = this.backend.splitTextToSize(textValue, availableWidth, style);
     let tempY = y;
 
     lines.forEach((line: string) => {
       const lineWidth = this.backend.getTextWidth(line, style);
-      const x = this.calculateX(position.x, lineWidth);
+      const alignmentWidth = position.width ?? lineWidth;
+      this.backend.setTextItem?.(textItem);
+      const x = this.calculateX(position.x, alignmentWidth, position.offsetX);
       this.backend.text(line, x, tempY);
       tempY += style.size * (style.lineHeight ?? 1.2);
     });
@@ -215,7 +233,7 @@ export class LayoutSectionRenderer {
       src, position, size, alias, compression, rotation,
     } = imageItem;
 
-    const x = this.calculateX(position.x, size.width);
+    const x = this.calculateX(position.x, size.width, position.offsetX);
     const y = sectionY + position.y;
     const format = src.split('.').pop()?.toUpperCase() as string;
 
@@ -252,18 +270,18 @@ export class LayoutSectionRenderer {
   /**
    * Calculates the X position based on alignment
    */
-  calculateX(alignment: Alignment | number, width = 0): number {
+  calculateX(alignment: Alignment | number, width = 0, offsetX = 0): number {
     switch (alignment) {
       case 'center':
-        return this.backend.pageSize.width / 2 - width / 2;
+        return this.backend.pageSize.width / 2 - width / 2 + offsetX;
       case 'right':
-        return this.backend.pageSize.width - this.context.margins.right - width;
+        return this.backend.pageSize.width - this.context.margins.right - width + offsetX;
       case 'left':
       default:
         if (typeof alignment === 'number') {
-          return this.context.margins.left + alignment;
+          return this.context.margins.left + alignment + offsetX;
         }
-        return this.context.margins.left;
+        return this.context.margins.left + offsetX;
     }
   }
 

--- a/test/parser/chord_sheet_parser.test.ts
+++ b/test/parser/chord_sheet_parser.test.ts
@@ -11,7 +11,7 @@ Whisper words of wisdom, let it be`;
 
 describe('ChordSheetParser', () => {
   it('parses a regular chord sheet correctly', () => {
-    const parser = new ChordSheetParser();
+    const parser = new ChordSheetParser({}, false);
     const song = parser.parse(defaultChordSheet);
     const { lines } = song;
 
@@ -44,7 +44,7 @@ describe('ChordSheetParser', () => {
       Am               Bb             F  C
       Whisper words of wisdom, let it be`;
 
-    const parser = new ChordSheetParser();
+    const parser = new ChordSheetParser({}, false);
     const song = parser.parse(chordSheetWithParagraphs);
     const { paragraphs } = song;
 
@@ -75,7 +75,7 @@ describe('ChordSheetParser', () => {
 
   describe('with option preserveWhitespace:true', () => {
     it('parses a regular chord sheet correctly', () => {
-      const parser = new ChordSheetParser({ preserveWhitespace: true });
+      const parser = new ChordSheetParser({ preserveWhitespace: true }, false);
       const song = parser.parse(defaultChordSheet);
       const { lines } = song;
 
@@ -101,7 +101,7 @@ describe('ChordSheetParser', () => {
 
   describe('with option preserveWhitespace:false', () => {
     it('parses a regular chord sheet correctly', () => {
-      const parser = new ChordSheetParser({ preserveWhitespace: false });
+      const parser = new ChordSheetParser({ preserveWhitespace: false }, false);
       const song = parser.parse(defaultChordSheet);
       const { lines } = song;
 
@@ -128,7 +128,7 @@ describe('ChordSheetParser', () => {
   it('support CR line endings', () => {
     const chordSheet = '       Am         C/G\rLet it be, let it be,\r       F          C\rlet it be, let it be';
 
-    const parser = new ChordSheetParser();
+    const parser = new ChordSheetParser({}, false);
     const song = parser.parse(chordSheet);
     const { lines } = song;
     const [{ items: line0Items }, { items: line1Items }] = lines;
@@ -146,7 +146,7 @@ describe('ChordSheetParser', () => {
   it('support LF line endings', () => {
     const chordSheet = '       Am         C/G\nLet it be, let it be,\n       F          C\nlet it be, let it be';
 
-    const parser = new ChordSheetParser();
+    const parser = new ChordSheetParser({}, false);
     const song = parser.parse(chordSheet);
     const { lines } = song;
     const [{ items: line0Items }, { items: line1Items }] = lines;
@@ -164,7 +164,7 @@ describe('ChordSheetParser', () => {
   it('support CRLF line endings', () => {
     const chordSheet = '       Am         C/G\r\nLet it be, let it be,\r\n       F          C\r\nlet it be, let it be';
 
-    const parser = new ChordSheetParser();
+    const parser = new ChordSheetParser({}, false);
     const song = parser.parse(chordSheet);
     const { lines } = song;
     const [{ items: line0Items }, { items: line1Items }] = lines;

--- a/test/rendering/js_pdf_renderer.test.ts
+++ b/test/rendering/js_pdf_renderer.test.ts
@@ -94,28 +94,28 @@ function createBaseConfig(): PDFFormatterConfiguration {
   return deepMerge(clone, {
     fonts: {
       text: {
-        name: 'TestText', style: 'normal', size: 12, color: '#111111',
+        name: 'NimbusSansL-Reg', style: 'normal', size: 12, color: '#111111',
       },
       chord: {
-        name: 'TestChord', style: 'bold', size: 10, color: '#222222',
+        name: 'NimbusSansL-Bol', style: 'bold', size: 10, color: '#222222',
       },
       sectionLabel: {
-        name: 'TestSection', style: 'bold', size: 11, color: '#333333', underline: true,
+        name: 'NimbusSansL-Bol', style: 'bold', size: 11, color: '#333333', underline: true,
       },
       comment: {
-        name: 'TestComment', style: 'italic', size: 10, color: '#444444',
+        name: 'NimbusSansL-RegIta', style: 'italic', size: 10, color: '#444444',
       },
       metadata: {
-        name: 'TestMeta', style: 'normal', size: 9, color: '#555555',
+        name: 'NimbusSansL-Reg', style: 'normal', size: 9, color: '#555555',
       },
       subtitle: {
-        name: 'TestSubtitle', style: 'normal', size: 9, color: '#666666',
+        name: 'NimbusSansL-Reg', style: 'normal', size: 9, color: '#666666',
       },
       title: {
-        name: 'TestTitle', style: 'bold', size: 18, color: '#777777',
+        name: 'NimbusSansL-Bol', style: 'bold', size: 18, color: '#777777',
       },
       annotation: {
-        name: 'TestAnnotation', style: 'normal', size: 8, color: '#888888',
+        name: 'NimbusSansL-Reg', style: 'normal', size: 8, color: '#888888',
       },
     },
     layout: {
@@ -158,13 +158,13 @@ function createBaseConfig(): PDFFormatterConfiguration {
         enabled: true,
         fonts: {
           title: {
-            name: 'DiagramTitle', style: 'bold', size: 8, color: '#000000',
+            name: 'NimbusSansL-Bol', style: 'bold', size: 8, color: '#000000',
           },
           fingerings: {
-            name: 'DiagramFinger', style: 'bold', size: 6, color: '#000000',
+            name: 'NimbusSansL-Bol', style: 'bold', size: 6, color: '#000000',
           },
           baseFret: {
-            name: 'DiagramBase', style: 'bold', size: 6, color: '#000000',
+            name: 'NimbusSansL-Bol', style: 'bold', size: 6, color: '#000000',
           },
         },
         overrides: {
@@ -476,7 +476,7 @@ describe('JsPdfRenderer', () => {
                 type: 'text',
                 value: 'Header',
                 style: {
-                  name: 'Test', style: 'normal', size: 12, color: '#000',
+                  name: 'NimbusSansL-Reg', style: 'normal', size: 12, color: '#000',
                 },
                 position: { x: 'left', y: 5 },
               },
@@ -490,7 +490,7 @@ describe('JsPdfRenderer', () => {
                 type: 'text',
                 value: 'Footer',
                 style: {
-                  name: 'Test', style: 'normal', size: 10, color: '#000',
+                  name: 'NimbusSansL-Reg', style: 'normal', size: 10, color: '#000',
                 },
                 position: { x: 'left', y: 5 },
               },
@@ -529,7 +529,7 @@ describe('JsPdfRenderer', () => {
                 type: 'text',
                 value: 'Capo Info',
                 style: {
-                  name: 'TestTitle',
+                  name: 'NimbusSansL-Bol',
                   style: 'bold',
                   size: 16,
                   color: '#777777',

--- a/test/rendering/positioned_html_renderer.test.ts
+++ b/test/rendering/positioned_html_renderer.test.ts
@@ -606,15 +606,145 @@ describe('PositionedHtmlRenderer', () => {
       });
 
       doc.pages = [new MockElement('div'), new MockElement('div')];
+      doc.totalPages = 2;
 
       (renderer as any).renderHeadersAndFooters();
 
       expect(doc.eachPage).toHaveBeenCalledTimes(2);
       expect(doc.addElement).toHaveBeenCalled();
-      expect(conditionCalls[0].metadata.page).toBe('1');
-      expect(conditionCalls[0].metadata.pages).toBe(doc.totalPages.toString());
+      expect(conditionCalls[0].metadata.page).toBe(1);
+      expect(conditionCalls[1].metadata.page).toBe(2);
+      expect(conditionCalls[0].metadata.pages).toBe(doc.totalPages);
       expect(conditionCalls[0].metadata.capoKey).toBeDefined();
       expect(song.metadata.getSingle('key')).toBe('C');
+    });
+
+    it('applies layout font styles to rendered header text', () => {
+      const { renderer, doc } = createRenderer({
+        layout: {
+          ...measuredHtmlSpecificDefaults.layout,
+          header: {
+            height: 45,
+            content: [
+              {
+                type: 'text',
+                value: 'Styled header',
+                style: {
+                  name: 'Arial',
+                  style: 'bold',
+                  size: 14,
+                  color: 120,
+                  lineHeight: 1.4,
+                },
+                position: {
+                  x: 'left',
+                  y: 10,
+                },
+              },
+            ],
+          },
+          footer: {
+            height: 0,
+            content: [],
+          },
+        } as any,
+      });
+
+      (renderer as any).renderHeadersAndFooters();
+
+      const headerElement = doc.addedElements[0].element;
+      expect(headerElement.textContent).toBe('Styled header');
+      expect(headerElement.style.fontFamily).toBe('Arial');
+      expect(headerElement.style.fontSize).toBe('14px');
+      expect(headerElement.style.fontWeight).toBe('bold');
+      expect(headerElement.style.color).toBe('rgb(120, 120, 120)');
+      expect(headerElement.style.lineHeight).toBe('1.4');
+    });
+
+    it('applies configured line styles to rendered layout lines', () => {
+      const { renderer, doc } = createRenderer({
+        layout: {
+          ...measuredHtmlSpecificDefaults.layout,
+          header: {
+            height: 20,
+            content: [
+              {
+                type: 'line',
+                style: { width: 3, color: '#a1312d', dash: [4, 2] },
+                position: {
+                  x: 0,
+                  y: 8,
+                  width: 'auto',
+                },
+              },
+            ],
+          },
+          footer: {
+            height: 0,
+            content: [],
+          },
+        } as any,
+      });
+
+      (renderer as any).renderHeadersAndFooters();
+
+      const lineElement = doc.addedElements[0].element;
+      expect(lineElement.className).toBe('test-line');
+      expect(lineElement.style.borderBottomWidth).toBe('3px');
+      expect(lineElement.style.borderBottomStyle).toBe('dashed');
+      expect(lineElement.style.borderBottomColor).toBe('#a1312d');
+    });
+
+    it('adds custom text classes, element styles, and right offsets for header badges', () => {
+      const { renderer, doc } = createRenderer({
+        layout: {
+          ...measuredHtmlSpecificDefaults.layout,
+          header: {
+            height: 45,
+            content: [
+              {
+                type: 'text',
+                value: 'A',
+                cssClass: 'measured-html-key-badge',
+                elementStyle: {
+                  width: '28px',
+                  height: '28px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  borderRadius: '999px',
+                  backgroundColor: '#a1312d',
+                },
+                style: {
+                  name: 'Arial',
+                  style: 'bold',
+                  size: 12,
+                  color: '#ffffff',
+                },
+                position: {
+                  x: 'right',
+                  y: 4,
+                  width: 28,
+                  offsetX: -12,
+                  clip: true,
+                },
+              },
+            ],
+          },
+          footer: {
+            height: 0,
+            content: [],
+          },
+        } as any,
+      });
+
+      (renderer as any).renderHeadersAndFooters();
+
+      const badgeElement = doc.addedElements[0].element;
+      expect(badgeElement.classList.contains('measured-html-key-badge')).toBe(true);
+      expect(badgeElement.style.backgroundColor).toBe('#a1312d');
+      expect(badgeElement.style.borderRadius).toBe('999px');
+      expect(doc.addedElements[0].x).toBe(515);
     });
   });
 


### PR DESCRIPTION
Adds the ability to have header/footer content from the configuration in the measured html formatters

<img width="1602" height="469" alt="image" src="https://github.com/user-attachments/assets/eff9e0ad-55ff-47df-9f6b-22c6b8a470ba" />

In the process of creating this I couldn't get past CI without doing some work to move the useModifier() to be useAccidental((), yarn test kept failing on deprecated errors. 