### PR TITLE
fix: apply useUnicodeModifiers to chord suffix

### DIFF
--- a/src/chord.ts
+++ b/src/chord.ts
@@ -293,8 +293,12 @@ class Chord implements ChordProperties {
    */
   toString({ useUnicodeModifier = false } = {}): string {
     let chordString = '';
-    const suffix = this.suffix || '';
+    let suffix = this.suffix || '';
     const showMinor = suffix[0] !== 'm';
+
+    if (useUnicodeModifier) {
+      suffix = suffix.replace(/#(?=\d)/g, '\u266f').replace(/b(?=\d)/g, '\u266d');
+    }
 
     if (this.root) chordString = this.root.toString({ showMinor, useUnicodeModifier }) + suffix;
     if (this.bass) chordString = `${chordString}/${this.bass.toString({ useUnicodeModifier })}`;

--- a/test/chord_symbol/to_string.test.ts
+++ b/test/chord_symbol/to_string.test.ts
@@ -88,6 +88,38 @@ describe('Chord', () => {
 
           expect(chord.toString({ useUnicodeModifier: true })).toEqual('F♯');
         });
+
+        it('replaces flat modifiers in the suffix', () => {
+          const chord = new Chord({
+            base: 'B',
+            accidental: 'b',
+            suffix: '7b9',
+            chordType: SYMBOL,
+          });
+
+          expect(chord.toString({ useUnicodeModifier: true })).toEqual('B♭7♭9');
+        });
+
+        it('replaces sharp modifiers in the suffix', () => {
+          const chord = new Chord({
+            base: 'C',
+            suffix: '7#11',
+            chordType: SYMBOL,
+          });
+
+          expect(chord.toString({ useUnicodeModifier: true })).toEqual('C7♯11');
+        });
+
+        it('replaces multiple modifiers in the suffix', () => {
+          const chord = new Chord({
+            base: 'B',
+            accidental: 'b',
+            suffix: '7b9#11',
+            chordType: SYMBOL,
+          });
+
+          expect(chord.toString({ useUnicodeModifier: true })).toEqual('B♭7♭9♯11');
+        });
       });
     });
   });


### PR DESCRIPTION
## Summary

- Fixes #2106: `useUnicodeModifiers` now also converts `#` and `b` modifiers in chord suffixes (e.g. `Bb7b9` → `B♭7♭9`)
- Previously only root and bass note accidentals were converted