### PR TITLE
Support German notation: H as B natural

### DIFF
--- a/src/chord.ts
+++ b/src/chord.ts
@@ -8,9 +8,14 @@ import {
   ChordType,
   NUMERAL,
   NUMERIC,
+  Notation,
   SOLFEGE,
   SYMBOL,
 } from './constants';
+
+export interface ChordParseOptions {
+  notation?: Notation | null;
+}
 
 interface ChordProperties {
   root?: Key | null;
@@ -33,6 +38,7 @@ export interface ChordConstructorOptions {
   bass?: Key | null;
   chordType?: ChordType | null;
   optional?: boolean;
+  notation?: Notation | null;
 }
 
 /**
@@ -70,22 +76,26 @@ class Chord implements ChordProperties {
    * Tries to parse a chord string into a chord
    * Any leading or trailing whitespace is removed first, so a chord like `  \n  E/G# \r ` is valid.
    * @param chordString the chord string, eg `Esus4/G#` or `1sus4/#3`.
+   * @param {ChordParseOptions} [options] parse options
+   * @param {Notation|null} [options.notation] when `'german'`, `B` is interpreted as B-flat (grade 10)
+   * and `H` as B natural (grade 11), and output renders accordingly. Defaults to English semantics where
+   * `B` is B natural and `H` is accepted as an alias for it.
    * @returns {Chord|null}
    */
-  static parse(chordString: string): Chord | null {
+  static parse(chordString: string, options: ChordParseOptions = {}): Chord | null {
     try {
-      return this.parseOrFail(chordString);
+      return this.parseOrFail(chordString, options);
     } catch (_error) {
       return null;
     }
   }
 
-  static parseOrFail(chordString: string): Chord {
+  static parseOrFail(chordString: string, options: ChordParseOptions = {}): Chord {
     const trimmedChord = chordString.trim();
 
     try {
       const ast = parse(trimmedChord);
-      return new Chord(ast);
+      return new Chord({ ...ast, notation: options.notation ?? null });
     } catch (error) {
       const errorObj = error as Error;
       throw new ChordParsingError(`Failed parsing '${trimmedChord}': ${errorObj.message}`);
@@ -414,7 +424,7 @@ class Chord implements ChordProperties {
 
   static determineRoot(options: ChordConstructorOptions & { suffix?: string | null }): Key | null {
     const {
-      root, base, accidental, suffix, chordType,
+      root, base, accidental, suffix, chordType, notation,
     } = options;
     if (root) return root;
     if (!base) return null;
@@ -425,12 +435,13 @@ class Chord implements ChordProperties {
       keyType: chordType,
       minor: isMinor(base, chordType, suffix ?? null),
       accidental: accidental ?? null,
+      preferredNotation: notation ?? null,
     });
   }
 
   static determineBass(options: ChordConstructorOptions): Key | null {
     const {
-      bass, bassBase, bassAccidental, chordType,
+      bass, bassBase, bassAccidental, chordType, notation,
     } = options;
     if (bass) return bass;
     if (!bassBase) return null;
@@ -441,6 +452,7 @@ class Chord implements ChordProperties {
       accidental: bassAccidental ?? null,
       minor: false,
       keyType: chordType,
+      preferredNotation: notation ?? null,
     });
   }
 

--- a/src/chord_sheet_serializer.ts
+++ b/src/chord_sheet_serializer.ts
@@ -13,6 +13,7 @@ import SongBuilder from './song_builder';
 import Tag from './chord_sheet/tag';
 import Ternary from './chord_sheet/chord_pro/ternary';
 
+import { Notation } from './constants';
 import { warn } from './utilities';
 
 import {
@@ -41,6 +42,8 @@ class ChordSheetSerializer {
   song: Song = new Song();
 
   songBuilder: SongBuilder = new SongBuilder(this.song);
+
+  notation: Notation | null = null;
 
   /**
    * Serializes the chord sheet to a plain object, which can be converted to any format like JSON, XML etc
@@ -148,9 +151,14 @@ class ChordSheetSerializer {
   /**
    * Deserializes a song that has been serialized using {@link serialize}
    * @param {object} serializedSong The serialized song
+   * @param {object} [options] Deserialization options
+   * @param {Notation|null} [options.notation] When `'german'`, chord strings on the song are eagerly
+   * parsed with German notation (`B` = B-flat, `H` = B natural) so the preference survives transpose
+   * and re-serialization. Defaults to English semantics.
    * @returns {Song} The deserialized song
    */
-  deserialize(serializedSong: SerializedSong): Song {
+  deserialize(serializedSong: SerializedSong, options: { notation?: Notation | null } = {}): Song {
+    this.notation = options.notation ?? null;
     this.parseAstComponent(serializedSong);
     return this.song;
   }
@@ -205,11 +213,16 @@ class ChordSheetSerializer {
       chord, chords, lyrics, annotation, isRhythmSymbol,
     } = astComponent;
 
+    const chordString = chord ? new Chord(chord).toString() : chords;
+    const eagerChord = this.notation && chordString ?
+      Chord.parse(chordString, { notation: this.notation }) :
+      null;
+
     return new ChordLyricsPair(
-      chord ? new Chord(chord).toString() : chords,
+      eagerChord ? eagerChord.toString() : chordString,
       lyrics,
       annotation,
-      null,
+      eagerChord,
       isRhythmSymbol || false,
     );
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -152,3 +152,6 @@ export type Fret = FretNumber | OpenFret | NonSoundingString;
 export const START_TAG = 'start_tag';
 export const END_TAG = 'end_tag';
 export const AUTO = 'auto';
+
+export const GERMAN = 'german';
+export type Notation = 'german';

--- a/src/key.ts
+++ b/src/key.ts
@@ -2,25 +2,28 @@ import ENHARMONIC_MAPPING from './normalize_mappings/enharmonic-normalize';
 
 import {
   Accidental,
-  AccidentalMaybe,
   ChordType,
   FLAT,
+  GERMAN,
   MAJOR,
   MINOR,
   NO_ACCIDENTAL,
   NUMERAL,
   NUMERIC,
+  Notation,
   ROMAN_NUMERALS,
   SHARP,
   SOLFEGE,
   SYMBOL,
 } from './constants';
 
-import { KEY_TO_GRADE } from './scales';
-import { deprecate, gradeToKey } from './utilities';
+import {
+  canonicalizeForEnharmonicLookup, deprecate, germanBLookupAccidental,
+  gradeToKey, isGermanNote, keyToGrade, resolveNotation,
+} from './utilities';
 
 const regexes: Record<ChordType, RegExp> = {
-  symbol: /^(?<key>((?<note>[A-Ga-g])(?<accidental>#|b)?))(?<minor>m)?$/,
+  symbol: /^(?<key>((?<note>[A-Ha-h])(?<accidental>#|b)?))(?<minor>m)?$/,
   solfege: /^(?<key>((?<note>Do|Re|Mi|Fa|Sol|La|Si|do|re|mi|fa|sol|la|si)(?<accidental>#|b)?))(?<minor>m)?$/,
   numeric: /^(?<key>(?<accidental>#|b)?(?<note>[1-7]))(?<minor>m)?$/,
   numeral: /^(?<key>(?<accidental>#|b)?(?<note>I{1,3}|IV|VI{0,2}|i{1,3}|iv|vi{0,2}))$/,
@@ -36,6 +39,7 @@ interface KeyProperties {
   referenceKeyMode?: string | null;
   preferredAccidental?: Accidental | null;
   explicitAccidental?: boolean;
+  preferredNotation?: Notation | null;
 }
 
 const KEY_TYPES: ChordType[] = [SYMBOL, SOLFEGE, NUMERIC, NUMERAL];
@@ -57,6 +61,7 @@ interface ConstructorOptions {
   originalKeyString?: string | null;
   preferredAccidental: Accidental | null;
   explicitAccidental?: boolean;
+  preferredNotation?: Notation | null;
 }
 
 /**
@@ -114,6 +119,8 @@ class Key implements KeyProperties {
 
   explicitAccidental = false;
 
+  preferredNotation: Notation | null = null;
+
   static parse(keyString: string | null): null | Key {
     if (!keyString) return null;
 
@@ -141,46 +148,45 @@ class Key implements KeyProperties {
       keyType,
       minor: minor || false,
       accidental: accidental || null,
+      preferredNotation: keyType === SYMBOL && isGermanNote(note) ? GERMAN : null,
     });
   }
 
   /* eslint-disable-next-line max-lines-per-function */
   static resolve(
     {
-      key,
-      keyType,
-      minor,
-      accidental,
+      key, keyType, minor, accidental, preferredNotation,
     }: {
       key: string | number,
       keyType: ChordType,
       minor: string | boolean,
       accidental: Accidental | null,
+      preferredNotation?: Notation | null,
     },
   ): Key | null {
     const keyString = `${key}`;
     const isMinor = this.isMinor(keyString, keyType, minor);
+    const notation = resolveNotation(keyString, preferredNotation);
+    const lookupAccidental = germanBLookupAccidental(keyString, accidental, notation) ?? accidental;
+    const grade = (keyType === SYMBOL || keyType === SOLFEGE) ?
+      keyToGrade(keyString, lookupAccidental || NO_ACCIDENTAL, keyType, isMinor) :
+      null;
 
-    if (keyType === SYMBOL || keyType === SOLFEGE) {
-      const grade = this.toGrade(keyString, accidental || NO_ACCIDENTAL, keyType, isMinor);
-
-      if (grade !== null) {
-        return new Key({
-          grade: 0,
-          minor: isMinor,
-          type: keyType,
-          accidental: accidental || null,
-          preferredAccidental: accidental || null,
-          referenceKeyGrade: grade,
-          originalKeyString: keyString,
-        });
-      }
+    if (grade !== null) {
+      return new Key({
+        grade: 0,
+        minor: isMinor,
+        type: keyType,
+        accidental: accidental || null,
+        preferredAccidental: accidental || null,
+        referenceKeyGrade: grade,
+        originalKeyString: keyString,
+        preferredNotation: notation,
+      });
     }
 
-    const number = this.getNumberFromKey(keyString, keyType);
-
     return new Key({
-      number,
+      number: this.getNumberFromKey(keyString, keyType),
       minor: isMinor,
       type: keyType,
       accidental: accidental || null,
@@ -217,23 +223,6 @@ class Key implements KeyProperties {
   static keyWithModifier(key: string, accidental: Accidental | null, type: ChordType): string {
     deprecate('keyWithModifier is deprecated, use keyWithAccidental instead');
     return this.keyWithAccidental(key, accidental, type);
-  }
-
-  static toGrade(key: string, accidental: AccidentalMaybe, type: ChordType, isMinor: boolean): number | null {
-    const mode = (isMinor ? MINOR : MAJOR);
-    const grades = KEY_TO_GRADE[type][mode][accidental];
-
-    if (key in grades) {
-      return grades[key];
-    }
-
-    const upperCaseKey = key.toUpperCase();
-
-    if (upperCaseKey in grades) {
-      return grades[upperCaseKey];
-    }
-
-    return null;
   }
 
   static isMinor(key: string, keyType: ChordType, minor: string | undefined | boolean) {
@@ -296,7 +285,7 @@ class Key implements KeyProperties {
     {
       grade = null, number = null, minor, type, accidental, referenceKeyGrade = null,
       referenceKeyMode = null, originalKeyString = null, preferredAccidental = null,
-      explicitAccidental = false,
+      explicitAccidental = false, preferredNotation = null,
     }: ConstructorOptions,
   ) {
     this.grade = grade;
@@ -309,6 +298,7 @@ class Key implements KeyProperties {
     this.referenceKeyMode = referenceKeyMode;
     this.originalKeyString = originalKeyString;
     this.explicitAccidental = explicitAccidental;
+    this.preferredNotation = preferredNotation;
   }
 
   distanceTo(otherKey: Key | string): number {
@@ -363,13 +353,7 @@ class Key implements KeyProperties {
       throw new Error('Cannot calculate grade, number is null');
     }
 
-    this.grade = Key.toGrade(
-      this.number.toString(),
-      this.accidental || NO_ACCIDENTAL,
-      NUMERIC,
-      this.isMinor(),
-    );
-
+    this.grade = keyToGrade(this.number.toString(), this.accidental || NO_ACCIDENTAL, NUMERIC, this.isMinor());
     this.number = null;
   }
 
@@ -552,13 +536,22 @@ class Key implements KeyProperties {
       minor = this.referenceKeyMode === MINOR;
     }
 
-    return gradeToKey({
+    const rendered = gradeToKey({
       type: this.type,
       accidental: this.accidental,
       preferredAccidental: this.preferredAccidental,
       grade: this.effectiveGrade,
       minor,
     });
+
+    return this.applyGermanRendering(rendered);
+  }
+
+  private applyGermanRendering(rendered: string): string {
+    if (this.preferredNotation !== GERMAN || !this.isChordSymbol()) return rendered;
+    if (this.accidental === null && this.effectiveGrade === 10) return 'B';
+    if (rendered === 'B') return 'H';
+    return rendered;
   }
 
   private getNoteForNumber() {
@@ -696,14 +689,14 @@ class Key implements KeyProperties {
       // Preserve explicit accidental choices made via useAccidental()
       if (this.explicitAccidental) return this.clone();
 
-      const rootKeyString = Key.wrapOrFail(key).toString({ showMinor: true });
+      const rootKeyString = canonicalizeForEnharmonicLookup(Key.wrapOrFail(key).toString({ showMinor: true }));
       const enharmonics = ENHARMONIC_MAPPING[rootKeyString];
-      const thisKeyString = this.toString({ showMinor: false });
+      const thisKeyString = canonicalizeForEnharmonicLookup(this.toString({ showMinor: false }));
 
       if (enharmonics && enharmonics[thisKeyString]) {
         return Key
           .parseOrFail(enharmonics[thisKeyString])
-          .set({ minor: this.minor });
+          .set({ minor: this.minor, preferredNotation: this.preferredNotation });
       }
     }
 
@@ -722,6 +715,7 @@ class Key implements KeyProperties {
       originalKeyString: this.originalKeyString,
       preferredAccidental: this.preferredAccidental,
       explicitAccidental: this.explicitAccidental,
+      preferredNotation: this.preferredNotation,
       ...(overwrite ? attributes : {}),
     });
   }

--- a/src/parser/chord/base_grammar.pegjs
+++ b/src/parser/chord/base_grammar.pegjs
@@ -21,7 +21,7 @@ ChordSymbol
     }
 
 ChordSymbolRoot
-  = [A-Ga-g]
+  = [A-Ha-h]
 
 ChordSymbolBass
   = "/" root:ChordSymbolRoot accidental:ChordAccidental? {

--- a/src/parser/chord_pro_parser.ts
+++ b/src/parser/chord_pro_parser.ts
@@ -1,14 +1,17 @@
 import ChordSheetSerializer from '../chord_sheet_serializer';
 import NullTracer from './null_tracer';
 import ParserWarning from './parser_warning';
-import { SerializedSong } from '../serialized_types';
 import Song from '../chord_sheet/song';
+
+import { Notation } from '../constants';
+import { SerializedSong } from '../serialized_types';
 import { normalizeLineEndings } from '../utilities';
 import { ParseOptions, parse } from './chord_pro/peg_parser';
 
 export type ChordProParserOptions = ParseOptions & {
   softLineBreaks?: boolean;
   chopFirstWord?: boolean;
+  notation?: Notation | null;
 };
 
 /**
@@ -34,6 +37,9 @@ class ChordProParser {
    * followed by * a space is treated as a soft line break
    * @param {ChordProParserOptions.chopFirstWord} options.chopFirstWord=true If true, only the first lyric
    * word is paired with the chord, the rest of the lyric is put in a separate chord lyric pair
+   * @param {Notation|null} [options.notation] When `'german'`, every chord in the song is parsed using
+   * German notation (`B` = B-flat, `H` = B natural) and rendered accordingly. Defaults to English
+   * semantics where `B` is B natural and `H` is accepted as an alias for it.
    * @see https://peggyjs.org/documentation.html#using-the-parser
    * @returns {Song} The parsed song
    */
@@ -43,7 +49,7 @@ class ChordProParser {
       { tracer: new NullTracer(), ...options },
     ) as SerializedSong;
 
-    this.song = new ChordSheetSerializer().deserialize(ast);
+    this.song = new ChordSheetSerializer().deserialize(ast, { notation: options?.notation ?? null });
     return this.song;
   }
 }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -3,14 +3,53 @@ import Item from './chord_sheet/item';
 import Line from './chord_sheet/line';
 import SUFFIX_MAPPING from './normalize_mappings/suffix-normalize-mapping';
 
-import { GRADE_TO_KEY } from './scales';
+import { GRADE_TO_KEY, KEY_TO_GRADE } from './scales';
 
 import {
-  Accidental, AccidentalMaybe, ChordType, MAJOR, MINOR, NO_ACCIDENTAL, NUMERAL, SHARP,
+  Accidental, AccidentalMaybe, ChordType, FLAT, GERMAN, MAJOR, MINOR, NO_ACCIDENTAL, NUMERAL, Notation, SHARP, SYMBOL,
 } from './constants';
 
 export function callChain<T>(value: T, functions: ((_value: T) => T)[]): T {
   return functions.reduce((acc, fn) => fn(acc), value);
+}
+
+export function isGermanNote(key: string): boolean {
+  return key === 'H' || key === 'h';
+}
+
+export function translateGermanNote(key: string): string {
+  if (key === 'H') return 'B';
+  if (key === 'h') return 'b';
+  return key;
+}
+
+export function canonicalizeForEnharmonicLookup(keyString: string): string {
+  return keyString.startsWith('H') ? `B${keyString.slice(1)}` : keyString;
+}
+
+// In German notation, an unadorned `B` denotes B-flat. Returns the accidental to use for grade
+// lookup so `B` maps to grade 10 (Bb); the stored accidental on the Key stays null so the
+// output renders as `B` rather than `Bb`.
+export function germanBLookupAccidental(key: string, accidental: Accidental | null, notation: Notation | null) {
+  if (notation === GERMAN && accidental === null && (key === 'B' || key === 'b')) return FLAT;
+  return null;
+}
+
+export function resolveNotation(keyString: string, explicit?: Notation | null): Notation | null {
+  if (explicit) return explicit;
+  return isGermanNote(keyString) ? GERMAN : null;
+}
+
+export function keyToGrade(key: string, accidental: AccidentalMaybe, type: ChordType, minor: boolean): number | null {
+  const grades = KEY_TO_GRADE[type][(minor ? MINOR : MAJOR)][accidental];
+  const lookupKey = type === SYMBOL ? translateGermanNote(key) : key;
+
+  if (lookupKey in grades) return grades[lookupKey];
+
+  const upperCaseKey = lookupKey.toUpperCase();
+  if (upperCaseKey in grades) return grades[upperCaseKey];
+
+  return null;
 }
 
 export function hasChordContents(line: Line): boolean {

--- a/test/chord_symbol/german_notation.test.ts
+++ b/test/chord_symbol/german_notation.test.ts
@@ -1,0 +1,160 @@
+import '../util/matchers';
+
+import { Chord, SYMBOL } from '../../src';
+
+describe('Chord', () => {
+  describe('chord symbol', () => {
+    describe('German notation (H = B natural)', () => {
+      describe('parse', () => {
+        it('parses H as B natural (grade 11)', () => {
+          const chord = Chord.parse('H');
+
+          expect(chord).toMatchObject({
+            root: {
+              grade: 0,
+              accidental: null,
+              type: SYMBOL,
+              minor: false,
+              referenceKeyGrade: 11,
+              originalKeyString: 'H',
+              preferredNotation: 'german',
+            },
+          });
+        });
+
+        it('parses Hm as B minor', () => {
+          const chord = Chord.parse('Hm');
+
+          expect(chord).toMatchObject({
+            root: {
+              referenceKeyGrade: 11,
+              minor: true,
+              preferredNotation: 'german',
+            },
+            suffix: 'm',
+          });
+        });
+
+        it('parses H7', () => {
+          const chord = Chord.parse('H7');
+
+          expect(chord?.toString()).toEqual('H7');
+          expect(chord?.root?.effectiveGrade).toEqual(11);
+        });
+
+        it('parses Hsus4', () => {
+          const chord = Chord.parse('Hsus4');
+
+          expect(chord?.toString()).toEqual('Hsus4');
+          expect(chord?.root?.effectiveGrade).toEqual(11);
+        });
+
+        it('parses a slash chord with H as bass', () => {
+          const chord = Chord.parse('D/H');
+
+          expect(chord?.toString()).toEqual('D/H');
+          expect(chord?.bass?.effectiveGrade).toEqual(11);
+        });
+
+        it('parses a slash chord with H as root', () => {
+          const chord = Chord.parse('H/D');
+
+          expect(chord?.toString()).toEqual('H/D');
+          expect(chord?.root?.effectiveGrade).toEqual(11);
+        });
+
+        it('still parses B as B natural (English notation, unchanged)', () => {
+          const chord = Chord.parse('B');
+
+          expect(chord?.toString()).toEqual('B');
+          expect(chord?.root?.effectiveGrade).toEqual(11);
+        });
+      });
+
+      describe('transpose', () => {
+        it('transposes H up to C', () => {
+          expect(Chord.parse('H')?.transposeUp().toString()).toEqual('C');
+        });
+
+        it('transposes H down to Bb', () => {
+          expect(Chord.parse('H')?.transposeDown().toString()).toEqual('Bb');
+        });
+
+        it('transposes Hm up to Cm', () => {
+          expect(Chord.parse('Hm')?.transposeUp().toString()).toEqual('Cm');
+        });
+
+        it('does not switch to H notation when transposing a non-H chord', () => {
+          // A doesn't use H, so result is B (English default)
+          expect(Chord.parse('A')?.transpose(2).toString()).toEqual('B');
+        });
+
+        it('preserves H notation when transposing by full octave', () => {
+          expect(Chord.parse('H')?.transpose(12).toString()).toEqual('H');
+        });
+
+        it('transposes a slash chord with H bass', () => {
+          expect(Chord.parse('D/H')?.transposeUp().toString()).toEqual('D#/C');
+        });
+      });
+
+      describe('normalize', () => {
+        it('keeps H as H after normalize', () => {
+          expect(Chord.parse('H')?.normalize().toString()).toEqual('H');
+        });
+
+        it('keeps Hm as Hm after normalize', () => {
+          expect(Chord.parse('Hm')?.normalize().toString()).toEqual('Hm');
+        });
+
+        it('normalizes enharmonic bass note for H-rooted minor chord', () => {
+          // Mirrors existing Bm/A# -> Bm/Bb behaviour; H notation should not break the lookup
+          expect(Chord.parse('Hm/A#')?.normalize().toString()).toEqual('Hm/Bb');
+        });
+      });
+    });
+
+    describe('strict German notation (notation: \'german\')', () => {
+      const opts = { notation: 'german' as const };
+
+      it('parses B as B flat (grade 10) and renders as B', () => {
+        const chord = Chord.parse('B', opts);
+
+        expect(chord?.root?.effectiveGrade).toEqual(10);
+        expect(chord?.toString()).toEqual('B');
+      });
+
+      it('parses Bm as B-flat minor and renders as Bm', () => {
+        const chord = Chord.parse('Bm', opts);
+
+        expect(chord?.root?.effectiveGrade).toEqual(10);
+        expect(chord?.toString()).toEqual('Bm');
+      });
+
+      it('still parses H as B natural', () => {
+        const chord = Chord.parse('H', opts);
+
+        expect(chord?.root?.effectiveGrade).toEqual(11);
+        expect(chord?.toString()).toEqual('H');
+      });
+
+      it('keeps Bb explicit as Bb', () => {
+        expect(Chord.parse('Bb', opts)?.toString()).toEqual('Bb');
+      });
+
+      it('transposes B up by 1 to H', () => {
+        expect(Chord.parse('B', opts)?.transposeUp().toString()).toEqual('H');
+      });
+
+      it('transposes H up by 1 to C', () => {
+        expect(Chord.parse('H', opts)?.transposeUp().toString()).toEqual('C');
+      });
+
+      it('renders bass note in German style too', () => {
+        expect(Chord.parse('D/B', opts)?.toString()).toEqual('D/B');
+        expect(Chord.parse('D/B', opts)?.root?.effectiveGrade).toEqual(2);
+        expect(Chord.parse('D/B', opts)?.bass?.effectiveGrade).toEqual(10);
+      });
+    });
+  });
+});

--- a/test/parser/chord_pro_parser_german_notation.test.ts
+++ b/test/parser/chord_pro_parser_german_notation.test.ts
@@ -1,0 +1,26 @@
+import ChordProFormatter from '../../src/formatter/chord_pro_formatter';
+import ChordProParser from '../../src/parser/chord_pro_parser';
+
+describe('ChordProParser', () => {
+  describe('notation: \'german\'', () => {
+    const text = '{title:Test}\n[H]Heut[B]ig [G]lied [D/H]wee';
+
+    it('interprets B as B flat throughout the song', () => {
+      const song = new ChordProParser().parse(text, { notation: 'german' });
+
+      expect(new ChordProFormatter().format(song)).toContain('[H]Heut[B]ig [G]lied [D/H]wee');
+    });
+
+    it('transposing up keeps German notation', () => {
+      const song = new ChordProParser().parse(text, { notation: 'german' });
+
+      expect(new ChordProFormatter().format(song.transposeUp())).toContain('[C]Heut[H]ig [G#]lied [D#/C]wee');
+    });
+
+    it('default mode still interprets B as B natural', () => {
+      const song = new ChordProParser().parse(text);
+
+      expect(new ChordProFormatter().format(song.transposeUp())).toContain('[C]Heut[C]ig');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2134.

`H` (and lowercase `h`) is now accepted as a chord root in chord symbols, mapped to B natural (grade 11). The H-notation is preserved through transposing, normalizing, and rendering — so input `[H]` stays `[H]`, `[Hm/D]` stays `[Hm/D]`, `[D/H]` stays `[D/H]`.

This implements the pragmatic "Bb + H" convention used widely in German/European chord sheets: write `Bb` for B flat and `H` for B natural. The meaning of `B` is unchanged (still B natural in English/Dutch/jazz notation), so this is non-breaking.

The strict-German convention (`B` = Bb) is not part of this change — it requires a parsing-mode opt-in because it changes the meaning of `B`. Can be added later if requested.