### PR TITLE
feat: add getKeys getCapos & mergeConfigs to the exports

### DIFF
--- a/src/formatter/configuration/index.ts
+++ b/src/formatter/configuration/index.ts
@@ -83,6 +83,8 @@ import {
 
 import { mergeConfigs } from '../../utilities';
 
+export { mergeConfigs } from '../../utilities';
+
 type Configuration = BaseFormatterConfiguration;
 
 /**

--- a/src/formatter_configuration.ts
+++ b/src/formatter_configuration.ts
@@ -1,0 +1,27 @@
+import { mergeConfigs } from './utilities';
+
+import {
+  configure,
+  getDefaultConfig,
+  getHTMLDefaultConfig,
+  getMeasuredHtmlDefaultConfig,
+  getPDFDefaultConfig,
+} from './formatter/configuration';
+
+export {
+  configure,
+  getDefaultConfig,
+  getHTMLDefaultConfig,
+  getMeasuredHtmlDefaultConfig,
+  getPDFDefaultConfig,
+  mergeConfigs,
+};
+
+export default {
+  configure,
+  getDefaultConfig,
+  getHTMLDefaultConfig,
+  getMeasuredHtmlDefaultConfig,
+  getPDFDefaultConfig,
+  mergeConfigs,
+};

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -63,10 +63,13 @@ export function renderChord(
 }
 
 /**
- * Returns applicable capos for the provided key
- * @param {Key|string} key The key to get capos for
- * @returns {Object.<string, string>} The available capos, where the keys are capo numbers and the
- * values are the effective key for that capo.
+ * Returns recommended capo positions for the provided key.
+ *
+ * The returned object maps capo fret numbers to the effective key when using
+ * that capo position.
+ *
+ * @param {Key|string} key The key to get capo positions for.
+ * @returns {Object.<string, string>} The available capo positions, keyed by capo fret number.
  */
 export function getCapos(key: Key | string): Record<string, string> {
   const keyObj = Key.wrapOrFail(key);
@@ -75,9 +78,13 @@ export function getCapos(key: Key | string): Record<string, string> {
 }
 
 /**
- * Returns applicable keys to transpose to from the provided key
- * @param {Key|string} key The key to get keys for
- * @returns {Array<string>} The available keys
+ * Returns available transpose target keys for the provided key.
+ *
+ * The result uses symbol or solfege notation to match the input key, and major
+ * or minor keys depending on the input mode.
+ *
+ * @param {Key|string} key The key to get transpose targets for.
+ * @returns {Array<string>} The available target keys.
  */
 export function getKeys(key: Key | string): string[] {
   const keyObj = Key.wrapOrFail(key);

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,9 @@ import TextFormatter from './formatter/text_formatter';
 import UltimateGuitarParser from './parser/ultimate_guitar_parser';
 import version from './version';
 
+import formatterConfiguration from './formatter_configuration';
+import keyHelpers from './key_helpers';
+
 import {
   each,
   evaluate,
@@ -92,6 +95,8 @@ export { default as TextFormatter } from './formatter/text_formatter';
 export { default as UltimateGuitarParser } from './parser/ultimate_guitar_parser';
 export { default as templateHelpers } from './template_helpers';
 export { default as version } from './version';
+export { default as formatterConfiguration } from './formatter_configuration';
+export { default as keyHelpers } from './key_helpers';
 
 export { IMAGE } from './chord_sheet/tags';
 export { defaultPangoRenderer, pangoToHtml, stripPangoMarkup } from './pango/pango_helpers';
@@ -160,6 +165,8 @@ export default {
   CanvasMeasurer,
   JsPdfMeasurer,
   LayoutEngine,
+  formatterConfiguration,
+  keyHelpers,
   version,
   templateHelpers: {
     isEvaluatable,

--- a/src/key_helpers.ts
+++ b/src/key_helpers.ts
@@ -1,0 +1,8 @@
+import { getCapos, getKeys } from './helpers';
+
+export { getCapos, getKeys };
+
+export default {
+  getCapos,
+  getKeys,
+};

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -48,6 +48,8 @@ import ChordSheetJS, {
   TextFormatter,
   UltimateGuitarParser,
   VERSE,
+  formatterConfiguration,
+  keyHelpers,
   pangoToHtml,
   stripPangoMarkup,
   templateHelpers,
@@ -110,6 +112,8 @@ describe('exports', () => {
     expect(SYMBOL).toBeDefined();
     expect(TAB).toBeDefined();
     expect(VERSE).toBeDefined();
+    expect(formatterConfiguration).toBeDefined();
+    expect(keyHelpers).toBeDefined();
     expect(pangoToHtml).toBeDefined();
     expect(stripPangoMarkup).toBeDefined();
     expect(templateHelpers).toBeDefined();
@@ -162,7 +166,28 @@ describe('exports', () => {
     expect(ChordSheetJS.NONE).toBeDefined();
     expect(ChordSheetJS.TAB).toBeDefined();
     expect(ChordSheetJS.VERSE).toBeDefined();
+    expect(ChordSheetJS.formatterConfiguration).toBeDefined();
+    expect(ChordSheetJS.keyHelpers).toBeDefined();
     expect(ChordSheetJS.version).toEqual(packageJSON.version);
+  });
+
+  it('supplies public key helper behavior from the package entrypoint', () => {
+    expect(keyHelpers.getCapos('Bb')).toEqual({
+      1: 'A', 3: 'G', 6: 'E', 8: 'D', 10: 'C',
+    });
+
+    expect(keyHelpers.getKeys('Dm')).toEqual([
+      'F#m', 'Gm', 'G#m', 'Am', 'Bbm', 'Bm', 'Cm', 'C#m', 'Dm', 'D#m', 'Ebm', 'Em', 'Fm',
+    ]);
+  });
+
+  it('supplies public formatter configuration behavior from the package entrypoint', () => {
+    expect(formatterConfiguration.getPDFDefaultConfig()).toBeDefined();
+
+    expect(formatterConfiguration.mergeConfigs(
+      { layout: { columns: 1, content: ['title'] } },
+      { layout: { content: ['subtitle'] } },
+    )).toEqual({ layout: { columns: 1, content: ['subtitle'] } });
   });
 
   it('supplies template helpers on the default export', () => {

--- a/test/get_capos.test.ts
+++ b/test/get_capos.test.ts
@@ -1,10 +1,9 @@
-import { Key } from '../src';
-import { getCapos } from '../src/helpers';
+import { Key, keyHelpers } from '../src';
 
 describe('getCapos', () => {
   it('returns the applicable capos for the provided key object', () => {
     const key = Key.parseOrFail('Eb');
-    const capos = getCapos(key);
+    const capos = keyHelpers.getCapos(key);
 
     expect(capos).toEqual({
       1: 'D', 3: 'C', 6: 'A', 8: 'G',
@@ -12,7 +11,7 @@ describe('getCapos', () => {
   });
 
   it('returns the applicable capos for the provided key string', () => {
-    const capos = getCapos('eb');
+    const capos = keyHelpers.getCapos('eb');
 
     expect(capos).toEqual({
       1: 'D', 3: 'C', 6: 'A', 8: 'G',

--- a/test/get_keys.test.ts
+++ b/test/get_keys.test.ts
@@ -1,21 +1,21 @@
 /* eslint max-len: 0 */
 
-import { getKeys } from '../src/helpers';
+import { keyHelpers } from '../src';
 
 describe('getKeys', () => {
   it('returns the applicable keys for a major key symbol', () => {
-    expect(getKeys('A')).toEqual(['A', 'Bb', 'B', 'C', 'C#', 'Db', 'D', 'Eb', 'E', 'F', 'F#', 'Gb', 'G', 'G#', 'Ab']);
+    expect(keyHelpers.getKeys('A')).toEqual(['A', 'Bb', 'B', 'C', 'C#', 'Db', 'D', 'Eb', 'E', 'F', 'F#', 'Gb', 'G', 'G#', 'Ab']);
   });
 
   it('returns the applicable keys for a minor key symbol', () => {
-    expect(getKeys('Dm')).toEqual(['F#m', 'Gm', 'G#m', 'Am', 'Bbm', 'Bm', 'Cm', 'C#m', 'Dm', 'D#m', 'Ebm', 'Em', 'Fm']);
+    expect(keyHelpers.getKeys('Dm')).toEqual(['F#m', 'Gm', 'G#m', 'Am', 'Bbm', 'Bm', 'Cm', 'C#m', 'Dm', 'D#m', 'Ebm', 'Em', 'Fm']);
   });
 
   it('returns the applicable keys for a major key solfege', () => {
-    expect(getKeys('La')).toEqual(['La', 'Sib', 'Si', 'Do', 'Do#', 'Reb', 'Re', 'Mib', 'Mi', 'Fa', 'Fa#', 'Solb', 'Sol', 'Sol#', 'Lab']);
+    expect(keyHelpers.getKeys('La')).toEqual(['La', 'Sib', 'Si', 'Do', 'Do#', 'Reb', 'Re', 'Mib', 'Mi', 'Fa', 'Fa#', 'Solb', 'Sol', 'Sol#', 'Lab']);
   });
 
   it('returns the applicable keys for a minor key solfege', () => {
-    expect(getKeys('Rem')).toEqual(['Fa#m', 'Solm', 'Sol#m', 'Lam', 'Sibm', 'Sim', 'Dom', 'Do#m', 'Rem', 'Re#m', 'Mibm', 'Mim', 'Fam']);
+    expect(keyHelpers.getKeys('Rem')).toEqual(['Fa#m', 'Solm', 'Sol#m', 'Lam', 'Sibm', 'Sim', 'Dom', 'Do#m', 'Rem', 'Re#m', 'Mibm', 'Mim', 'Fam']);
   });
 });


### PR DESCRIPTION
Exposes the internal getKeys and getCapos helpers.
Exposes the mergeConfigs so we build a system that allows partial customization over a default config without having to persist the whole config for the person who wants to override. 