### PR TITLE
Preserve explicit accidental choice across chained song transformations

### DIFF
--- a/src/chord_sheet/chord_lyrics_pair.ts
+++ b/src/chord_sheet/chord_lyrics_pair.ts
@@ -128,7 +128,7 @@ class ChordLyricsPair {
   }
 
   changeChord(func: (chord: Chord) => Chord): ChordLyricsPair {
-    const chordObj = Chord.parse(this.chords.trim());
+    const chordObj = this.chord;
 
     if (chordObj) {
       const changedChord = func(chordObj);

--- a/test/chord_sheet/song.test.ts
+++ b/test/chord_sheet/song.test.ts
@@ -664,6 +664,22 @@ describe('Song', () => {
       const normalizedSong = song.normalizeChords('F#', { normalizeSuffix: true });
       expect((normalizedSong.paragraphs[0].lines[0].items[0] as ChordLyricsPair).chords).toEqual('E(9)');
     });
+
+    it('preserves an accidental that was explicitly chosen with useAccidental', () => {
+      const song = createSongFromAst([
+        [
+          chordLyricsPair('Bbdim7', 'one'),
+          chordLyricsPair('Eb+', 'two'),
+        ],
+      ]);
+
+      const sharpened = song.useAccidental('#');
+      const normalized = sharpened.normalizeChords('Bm');
+
+      const { items } = normalized.paragraphs[0].lines[0];
+      expect((items[0] as ChordLyricsPair).chords).toEqual('A#dim7');
+      expect((items[1] as ChordLyricsPair).chords).toEqual('D#+');
+    });
   });
 
   describe('#useModifier', () => {


### PR DESCRIPTION
When a song-level operation (\`useAccidental\`, \`transpose\`, \`normalizeChords\`, ...) builds a new \`ChordLyricsPair\`, \`changeChord\` stores the updated \`Chord\` object (including its \`explicitAccidental\` flag). A subsequent operation ignored that stored object and re-parsed the chord from its string, which dropped the explicit flag. \`normalizeEnharmonics\` then undid the previously-chosen accidental.

By using \`this.chord\` — which reuses the stored \`_chordObj\` when present — \`useAccidental\` choices stay intact across every following transformation.

Closes #2143