### PR TITLE
Preserve user-chosen chord suffix variant in ChordProFormatter

### DIFF
--- a/src/formatter/chord_pro_formatter.ts
+++ b/src/formatter/chord_pro_formatter.ts
@@ -11,10 +11,17 @@ import Song from '../chord_sheet/song';
 import Tag from '../chord_sheet/tag';
 import Ternary from '../chord_sheet/chord_pro/ternary';
 
+import { BaseFormatterConfiguration } from './configuration/base_configuration';
+import { getBaseDefaultConfig } from './configuration/default_config_manager';
+
 /**
  * Formats a song into a ChordPro chord sheet
  */
 class ChordProFormatter extends Formatter {
+  protected getDefaultConfiguration(): BaseFormatterConfiguration {
+    return { ...getBaseDefaultConfig(), normalizeChordSuffix: false };
+  }
+
   /**
    * Formats a song into a ChordPro chord sheet.
    * @param {Song} song The song to be formatted
@@ -210,7 +217,9 @@ class ChordProFormatter extends Formatter {
         return `[${chordLyricsPair.chords}]`;
       }
 
-      const finalChord = this.configuration.normalizeChords ? chordObj.normalize() : chordObj;
+      const finalChord = this.configuration.normalizeChords ?
+        chordObj.normalize(null, { normalizeSuffix: this.configuration.normalizeChordSuffix }) :
+        chordObj;
       return `[${finalChord}]`;
     }
 

--- a/src/formatter/chord_renderer.ts
+++ b/src/formatter/chord_renderer.ts
@@ -9,6 +9,7 @@ interface ConstructorOptions {
   contextKey: Key | null;
   decapo: boolean;
   normalizeChords: boolean;
+  normalizeChordSuffix: boolean;
   renderKey: Key | null;
   songKey: Key | null;
   style: NullableChordStyle;
@@ -21,6 +22,7 @@ const defaultConstructorOptions = {
   contextKey: null,
   decapo: false,
   normalizeChords: true,
+  normalizeChordSuffix: true,
   renderKey: null,
   songKey: null,
   style: null,
@@ -34,6 +36,8 @@ class ChordRenderer {
   contextKey: Key | null;
 
   normalizeChords: boolean;
+
+  normalizeChordSuffix: boolean;
 
   renderKey: Key | null;
 
@@ -51,6 +55,7 @@ class ChordRenderer {
     this.capo = config.decapo ? config.capo : 0;
     this.contextKey = config.contextKey;
     this.normalizeChords = config.normalizeChords;
+    this.normalizeChordSuffix = config.normalizeChordSuffix;
     this.renderKey = config.renderKey;
     this.songKey = config.songKey;
     this.style = config.style;
@@ -70,7 +75,9 @@ class ChordRenderer {
       [
         (c: Chord) => c.transpose(this.effectiveTransposeDistance),
         (c: Chord) => (this.accidental ? c.useAccidental(this.accidental) : c),
-        (c: Chord) => (this.normalizeChords ? c.normalize(this.effectiveKey) : c),
+        (c: Chord) => (
+          this.normalizeChords ? c.normalize(this.effectiveKey, { normalizeSuffix: this.normalizeChordSuffix }) : c
+        ),
         (c: Chord) => this.changeChordType(c),
       ],
     ).toString({ useUnicodeModifier: this.useUnicodeModifier });

--- a/src/formatter/chords_over_words_formatter.ts
+++ b/src/formatter/chords_over_words_formatter.ts
@@ -153,6 +153,7 @@ class ChordsOverWordsFormatter extends Formatter {
       {
         renderKey: this.configuration.key,
         normalizeChords: this.configuration.normalizeChords,
+        normalizeChordSuffix: this.configuration.normalizeChordSuffix,
         decapo: this.configuration.decapo,
       },
     );

--- a/src/formatter/configuration/base_configuration.ts
+++ b/src/formatter/configuration/base_configuration.ts
@@ -63,6 +63,7 @@ export interface BaseFormatterConfiguration {
   key: Key | null;
   metadata: MetadataConfiguration;
   normalizeChords: boolean;
+  normalizeChordSuffix: boolean;
   useUnicodeModifiers: boolean;
   user: UserConfigurationProperties | null;
 }
@@ -77,6 +78,7 @@ export type ConfigurationProperties = Record<string, any> & Partial<{
   key: Key | string | null;
   metadata: Partial<MetadataConfiguration>;
   normalizeChords: boolean;
+  normalizeChordSuffix: boolean;
   useUnicodeModifiers: boolean;
   user: Partial<UserConfigurationProperties>;
 }>;
@@ -91,6 +93,7 @@ export const defaultBaseConfiguration: BaseFormatterConfiguration = {
   key: null,
   metadata: defaultMetadataConfiguration,
   normalizeChords: true,
+  normalizeChordSuffix: true,
   useUnicodeModifiers: false,
   user: null,
 };

--- a/src/formatter/measured_html_formatter.ts
+++ b/src/formatter/measured_html_formatter.ts
@@ -93,6 +93,7 @@ class MeasuredHtmlFormatter extends MeasurementBasedFormatter<MeasuredHtmlFormat
       linePadding: this.configuration.layout.sections.global.linePadding,
       useUnicodeModifiers: this.configuration.useUnicodeModifiers,
       normalizeChords: this.configuration.normalizeChords,
+      normalizeChordSuffix: this.configuration.normalizeChordSuffix,
 
       // Column and page layout information
       minY: dimensions.minY,

--- a/src/formatter/pdf_formatter.ts
+++ b/src/formatter/pdf_formatter.ts
@@ -84,6 +84,7 @@ class PdfFormatter extends MeasurementBasedFormatter<PDFFormatterConfiguration> 
       linePadding: this.configuration.layout.sections.global.linePadding,
       useUnicodeModifiers: this.configuration.useUnicodeModifiers,
       normalizeChords: this.configuration.normalizeChords,
+      normalizeChordSuffix: this.configuration.normalizeChordSuffix,
 
       // Column and page layout information
       minY: dimensions.minY,

--- a/src/formatter/templates/html_div_formatter.ts
+++ b/src/formatter/templates/html_div_formatter.ts
@@ -78,6 +78,7 @@ export default (
                               renderKey: key,
                               useUnicodeModifier: configuration.useUnicodeModifiers,
                               normalizeChords: configuration.normalizeChords,
+                              normalizeChordSuffix: configuration.normalizeChordSuffix,
                               decapo: configuration.decapo,
                             },
                           ) }

--- a/src/formatter/templates/html_table_formatter.ts
+++ b/src/formatter/templates/html_table_formatter.ts
@@ -88,6 +88,7 @@ export default (
                                   renderKey: key,
                                   useUnicodeModifier: configuration.useUnicodeModifiers,
                                   normalizeChords: configuration.normalizeChords,
+                                  normalizeChordSuffix: configuration.normalizeChordSuffix,
                                   decapo: configuration.decapo,
                                 },
                               )

--- a/src/formatter/text_formatter.ts
+++ b/src/formatter/text_formatter.ts
@@ -128,6 +128,7 @@ class TextFormatter extends Formatter {
         renderKey: this.configuration.key,
         useUnicodeModifier: this.configuration.useUnicodeModifiers,
         normalizeChords: this.configuration.normalizeChords,
+        normalizeChordSuffix: this.configuration.normalizeChordSuffix,
         decapo: this.configuration.decapo,
       },
     );

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -20,6 +20,7 @@ interface RenderChordOptions {
   renderKey?: Key | null;
   useUnicodeModifier?: boolean;
   normalizeChords?: boolean;
+  normalizeChordSuffix?: boolean;
   decapo?: boolean;
 }
 
@@ -33,33 +34,40 @@ interface RenderChordOptions {
  * @param useUnicodeModifier Whether to use unicode modifiers ('\u266f'/'\u266d') or plain text ('#'/'b').
  * Default `false`.
  * @param normalizeChords Whether to normalize the chord to the key (default `true`)
+ * @param normalizeChordSuffix Whether to normalize the chord suffix (e.g. `sus2` to `2`, `maj7` to `ma7`).
+ * Only takes effect when `normalizeChords` is `true`. Default `true`.
  * @param decapo Whether to transpose all chords to eliminate the capo (default `false`)
  */
+const renderChordDefaults: Required<RenderChordOptions> = {
+  renderKey: null,
+  useUnicodeModifier: false,
+  normalizeChords: true,
+  normalizeChordSuffix: true,
+  decapo: false,
+};
+
 export function renderChord(
   chordString: string,
   line: Line,
   song: Song,
-  {
-    renderKey = null,
-    useUnicodeModifier = false,
-    normalizeChords = true,
-    decapo = false,
-  }: RenderChordOptions = {},
+  options: RenderChordOptions = {},
 ): string {
+  const {
+    renderKey, useUnicodeModifier, normalizeChords, normalizeChordSuffix, decapo,
+  } = { ...renderChordDefaults, ...options };
   const capoString = song.metadata.getSingle(CAPO);
-
   return new ChordRenderer({
     capo: capoString ? parseInt(capoString, 10) : 0,
     contextKey: Key.wrap(line.key || song.key),
     decapo,
     normalizeChords,
+    normalizeChordSuffix,
     renderKey,
     songKey: Key.wrap(song.key),
     style: song.metadata.getSingle(CHORD_STYLE) as NullableChordStyle,
     transposeKey: line.transposeKey,
     useUnicodeModifier,
-  })
-    .render(chordString);
+  }).render(chordString);
 }
 
 /**

--- a/src/layout/engine/item_processor.ts
+++ b/src/layout/engine/item_processor.ts
@@ -160,6 +160,7 @@ export class ItemProcessor {
       renderKey: null,
       useUnicodeModifier: this.config.useUnicodeModifiers,
       normalizeChords: this.config.normalizeChords,
+      normalizeChordSuffix: this.config.normalizeChordSuffix,
       decapo: this.config.decapo,
     });
   }

--- a/src/layout/engine/types.ts
+++ b/src/layout/engine/types.ts
@@ -71,6 +71,7 @@ export interface LayoutConfig {
   linePadding: number;
   useUnicodeModifiers: boolean;
   normalizeChords: boolean;
+  normalizeChordSuffix: boolean;
 
   // Add column and page layout information
   minY: number;

--- a/test/formatter/chord_pro_formatter.test.ts
+++ b/test/formatter/chord_pro_formatter.test.ts
@@ -12,8 +12,28 @@ describe('ChordProFormatter', () => {
     expect(new ChordProFormatter().format(exampleSongSolfege)).toEqual(chordProSheetSolfege);
   });
 
-  it('allows enabling chord normalization', () => {
-    const formatter = new ChordProFormatter({ normalizeChords: true });
+  it('preserves the user-chosen suffix variant by default', () => {
+    const song = createSongFromAst([
+      [
+        chordLyricsPair('Gsus2', 'one '),
+        chordLyricsPair('Csus4', 'two '),
+        chordLyricsPair('Cmaj7', 'three '),
+        chordLyricsPair('FM7', 'four'),
+      ],
+    ]);
+
+    expect(new ChordProFormatter().format(song)).toEqual('[Gsus2]one [Csus4]two [Cmaj7]three [FM7]four');
+  });
+
+  it('round-trips a ChordPro sheet without altering chord suffixes', () => {
+    const chordSheet = '[Cmaj7]Hello [Gsus2]world';
+    const song = new ChordProParser().parse(chordSheet);
+
+    expect(new ChordProFormatter().format(song)).toEqual(chordSheet);
+  });
+
+  it('normalizes the chord suffix when normalizeChordSuffix is enabled', () => {
+    const formatter = new ChordProFormatter({ normalizeChordSuffix: true });
 
     const song = createSongFromAst([
       [chordLyricsPair('Dsus4', 'Let it be')],
@@ -22,14 +42,22 @@ describe('ChordProFormatter', () => {
     expect(formatter.format(song)).toEqual('[Dsus]Let it be');
   });
 
-  it('allows disabling chord normalization', () => {
+  it('normalizes enharmonic roots and bass notes by default', () => {
+    const song = createSongFromAst([
+      [chordLyricsPair('B#sus4', 'Let it be')],
+    ]);
+
+    expect(new ChordProFormatter().format(song)).toEqual('[Csus4]Let it be');
+  });
+
+  it('allows disabling chord normalization entirely', () => {
     const formatter = new ChordProFormatter({ normalizeChords: false });
 
     const song = createSongFromAst([
-      [chordLyricsPair('Dsus4', 'Let it be')],
+      [chordLyricsPair('B#sus4', 'Let it be')],
     ]);
 
-    expect(formatter.format(song)).toEqual('[Dsus4]Let it be');
+    expect(formatter.format(song)).toEqual('[B#sus4]Let it be');
   });
 
   it('formats image directive with attributes', () => {

--- a/test/integration/chords_over_words_to_chordpro.test.ts
+++ b/test/integration/chords_over_words_to_chordpro.test.ts
@@ -28,8 +28,8 @@ describe('chords over words to chordpro', () => {
       Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be
       [C]Whisper words of [G]wisdom, let it [F]be[C/E][Dm][C]
 
-      Let it [Bbm7]be, let it [Dbma7/Ab]be, let it [Gb2]be, let it [Db]be
-      [Gbma7]Whisper words of [Absus]wisdom, let it [Gb]be[Db/F][Ebm][Db]`;
+      Let it [Bbm7]be, let it [DbM7/Ab]be, let it [Gbsus2]be, let it [Db]be
+      [GbM7]Whisper words of [Absus]wisdom, let it [Gb]be[Db/F][Ebm][Db]`;
 
     const song = new ChordsOverWordsParser().parse(chordOverWords);
     const actualChordPro = new ChordProFormatter().format(song);

--- a/test/integration/transpose_song.test.ts
+++ b/test/integration/transpose_song.test.ts
@@ -15,7 +15,7 @@ describe('transposing a song', () => {
 
     const changedSheet = heredoc`
       {key: D}
-      Let it [Bm]be, let it [D/A]be, let it [G2]be, let it [D]be`;
+      Let it [Bm]be, let it [D/A]be, let it [Gsus2]be, let it [D]be`;
 
     const song = new ChordProParser().parse(chordpro);
     const updatedSong = song.transpose(2);
@@ -47,7 +47,7 @@ describe('transposing a song', () => {
 
     const changedSheet = heredoc`
       {key: C#}
-      Let it [A#m]be, let it [C#/G#]be, let it [F#2]be, let it [C#]be`;
+      Let it [A#m]be, let it [C#/G#]be, let it [F#sus2]be, let it [C#]be`;
 
     const song = new ChordProParser().parse(chordpro);
     const updatedSong = song.transposeUp();
@@ -79,7 +79,7 @@ describe('transposing a song', () => {
 
     const changedSheet = heredoc`
       {key: Db}
-      Let it [Bbm]be, let it [Db/Ab]be, let it [Gb2]be, let it [Db]be`;
+      Let it [Bbm]be, let it [Db/Ab]be, let it [Gbsus2]be, let it [Db]be`;
 
     const song = new ChordProParser().parse(chordpro);
     const updatedSong = song.transposeDown();
@@ -248,7 +248,7 @@ describe('transposing a song', () => {
 
     const changedSheet = heredoc`
       {key: C}
-      [C]Something in the way she [Cma7]moves
+      [C]Something in the way she [Cmaj7]moves
       {key: A}
       [A]You're asking m[C#m/G#]e will my love [F#m7]grow [A/E]`;
 

--- a/test/layout/engine/item_processor.test.ts
+++ b/test/layout/engine/item_processor.test.ts
@@ -109,6 +109,7 @@ function createTestConfig(overrides: Partial<LayoutConfig> = {}): LayoutConfig {
     linePadding: 2,
     useUnicodeModifiers: false,
     normalizeChords: false,
+    normalizeChordSuffix: true,
     minY: 50,
     columnWidth: 500,
     columnCount: 1,

--- a/test/layout/engine/layout_engine.test.ts
+++ b/test/layout/engine/layout_engine.test.ts
@@ -116,6 +116,7 @@ describe('LayoutEngine', () => {
     linePadding: 2,
     useUnicodeModifiers: false,
     normalizeChords: false,
+    normalizeChordSuffix: true,
     minY: 50,
     columnWidth: 500,
     columnCount: 1,

--- a/test/layout/engine/line_breaker.test.ts
+++ b/test/layout/engine/line_breaker.test.ts
@@ -110,6 +110,7 @@ function createTestConfig(overrides: Partial<LayoutConfig> = {}): LayoutConfig {
     linePadding: 2,
     useUnicodeModifiers: false,
     normalizeChords: false,
+    normalizeChordSuffix: true,
     minY: 50,
     columnWidth: 500,
     columnCount: 1,


### PR DESCRIPTION
ChordProFormatter normalized chord suffixes by default (sus2 → 2, sus4 → sus, maj7 → ma7, M7 → ma7). As a result, a ChordPro round-trip produced output that differed from what the user wrote, and an UltimateGuitar → ChordPro pipeline converted `Gsus2` to `G2` and `Cmaj7` to `Cma7`.

This PR adds a separate `normalizeChordSuffix` setting to `BaseFormatterConfiguration` that all formatters respect (ChordProFormatter, TextFormatter, HTML, PDF, MeasuredHtml, ChordsOverWords). It defaults to `true` so existing TextFormatter et al. behavior is preserved. ChordProFormatter overrides the default to `false`, so ChordPro round-trips keep the user-chosen suffix variant by default. Root and bass normalization remain controlled by `normalizeChords`, so `B# → C` and `D/E# → D/F` still work as before.

Matrix:
- \`normalizeChords: false\` → no normalization
- \`normalizeChords: true, normalizeChordSuffix: false\` (ChordPro default) → root/bass enharmonic normalization only
- \`normalizeChords: true, normalizeChordSuffix: true\` (default for other formatters) → also normalize suffixes (\`sus2 → 2\`)

Closes #2154