### PR TITLE
Fix export declaration types for helpers

### DIFF
--- a/src/formatter_configuration.ts
+++ b/src/formatter_configuration.ts
@@ -17,7 +17,16 @@ export {
   mergeConfigs,
 };
 
-export default {
+export interface FormatterConfigurationHelpers {
+  configure: typeof configure;
+  getDefaultConfig: typeof getDefaultConfig;
+  getHTMLDefaultConfig: typeof getHTMLDefaultConfig;
+  getMeasuredHtmlDefaultConfig: typeof getMeasuredHtmlDefaultConfig;
+  getPDFDefaultConfig: typeof getPDFDefaultConfig;
+  mergeConfigs: typeof mergeConfigs;
+}
+
+export const formatterConfiguration: FormatterConfigurationHelpers = {
   configure,
   getDefaultConfig,
   getHTMLDefaultConfig,
@@ -25,3 +34,5 @@ export default {
   getPDFDefaultConfig,
   mergeConfigs,
 };
+
+export default formatterConfiguration;

--- a/src/key_helpers.ts
+++ b/src/key_helpers.ts
@@ -2,7 +2,14 @@ import { getCapos, getKeys } from './helpers';
 
 export { getCapos, getKeys };
 
-export default {
+export interface KeyHelpers {
+  getCapos: typeof getCapos;
+  getKeys: typeof getKeys;
+}
+
+export const keyHelpers: KeyHelpers = {
   getCapos,
   getKeys,
 };
+
+export default keyHelpers;


### PR DESCRIPTION
## Summary

Fixes invalid TypeScript declaration output generated during release builds for the default export helper objects.

The release workflow failed during `yarn typedoc` because `lib/main.d.ts` emitted value names as types, e.g. `getKeys: getKeys` instead of a valid type reference. This change makes the relevant source objects explicitly typed so the generated declarations use valid `typeof` references.

## Validation

- `PATH="/var/deployment/musicready/ChordSheetJS/node_modules/.bin:/home/isaiahdahl/.pi/agent/intercepted-commands:/home/isaiahdahl/.pi/agent/bin:/home/isaiahdahl/.local/share/mise/installs/node/25.7.0/bin:/home/isaiahdahl/.local/share/omarchy/bin:/home/isaiahdahl/.local/share/omarchy/bin:/home/isaiahdahl/.local/share/mise/shims:/home/isaiahdahl/.local/share/omarchy/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/opt/cuda/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/home/isaiahdahl/.local/bin:/home/isaiahdahl/.local/bin:/home/isaiahdahl/google-cloud-sdk/bin" yarn build:release`
- `yarn typedoc`
- `yarn test`

## Release note

After merge, cut a patch release: `yarn release 15.1.1`.