### PR TITLE
Fix Song.transpose() altering ABC section content

### DIFF
--- a/src/chord_sheet/ast_component.ts
+++ b/src/chord_sheet/ast_component.ts
@@ -1,6 +1,9 @@
+import type Line from './line';
 import TraceInfo from './trace_info';
 
 abstract class AstComponent {
+  parentLine: Line | null = null;
+
   line: number | null = null;
 
   column: number | null = null;

--- a/src/chord_sheet/chord_lyrics_pair.ts
+++ b/src/chord_sheet/chord_lyrics_pair.ts
@@ -1,5 +1,6 @@
 import Chord from '../chord';
 import Key from '../key';
+import type Line from './line';
 
 import { Accidental } from '../constants';
 import { deprecate } from '../utilities';
@@ -15,6 +16,8 @@ class ChordLyricsPair {
   annotation: string | null;
 
   isRhythmSymbol: boolean;
+
+  parentLine: Line | null = null;
 
   private _chordObj: Chord | null = null;
 

--- a/src/chord_sheet/comment.ts
+++ b/src/chord_sheet/comment.ts
@@ -1,8 +1,12 @@
+import type Line from './line';
+
 /**
  * Represents a comment. See https://www.chordpro.org/chordpro/chordpro-file-format-specification/#overview
  */
 class Comment {
   content: string;
+
+  parentLine: Line | null = null;
 
   constructor(content: string) {
     this.content = content;

--- a/src/chord_sheet/line.ts
+++ b/src/chord_sheet/line.ts
@@ -100,7 +100,9 @@ class Line {
     } else if (item instanceof Comment) {
       this.addComment(item);
     } else {
-      this.items.push(item);
+      const addedItem = item;
+      addedItem.parentLine = this;
+      this.items.push(addedItem);
     }
   }
 
@@ -198,6 +200,7 @@ class Line {
       this.currentChordLyricsPair = new ChordLyricsPair(chords || '', lyrics || '');
     }
 
+    this.currentChordLyricsPair.parentLine = this;
     this.items.push(this.currentChordLyricsPair);
     return this.currentChordLyricsPair;
   }
@@ -220,12 +223,14 @@ class Line {
 
   addTag(nameOrTag: Tag | string, value: string | null = null): Tag {
     const tag = (nameOrTag instanceof Tag) ? nameOrTag : new Tag(nameOrTag, value);
+    tag.parentLine = this;
     this.items.push(tag);
     return tag;
   }
 
   addComment(content: Comment | string): Comment {
     const comment = (content instanceof Comment) ? content : new Comment(content);
+    comment.parentLine = this;
     this.items.push(comment);
     return comment;
   }

--- a/src/chord_sheet/song.ts
+++ b/src/chord_sheet/song.ts
@@ -18,7 +18,9 @@ import SongMapper from './song_mapper';
 import Tag from './tag';
 
 import { Accidental } from '../constants';
+import { TEXTBLOCK } from '../constants';
 import { testSelector } from '../helpers';
+import { ABC, LILYPOND, SVG } from '../constants';
 import { CAPO, KEY } from './tags';
 import { configurationProviders, staticProviders } from './standard_metadata_providers';
 import { deprecate, filterObject } from '../utilities';
@@ -282,7 +284,7 @@ class Song extends MetadataAccessors {
       if (item instanceof ChordLyricsPair) {
         return Song.transposeChordLyricsPair(item, delta, transposedKey, normalizeChordSuffix, accidental);
       }
-      if (item instanceof Literal) {
+      if (item instanceof Literal && Song.isMusicalSection(item.parentLine)) {
         return Song.transposeLiteral(item, delta, transposedKey, normalizeChordSuffix, accidental);
       }
       return item;
@@ -417,11 +419,15 @@ class Song extends MetadataAccessors {
       if (item instanceof ChordLyricsPair) {
         return item.changeChord(func);
       }
-      if (item instanceof Literal) {
+      if (item instanceof Literal && Song.isMusicalSection(item.parentLine)) {
         return Song.mapChordsInLiteral(item, func);
       }
       return item;
     });
+  }
+
+  private static isMusicalSection(line: Line | null): boolean {
+    return line === null || ![ABC, LILYPOND, SVG, TEXTBLOCK].includes(line.type);
   }
 
   private static mapChordsInLiteral(item: Literal, func: (chord: Chord) => Chord): Literal {

--- a/test/integration/transpose_song.test.ts
+++ b/test/integration/transpose_song.test.ts
@@ -177,6 +177,68 @@ describe('transposing a song', () => {
     });
   });
 
+  describe('ABC section', () => {
+    it('does not alter ABC content when transposing', () => {
+      const chordpro = heredoc`
+        {key: C}
+        {start_of_abc}
+        X:1
+        M:4/4
+        L:1/4
+        K:C
+        ED | "Am"DCEG | "C/G"AGEE | "F"DCA,G, | "C"E2z2 |
+        {end_of_abc}
+        {start_of_chorus: Chorus}
+        Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be
+        {end_of_chorus}`;
+
+      const changedSheet = heredoc`
+        {key: Bb}
+        {start_of_abc}
+        X:1
+        M:4/4
+        L:1/4
+        K:C
+        ED | "Am"DCEG | "C/G"AGEE | "F"DCA,G, | "C"E2z2 |
+        {end_of_abc}
+        {start_of_chorus: Chorus}
+        Let it [Gm]be, let it [Bb/F]be, let it [Eb]be, let it [Bb]be
+        {end_of_chorus}`;
+
+      const song = new ChordProParser().parse(chordpro);
+      const updatedSong = song.transpose(-2);
+
+      expect(new ChordProFormatter().format(updatedSong)).toEqual(changedSheet);
+    });
+
+    it('does not alter ABC content with spaces in headers when transposing', () => {
+      const chordpro = heredoc`
+        {key: C}
+        {start_of_abc}
+        X: 1
+        M: 4/4
+        L: 1/4
+        K: C
+        ED | "Am"DCEG | "C/G"AGEE | "F"DCA,G, | "C"E2z2 |
+        {end_of_abc}`;
+
+      const changedSheet = heredoc`
+        {key: Bb}
+        {start_of_abc}
+        X: 1
+        M: 4/4
+        L: 1/4
+        K: C
+        ED | "Am"DCEG | "C/G"AGEE | "F"DCA,G, | "C"E2z2 |
+        {end_of_abc}`;
+
+      const song = new ChordProParser().parse(chordpro);
+      const updatedSong = song.transpose(-2);
+
+      expect(new ChordProFormatter().format(updatedSong)).toEqual(changedSheet);
+    });
+  });
+
   describe('key change', () => {
     const chordpro = heredoc`
       {key: B}


### PR DESCRIPTION
## Summary

Fixes #2105

- Add `parentLine` reference to all item types (`AstComponent`, `ChordLyricsPair`, `Comment`), set by `Line` when items are added
- Skip `Literal` items in non-musical sections (ABC, LilyPond, SVG, Textblock) during `transpose()` and `changeChords()`