### PR TITLE
Preserve explicit accidental in formatter when song has a key directive

### DIFF
--- a/src/formatter/chord_renderer.ts
+++ b/src/formatter/chord_renderer.ts
@@ -63,13 +63,14 @@ class ChordRenderer {
     this.useUnicodeModifier = config.useUnicodeModifier;
   }
 
-  render(chordString: string): string {
-    const chord = Chord.parse(chordString);
+  render(chordOrString: Chord | string | null): string {
+    if (chordOrString instanceof Chord) return this.renderChord(chordOrString);
+    const input = chordOrString || '';
+    const chord = Chord.parse(input);
+    return chord ? this.renderChord(chord) : input;
+  }
 
-    if (!chord) {
-      return chordString;
-    }
-
+  private renderChord(chord: Chord): string {
     return callChain<Chord>(
       chord,
       [

--- a/src/formatter/chord_renderer.ts
+++ b/src/formatter/chord_renderer.ts
@@ -63,11 +63,10 @@ class ChordRenderer {
     this.useUnicodeModifier = config.useUnicodeModifier;
   }
 
-  render(chordOrString: Chord | string | null): string {
+  render(chordOrString: Chord | string): string {
     if (chordOrString instanceof Chord) return this.renderChord(chordOrString);
-    const input = chordOrString || '';
-    const chord = Chord.parse(input);
-    return chord ? this.renderChord(chord) : input;
+    const chord = Chord.parse(chordOrString);
+    return chord ? this.renderChord(chord) : chordOrString;
   }
 
   private renderChord(chord: Chord): string {

--- a/src/formatter/chords_over_words_formatter.ts
+++ b/src/formatter/chords_over_words_formatter.ts
@@ -147,7 +147,7 @@ class ChordsOverWordsFormatter extends Formatter {
 
   renderChord(item: ChordLyricsPair, line: Line) {
     return renderChord(
-      item.chords,
+      item.chord ?? item.chords,
       line,
       this.song,
       {

--- a/src/formatter/templates/html_div_formatter.ts
+++ b/src/formatter/templates/html_div_formatter.ts
@@ -71,7 +71,7 @@ export default (
                        return `
                         <div class="${ cls }"${ fontStyleTag(line.chordFont) }>
                           ${ renderChord(
-                            item.chords,
+                            item.chord ?? item.chords,
                             line,
                             song,
                             {

--- a/src/formatter/templates/html_table_formatter.ts
+++ b/src/formatter/templates/html_table_formatter.ts
@@ -81,7 +81,7 @@ export default (
                             return `
                             <td class="${ cls }"${ fontStyleTag(line.chordFont) }>${
                               renderChord(
-                                item.chords,
+                                item.chord ?? item.chords,
                                 line,
                                 song,
                                 {

--- a/src/formatter/text_formatter.ts
+++ b/src/formatter/text_formatter.ts
@@ -121,7 +121,7 @@ class TextFormatter extends Formatter {
 
   private renderChords(chordLyricsPair: ChordLyricsPair, line: Line) {
     const chords = renderChord(
-      chordLyricsPair.chords,
+      chordLyricsPair.chord ?? chordLyricsPair.chords,
       line,
       this.song,
       {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,3 +1,4 @@
+import Chord from './chord';
 import ChordRenderer from './formatter/chord_renderer';
 import FormattingContext from './formatter/formatting_context';
 import Key from './key';
@@ -26,7 +27,8 @@ interface RenderChordOptions {
 
 /**
  * Renders a chord in the context of a line and song and taking into account some options
- * @param chordString The chord to render
+ * @param chord The chord to render. Accepts either a {@link Chord} object (preferred \u2014 preserves
+ * explicit accidental choices) or a chord string.
  * @param line The line the chord is in
  * @param song The song the line is in
  * @param renderKey The key to render the chord in. If not provided, the line key will be used,
@@ -47,7 +49,7 @@ const renderChordDefaults: Required<RenderChordOptions> = {
 };
 
 export function renderChord(
-  chordString: string,
+  chord: Chord | string | null,
   line: Line,
   song: Song,
   options: RenderChordOptions = {},
@@ -67,7 +69,7 @@ export function renderChord(
     style: song.metadata.getSingle(CHORD_STYLE) as NullableChordStyle,
     transposeKey: line.transposeKey,
     useUnicodeModifier,
-  }).render(chordString);
+  }).render(chord);
 }
 
 /**

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,4 @@
-import Chord from './chord';
+import type Chord from './chord';
 import ChordRenderer from './formatter/chord_renderer';
 import FormattingContext from './formatter/formatting_context';
 import Key from './key';
@@ -49,7 +49,7 @@ const renderChordDefaults: Required<RenderChordOptions> = {
 };
 
 export function renderChord(
-  chord: Chord | string | null,
+  chord: Chord | string,
   line: Line,
   song: Song,
   options: RenderChordOptions = {},

--- a/test/integration/use_accidental_with_key.test.ts
+++ b/test/integration/use_accidental_with_key.test.ts
@@ -1,0 +1,17 @@
+import { ChordProParser, TextFormatter } from '../../src';
+
+describe('useAccidental with a song key (regression for #2143)', () => {
+  it(
+    'keeps a chord written with a sharp as sharp after useAccidental("#"), ' +
+    'even when the song key would map it to a flat',
+    () => {
+      const source = '{key: Bm}\n[Em] before I [D#aug]let you take the [Em]throne';
+
+      const song = new ChordProParser().parse(source).useAccidental('#');
+      const output = new TextFormatter().format(song).trim();
+
+      expect(output).toContain('D#+');
+      expect(output).not.toContain('Eb+');
+    },
+  );
+});

--- a/test/integration/use_accidental_with_key.test.ts
+++ b/test/integration/use_accidental_with_key.test.ts
@@ -5,13 +5,19 @@ describe('useAccidental with a song key (regression for #2143)', () => {
     'keeps a chord written with a sharp as sharp after useAccidental("#"), ' +
     'even when the song key would map it to a flat',
     () => {
-      const source = '{key: Bm}\n[Em] before I [D#aug]let you take the [Em]throne';
+      const source = [
+        '{key:Bm}',
+        '',
+        '[Em] before I [D#aug]let you take the [Em]throne',
+      ].join('\n');
 
       const song = new ChordProParser().parse(source).useAccidental('#');
-      const output = new TextFormatter().format(song).trim();
+      const output = new TextFormatter().format(song);
 
-      expect(output).toContain('D#+');
-      expect(output).not.toContain('Eb+');
+      expect(output).toEqual([
+        'Em          D#+              Em',
+        '   before I let you take the throne',
+      ].join('\n'));
     },
   );
 });


### PR DESCRIPTION
## Summary

When a chord was stored with `explicitAccidental: true` (e.g. via `song.useAccidental('#')`), the formatter re-parsed it from its string form on every render and lost that flag. `Chord.normalize(songKey)` then re-applied the enharmonic mapping (`Bm: { 'D#': 'Eb' }`), turning `D#aug` back into `Eb+`.

`renderChord` and `ChordRenderer.render` now accept a `Chord` object as well as a string; the four formatters pass `item.chord ?? item.chords` so the in-memory `Chord` (with its `explicitAccidental` flag) is used directly when available.

Closes #2143