### PR TITLE
Replace deprecated modifier API calls with accidental in tests

### DIFF
--- a/test/chord/parse_suffixes.test.ts
+++ b/test/chord/parse_suffixes.test.ts
@@ -8,14 +8,14 @@ const baseKey = Key.parse('A')!;
 
 for (let i = 0; i < 12; i += 1) {
   keys.add(baseKey.transpose(i).toString());
-  keys.add(baseKey.transpose(i).useModifier('#').toString());
-  keys.add(baseKey.transpose(i).useModifier('b').toString());
+  keys.add(baseKey.transpose(i).useAccidental('#').toString());
+  keys.add(baseKey.transpose(i).useAccidental('b').toString());
   keys.add(baseKey.transpose(i).toNumeralString(baseKey));
-  keys.add(baseKey.transpose(i).useModifier('#').toNumeralString(baseKey));
-  keys.add(baseKey.transpose(i).useModifier('b').toNumeralString(baseKey));
+  keys.add(baseKey.transpose(i).useAccidental('#').toNumeralString(baseKey));
+  keys.add(baseKey.transpose(i).useAccidental('b').toNumeralString(baseKey));
   keys.add(baseKey.transpose(i).toNumericString(baseKey));
-  keys.add(baseKey.transpose(i).useModifier('#').toNumericString(baseKey));
-  keys.add(baseKey.transpose(i).useModifier('b').toNumericString(baseKey));
+  keys.add(baseKey.transpose(i).useAccidental('#').toNumericString(baseKey));
+  keys.add(baseKey.transpose(i).useAccidental('b').toNumericString(baseKey));
 }
 
 describe('Chord', () => {

--- a/test/chord_sheet/song.test.ts
+++ b/test/chord_sheet/song.test.ts
@@ -675,7 +675,7 @@ describe('Song', () => {
         ],
       ]);
 
-      const modifiedSong = song.useModifier('b');
+      const modifiedSong = song.useAccidental('b');
 
       expect((modifiedSong.paragraphs[0].lines[0].items[0] as ChordLyricsPair).chords).toEqual('Ab');
       expect((modifiedSong.paragraphs[0].lines[0].items[1] as ChordLyricsPair).chords).toEqual('Gb');
@@ -686,7 +686,7 @@ describe('Song', () => {
         [tag('key', 'F#')],
       ]);
 
-      const modifiedSong = song.useModifier('b');
+      const modifiedSong = song.useAccidental('b');
 
       expect(modifiedSong.key).toEqual('Gb');
     });

