### PR TITLE
Add default classes to template helpers

### DIFF
--- a/src/template_helpers.ts
+++ b/src/template_helpers.ts
@@ -20,6 +20,7 @@ import {
   Configuration,
   Delegate,
   HtmlTemplateCssClasses,
+  defaultCssClasses,
   defaultDelegate,
 } from './formatter/configuration';
 
@@ -108,7 +109,7 @@ export function hasTextContents(line: Line): boolean {
   ));
 }
 
-export function lineClasses(line: Line, cssClasses: HtmlTemplateCssClasses): string {
+export function lineClasses(line: Line, cssClasses: HtmlTemplateCssClasses = defaultCssClasses): string {
   const classes = [cssClasses.row];
 
   if (!lineHasContents(line)) {
@@ -118,7 +119,7 @@ export function lineClasses(line: Line, cssClasses: HtmlTemplateCssClasses): str
   return classes.join(' ');
 }
 
-export function paragraphClasses(paragraph: Paragraph, cssClasses: HtmlTemplateCssClasses): string {
+export function paragraphClasses(paragraph: Paragraph, cssClasses: HtmlTemplateCssClasses = defaultCssClasses): string {
   const classes = [cssClasses.paragraph];
 
   if (paragraph.type !== INDETERMINATE && paragraph.type !== NONE) {

--- a/test/template_helpers.test.ts
+++ b/test/template_helpers.test.ts
@@ -282,6 +282,12 @@ describe('template_helpers', () => {
 
       expect(lineClasses(line, defaultCssClasses)).toEqual('row');
     });
+
+    it('falls back to default css classes when cssClasses is omitted', () => {
+      const line = new Line({ type: NONE, items: [] });
+
+      expect(lineClasses(line)).toEqual('row empty-line');
+    });
   });
 
   describe('paragraphClasses', () => {
@@ -305,6 +311,14 @@ describe('template_helpers', () => {
       const paragraph = new Paragraph();
 
       expect(paragraphClasses(paragraph, defaultCssClasses)).toEqual('paragraph');
+    });
+
+    it('falls back to default css classes when cssClasses is omitted', () => {
+      const line = new Line({ type: CHORUS, items: [] });
+      const paragraph = new Paragraph();
+      paragraph.addLine(line);
+
+      expect(paragraphClasses(paragraph)).toEqual('paragraph chorus');
     });
   });
 


### PR DESCRIPTION
In my application I have my own implementation of a formatter using Vue, catered to our own use case. I use the `lineClasses`, `paragraphClasses`, `renderChord`, `isComment` from the `temlateHelpers` export.

<details>

```vue
<script setup lang="ts">
import type { Line, Song } from "chordsheetjs";
import { computed } from "vue";
import { ChordSheet, parserOptions } from "../../../../util/chord-sheet";
import { createChordTransposer } from "../../../../util/transposer";
import { useSongStore } from "../../../store/song";

const { text, renderBlankLines = false } = defineProps<{
    text?: string;
    renderBlankLines?: boolean;
}>();

const ChordSheetJS = await import("chordsheetjs");
const { ChordLyricsPair, ChordProParser, Song: SongObject, Tag, templateHelpers } = ChordSheetJS;

const chordSheetTransformer = new ChordSheet(ChordSheetJS);
const parser = new ChordProParser();

const songStore = useSongStore();

const { lineClasses, paragraphClasses, renderChord, isComment } = templateHelpers;
const blank = (value: string | null | undefined) => value == null || value.trim().length === 0;
const shouldRenderLine = (line: Line) => {
    if (renderBlankLines) {
        return true;
    }

    return lineHasContents(line);
};
const lineHasContents = (line: Line) =>
    line.items.some((item) =>
        item instanceof Tag ? isComment(item) && shouldRenderComment(item) : item.isRenderable(),
    );
const shouldRenderComment = (item: InstanceType<typeof Tag>) =>
    item.selector !== null && songStore.song.literal_translation_languages.includes(item.selector);

const toChordSheetJSSongObject = (sectionTranslation?: string): Song => {
    if (!sectionTranslation) {
        return new SongObject();
    }

    let songObject = parser.parse(sectionTranslation, parserOptions);

    // Transpose from original key to current key
    const fromKey = songStore.song.key;
    const toKey = songStore.currentKey;
    if (fromKey !== toKey) {
        const transpose = createChordTransposer(fromKey, toKey);
        songObject = chordSheetTransformer.transformChordsInSongObject(songObject, transpose);
    }

    return songObject;
};

const song = computed(() => toChordSheetJSSongObject(text));
</script>

<template>
    <Transition name="transpose" mode="out-in" :duration="{ enter: 25, leave: 125 }">
        <!--
        The key attribute here is responsible for letting Vue know when to trigger the transpose transition.
        See: https://vuejs.org/guide/built-ins/transition.html#the-transition-component
        -->
        <div class="chord-sheet" :key="songStore.currentKey">
            <div v-for="paragraph in song.bodyParagraphs" :class="[paragraphClasses(paragraph)]">
                <template v-for="line in paragraph.lines">
                    <div v-if="shouldRenderLine(line)" :class="[lineClasses(line)]">
                        <template v-for="item in line.items">
                            <div v-if="item instanceof ChordLyricsPair" class="column">
                                <div class="chord">
                                    {{ renderChord(item.chords, line, song) }}
                                </div>
                                <div class="lyrics" :class="{ 'lyrics--empty': blank(item.lyrics) }">
                                    {{ item.lyrics }}
                                </div>
                            </div>
                            <div v-else-if="item instanceof Tag && isComment(item) && shouldRenderComment(item)"
                                 class="-mt-1.5 literal-translation"
                            >
                                <em class="text-cool-gray-700/60">{{ item.label }}</em>
                            </div>
                        </template>
                    </div>
                </template>
            </div>
        </div>
    </Transition>
</template>
```

</details>

Prior to ChordSheetJS 12.1.0, `paragraphClasses()` and `lineClasses()` only required one argument. In #1552 a required second argument got added, silently breaking external callers. This PR adds a default argument so the previous call shape works again.