### PR TITLE
Fix parsing of mmaj7 chords

### DIFF
--- a/src/normalize_mappings/suffix-mapping.txt
+++ b/src/normalize_mappings/suffix-mapping.txt
@@ -90,7 +90,7 @@ m, mi, min, minor, -
 m(11), m(add11)
 m(4), m(add4)
 m(9), m(add9)
-m(ma7), m(M7), mM7, mi(maj7), min(maj7), m(maj7), m(+7), m+7
+m(ma7), m(M7), mM7, mi(maj7), min(maj7), m(maj7), m(+7), m+7, mmaj7
 m(ma9), m(M9), mM9, mi(maj9), min(maj9), m(maj9), m(+9), m+9
 m(no5)
 m11, mi11, min11, -11

--- a/test/parser/chords_over_words_parser.test.ts
+++ b/test/parser/chords_over_words_parser.test.ts
@@ -703,6 +703,17 @@ describe('ChordsOverWordsParser', () => {
     expect(song.getChords()).toEqual(['Eb', 'Dbmaj13']);
   });
 
+  it('parses mmaj7 chords correctly', () => {
+    const chordOverWords = heredoc`
+      Eb      Dbmmaj7
+      A line`;
+
+    const parser = new ChordsOverWordsParser();
+    const song = parser.parse(chordOverWords);
+
+    expect(song.getChords()).toEqual(['Eb', 'Dbmmaj7']);
+  });
+
   describe('N.C. (no chord) notation', () => {
     it('parses N.C. mixed with chords paired with lyrics', () => {
       const chordOverWords = heredoc`


### PR DESCRIPTION
# Summary

- Add mmaj7 as an alias for the m(ma7) suffix in the suffix mapping
- Chords like Dbmmaj7 are now correctly parsed 

Fixes [#2078](https://github.com/martijnversluis/ChordSheetJS/issues/2078)