--- a/test/chord_solfege/use_modifier.test.ts
+++ b/test/chord_solfege/use_modifier.test.ts
@@ -5,19 +5,19 @@ describe('Chord', () => {
     describe('useModifier', () => {
       describe('for a chord without modifier', () => {
         it('does not change the chord', () => {
-          expect(Chord.parse('Fa/Fa')?.useModifier('b').toString()).toEqual('Fa/Fa');
+          expect(Chord.parse('Fa/Fa')?.useAccidental('b').toString()).toEqual('Fa/Fa');
         });
       });
 
       describe('for #', () => {
         it('changes to b', () => {
-          expect(Chord.parse('Sol#/Sol#')?.useModifier('b').toString()).toEqual('Lab/Lab');
+          expect(Chord.parse('Sol#/Sol#')?.useAccidental('b').toString()).toEqual('Lab/Lab');
         });
       });
 
       describe('for b', () => {
         it('changes to #', () => {
-          expect(Chord.parse('Solb/Solb')?.useModifier('#').toString()).toEqual('Fa#/Fa#');
+          expect(Chord.parse('Solb/Solb')?.useAccidental('#').toString()).toEqual('Fa#/Fa#');
         });
       });
     });

--- a/test/chord_symbol/parse.test.ts
+++ b/test/chord_symbol/parse.test.ts
@@ -497,7 +497,7 @@ describe('Chord', () => {
           expect(chord).toMatchObject({
             root: {
               grade: 0,
-              modifier: null,
+              accidental: null,
               type: SYMBOL,
               minor: false,
               referenceKeyGrade: 11,

--- a/test/chord_symbol/use_modifier.test.ts
+++ b/test/chord_symbol/use_modifier.test.ts
@@ -5,19 +5,19 @@ describe('Chord', () => {
     describe('useModifier', () => {
       describe('for a chord without modifier', () => {
         it('does not change the chord', () => {
-          expect(Chord.parse('F/F')?.useModifier('b').toString()).toEqual('F/F');
+          expect(Chord.parse('F/F')?.useAccidental('b').toString()).toEqual('F/F');
         });
       });
 
       describe('for #', () => {
         it('changes to b', () => {
-          expect(Chord.parse('G#/G#')?.useModifier('b').toString()).toEqual('Ab/Ab');
+          expect(Chord.parse('G#/G#')?.useAccidental('b').toString()).toEqual('Ab/Ab');
         });
       });
 
       describe('for b', () => {
         it('changes to #', () => {
-          expect(Chord.parse('Gb/Gb')?.useModifier('#').toString()).toEqual('F#/F#');
+          expect(Chord.parse('Gb/Gb')?.useAccidental('#').toString()).toEqual('F#/F#');
         });
       });
     });

--- a/test/integration/transpose_song.test.ts
+++ b/test/integration/transpose_song.test.ts
@@ -3,7 +3,7 @@ import { heredoc } from '../util/utilities';
 import {
   ChordProFormatter,
   ChordProParser,
-  ChordSheetParser,
+  ChordsOverWordsParser,
   TextFormatter,
 } from '../../src';
 
@@ -113,7 +113,7 @@ describe('transposing a song', () => {
              Bm         D/A        G          D
       Let it be, let it be, let it be, let it be`;
 
-    const song = new ChordSheetParser().parse(chordpro);
+    const song = new ChordsOverWordsParser().parse(chordpro);
     const updatedSong = song.transpose(2);
 
     expect(new TextFormatter().format(updatedSong)).toEqual(changedSheet);

--- a/test/integration/use_modifier.test.ts
+++ b/test/integration/use_modifier.test.ts
@@ -11,7 +11,7 @@ describe('changing the song modifiers', () => {
     `;
 
     const song = new ChordProParser().parse(chordpro);
-    const updatedSong = song.useModifier('#');
+    const updatedSong = song.useAccidental('#');
 
     expect(new TextFormatter().format(updatedSong)).toEqual(changedSheet);
   });
@@ -25,7 +25,7 @@ describe('changing the song modifiers', () => {
     `;
 
     const song = new ChordProParser().parse(chordpro);
-    const updatedSong = song.useModifier('b');
+    const updatedSong = song.useAccidental('b');
 
     expect(new TextFormatter().format(updatedSong)).toEqual(changedSheet);
   });

--- a/test/key/clone.test.ts
+++ b/test/key/clone.test.ts
@@ -11,8 +11,8 @@ describe('Key', () => {
       const clone = key.clone();
 
       expect(clone.grade).toEqual(5);
-      expect(clone.modifier).toEqual(SHARP);
-      expect(clone.preferredModifier).toEqual(FLAT);
+      expect(clone.accidental).toEqual(SHARP);
+      expect(clone.preferredAccidental).toEqual(FLAT);
       expect(clone.minor).toEqual(true);
       expect(clone.type).toEqual(NUMERAL);
       expect(clone.referenceKeyGrade).toEqual(4);

--- a/test/key/use_modifier.test.ts
+++ b/test/key/use_modifier.test.ts
@@ -9,7 +9,7 @@ describe('Key', () => {
         it('does not change the key', () => {
           const key = buildKey('F', SYMBOL);
 
-          const switchedKey = key.useModifier('b');
+          const switchedKey = key.useAccidental('b');
 
           expect(switchedKey.toString()).toEqual('F');
         });
@@ -19,7 +19,7 @@ describe('Key', () => {
         it('changes to b', () => {
           const key = buildKey('G', SYMBOL, '#');
 
-          const switchedKey = key.useModifier('b');
+          const switchedKey = key.useAccidental('b');
           expect(switchedKey.toString()).toEqual('Ab');
         });
       });
@@ -28,7 +28,7 @@ describe('Key', () => {
         it('changes to #', () => {
           const key = buildKey('G', SYMBOL, 'b');
 
-          const switchedKey = key.useModifier('#');
+          const switchedKey = key.useAccidental('#');
           expect(switchedKey.toString()).toEqual('F#');
         });
       });
@@ -39,7 +39,7 @@ describe('Key', () => {
         it('does not change the key', () => {
           const key = buildKey('Fa', SOLFEGE);
 
-          const switchedKey = key.useModifier('b');
+          const switchedKey = key.useAccidental('b');
 
           expect(switchedKey.toString()).toEqual('Fa');
         });
@@ -49,7 +49,7 @@ describe('Key', () => {
         it('changes to b', () => {
           const key = buildKey('Sol', SOLFEGE, '#');
 
-          const switchedKey = key.useModifier('b');
+          const switchedKey = key.useAccidental('b');
           expect(switchedKey.toString()).toEqual('Lab');
         });
       });
@@ -58,7 +58,7 @@ describe('Key', () => {
         it('changes to #', () => {
           const key = buildKey('Sol', SOLFEGE, 'b');
 
-          const switchedKey = key.useModifier('#');
+          const switchedKey = key.useAccidental('#');
           expect(switchedKey.toString()).toEqual('Fa#');
         });
       });
@@ -69,7 +69,7 @@ describe('Key', () => {
         it('does not change the key', () => {
           const key = buildKey(4, NUMERIC);
 
-          const switchedKey = key.useModifier('b');
+          const switchedKey = key.useAccidental('b');
 
           expect(switchedKey.toString()).toEqual('4');
         });
@@ -79,7 +79,7 @@ describe('Key', () => {
         it('changes to b', () => {
           const key = buildKey(5, NUMERIC, '#');
 
-          const switchedKey = key.useModifier('b');
+          const switchedKey = key.useAccidental('b');
           expect(switchedKey.toString()).toEqual('b6');
         });
       });
@@ -88,7 +88,7 @@ describe('Key', () => {
         it('changes to #', () => {
           const key = buildKey(5, NUMERIC, 'b');
 
-          const switchedKey = key.useModifier('#');
+          const switchedKey = key.useAccidental('#');
           expect(switchedKey.toString()).toEqual('#4');
         });
       });
@@ -99,7 +99,7 @@ describe('Key', () => {
         it('does not change the key', () => {
           const key = buildKey('IV', NUMERAL);
 
-          const switchedKey = key.useModifier('b');
+          const switchedKey = key.useAccidental('b');
 
           expect(switchedKey.toString()).toEqual('IV');
         });
@@ -109,7 +109,7 @@ describe('Key', () => {
         it('changes to b', () => {
           const key = buildKey('V', NUMERAL, '#');
 
-          const switchedKey = key.useModifier('b');
+          const switchedKey = key.useAccidental('b');
 
           expect(switchedKey.toString()).toEqual('bVI');
         });
@@ -119,7 +119,7 @@ describe('Key', () => {
         it('changes to #', () => {
           const key = buildKey('V', NUMERAL, 'b');
 
-          const switchedKey = key.useModifier('#');
+          const switchedKey = key.useAccidental('#');
 
           expect(switchedKey.toString()).toEqual('#IV');
         });

--- a/test/numeral_chord/use_modifier.test.ts
+++ b/test/numeral_chord/use_modifier.test.ts
@@ -4,19 +4,19 @@ describe('Chord', () => {
   describe('useModifier', () => {
     describe('for a chord without modifier', () => {
       it('does not change the chord', () => {
-        expect(Chord.parse('IV/IV')?.useModifier('b').toString()).toEqual('IV/IV');
+        expect(Chord.parse('IV/IV')?.useAccidental('b').toString()).toEqual('IV/IV');
       });
     });
 
     describe('for #', () => {
       it('changes to b', () => {
-        expect(Chord.parse('#V/#V')?.useModifier('b').toString()).toEqual('bVI/bVI');
+        expect(Chord.parse('#V/#V')?.useAccidental('b').toString()).toEqual('bVI/bVI');
       });
     });
 
     describe('for b', () => {
       it('changes to #', () => {
-        expect(Chord.parse('bV/bV')?.useModifier('#').toString()).toEqual('#IV/#IV');
+        expect(Chord.parse('bV/bV')?.useAccidental('#').toString()).toEqual('#IV/#IV');
       });
     });
   });

--- a/test/numeric_chord/use_modifier.test.ts
+++ b/test/numeric_chord/use_modifier.test.ts
@@ -5,19 +5,19 @@ describe('Chord', () => {
     describe('useModifier', () => {
       describe('for a chord without modifier', () => {
         it('does not change the chord', () => {
-          expect(Chord.parse('4/4')?.useModifier('b').toString()).toEqual('4/4');
+          expect(Chord.parse('4/4')?.useAccidental('b').toString()).toEqual('4/4');
         });
       });
 
       describe('for #', () => {
         it('changes to b', () => {
-          expect(Chord.parse('#5/#5')?.useModifier('b').toString()).toEqual('b6/b6');
+          expect(Chord.parse('#5/#5')?.useAccidental('b').toString()).toEqual('b6/b6');
         });
       });
 
       describe('for b', () => {
         it('changes to #', () => {
-          expect(Chord.parse('b5/b5')?.useModifier('#').toString()).toEqual('#4/#4');
+          expect(Chord.parse('b5/b5')?.useAccidental('#').toString()).toEqual('#4/#4');
         });
       });
     });


### PR DESCRIPTION
## Summary
- Replace all `useModifier()` calls with `useAccidental()` in tests
- Replace `modifier`/`preferredModifier` property access with `accidental`/`preferredAccidental`
- Replace deprecated `ChordSheetParser` with `ChordsOverWordsParser` in transpose_song test

Extracted from #2059.