### PR TITLE
Make PDF support optional to reduce bundle size

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,19 @@ const disp = formatter.format(song);
 
 > **Note:** `PdfFormatter` is currently in beta. Its API may change in future releases.
 
-Generates a PDF document directly. Requires configuration for page size and fonts.
+PDF support is available as a separate entry point to keep the main bundle small.
+To use it, install `jspdf` as a dependency:
+
+```bash
+npm install jspdf
+```
+
+Then import `PdfFormatter` from `chordsheetjs/pdf`:
 
 ```javascript
-const formatter = new ChordSheetJS.PdfFormatter();
+import { PdfFormatter } from 'chordsheetjs/pdf';
+
+const formatter = new PdfFormatter();
 const doc = formatter.format(song);
 doc.save('song.pdf');
 ```
@@ -163,7 +172,7 @@ and precise positioning of chords above lyrics. The layout engine uses measurers
 
 - `DomMeasurer` - Measures text using the browser's DOM
 - `CanvasMeasurer` - Measures text using HTML Canvas
-- `JsPdfMeasurer` - Measures text using jsPDF (for PDF output)
+- `JsPdfMeasurer` - Measures text using jsPDF (for PDF output, available from `chordsheetjs/pdf`)
 
 These are used internally by the measurement-based formatters but can also be accessed directly for advanced use cases.
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "globals": "^17.0.0",
     "jest": "^30.0.0",
     "js-levenshtein": "^1.1.6",
+    "jspdf": "^4.0.0",
     "parcel": "2.16.4",
     "peggy": "^5.0.2",
     "pegjs-backtrace": "^0.2.1",
@@ -76,8 +77,7 @@
     "tsx": "^4.10.5",
     "typedoc": "^0.28.0",
     "typescript": "^5.7.3",
-    "typescript-eslint": "^8.56.1",
-    "jspdf": "^4.0.0"
+    "typescript-eslint": "^8.56.1"
   },
   "scripts": {
     "build": "yarn unibuild",
@@ -99,7 +99,6 @@
     "test": "yarn unibuild lint && yarn unibuild test",
     "playground": "cd playground && parcel index.html --port=3300 --no-cache"
   },
-  "dependencies": {},
   "peerDependencies": {
     "jspdf": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,18 @@
   "main": "lib/index.js",
   "module": "lib/module.js",
   "types": "lib/main.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/main.d.ts",
+      "import": "./lib/module.js",
+      "require": "./lib/index.js"
+    },
+    "./pdf": {
+      "types": "./lib/pdf/pdf.d.ts",
+      "import": "./lib/pdf/module.js",
+      "require": "./lib/pdf/index.js"
+    }
+  },
   "files": [
     "/lib"
   ],
@@ -64,7 +76,8 @@
     "tsx": "^4.10.5",
     "typedoc": "^0.28.0",
     "typescript": "^5.7.3",
-    "typescript-eslint": "^8.56.1"
+    "typescript-eslint": "^8.56.1",
+    "jspdf": "^4.0.0"
   },
   "scripts": {
     "build": "yarn unibuild",
@@ -86,8 +99,14 @@
     "test": "yarn unibuild lint && yarn unibuild test",
     "playground": "cd playground && parcel index.html --port=3300 --no-cache"
   },
-  "dependencies": {
+  "dependencies": {},
+  "peerDependencies": {
     "jspdf": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "jspdf": {
+      "optional": true
+    }
   },
   "packageManager": "yarn@4.2.2"
 }

--- a/src/formatter/configuration/measurement_based_configuration.ts
+++ b/src/formatter/configuration/measurement_based_configuration.ts
@@ -1,4 +1,4 @@
-import { ImageCompression } from 'jspdf';
+import type { ImageCompression } from 'jspdf';
 
 import { ChordDiagramRenderingConfig } from '../../chord_diagram/chord_diagram';
 import Item from '../../chord_sheet/item';

--- a/src/formatter/pdf_formatter.ts
+++ b/src/formatter/pdf_formatter.ts
@@ -2,7 +2,7 @@ import { Blob } from 'buffer';
 import JsPDF from 'jspdf';
 
 import DocWrapper from './pdf_formatter/doc_wrapper';
-import { JsPdfMeasurer } from '../index';
+import { JsPdfMeasurer } from '../layout/measurement/js_pdf_measurer';
 import JsPdfRenderer from '../rendering/pdf/js_pdf_renderer';
 import MeasurementBasedFormatter from './measurement_based_formatter';
 import { PDFFormatterConfiguration } from './configuration';

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,6 @@ import Literal from './chord_sheet/chord_pro/literal';
 import MeasuredHtmlFormatter from './formatter/measured_html_formatter';
 import Metadata from './chord_sheet/metadata';
 import Paragraph from './chord_sheet/paragraph';
-import PdfFormatter from './formatter/pdf_formatter';
 import SoftLineBreak from './chord_sheet/soft_line_break';
 import Song from './chord_sheet/song';
 import Tag from './chord_sheet/tag';
@@ -59,14 +58,12 @@ import {
 import { BaseMeasurer } from './layout/measurement';
 import { CanvasMeasurer } from './layout/measurement';
 import { DomMeasurer } from './layout/measurement';
-import { JsPdfMeasurer } from './layout/measurement';
 import { LayoutEngine } from './layout/engine';
 
 export { default as Chord } from './chord';
 export { default as ChordDefinition } from './chord_definition/chord_definition';
 export { default as ChordLyricsPair } from './chord_sheet/chord_lyrics_pair';
 export { default as ChordProFormatter } from './formatter/chord_pro_formatter';
-export { default as PdfFormatter } from './formatter/pdf_formatter';
 export { default as MeasuredHtmlFormatter } from './formatter/measured_html_formatter';
 export { default as ChordProParser } from './parser/chord_pro_parser';
 export { default as ChordSheetParser } from './parser/chord_sheet_parser';
@@ -100,7 +97,6 @@ export type { PangoRenderer } from './pango/pango_helpers';
 export * from './serialized_types';
 
 export { BaseMeasurer } from './layout/measurement/measurer';
-export { JsPdfMeasurer } from './layout/measurement';
 export { DomMeasurer } from './layout/measurement';
 export { CanvasMeasurer } from './layout/measurement';
 export { LayoutEngine } from './layout/engine/layout_engine';
@@ -128,7 +124,6 @@ export default {
   ChordDefinition,
   ChordLyricsPair,
   ChordProFormatter,
-  PdfFormatter,
   MeasuredHtmlFormatter,
   ChordProParser,
   ChordSheetParser,
@@ -158,7 +153,6 @@ export default {
   BaseMeasurer,
   DomMeasurer,
   CanvasMeasurer,
-  JsPdfMeasurer,
   LayoutEngine,
   version,
   templateHelpers: {

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -1,0 +1,2 @@
+export { default as PdfFormatter } from './formatter/pdf_formatter';
+export { JsPdfMeasurer } from './layout/measurement';

--- a/src/rendering/shared/layout_section_renderer.ts
+++ b/src/rendering/shared/layout_section_renderer.ts
@@ -1,4 +1,4 @@
-import { ImageCompression } from 'jspdf';
+import type { ImageCompression } from 'jspdf';
 
 import ChordProParser from '../../parser/chord_pro_parser';
 import Condition from '../../layout/engine/condition';

--- a/tsconfig.pdf.json
+++ b/tsconfig.pdf.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./lib/pdf",
+    "rootDir": "./src"
+  },
+  "include": ["src/pdf.ts"]
+}

--- a/unibuild.ts
+++ b/unibuild.ts
@@ -129,6 +129,17 @@ export default unibuild((u: Config) => {
     releaseOnly: true,
   });
 
+  u.asset('pdfSources', {
+    input: jsBuild,
+    outfile: 'lib/pdf/index.js',
+    command: [
+      'esbuild src/pdf.ts --outfile=lib/pdf/index.js --format=cjs --bundle --external:jspdf',
+      'esbuild src/pdf.ts --outfile=lib/pdf/module.js --format=esm --bundle --external:jspdf',
+      'tsc -p tsconfig.pdf.json',
+    ].join(' && '),
+    releaseOnly: true,
+  });
+
   u.asset('bundle', {
     input: jsBuild,
     outfile: bundle.default,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4060,6 +4060,11 @@ __metadata:
     typedoc: "npm:^0.28.0"
     typescript: "npm:^5.7.3"
     typescript-eslint: "npm:^8.56.1"
+  peerDependencies:
+    jspdf: ^4.0.0
+  peerDependenciesMeta:
+    jspdf:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

- Move `PdfFormatter` and `JsPdfMeasurer` to a separate `chordsheetjs/pdf` entry point
- Move `jspdf` from `dependencies` to optional `peerDependencies`
- Add separate build step for the PDF sub-package (esbuild + tsc)
- Use `import type` for `ImageCompression` in shared files to avoid runtime jspdf dependency

Bundle size drops from 1.7 MB to 343 KB (minified) for consumers who don't use PDF.

Closes #2104