### PR TITLE
Fix PDF formatter across package entrypoints

### DIFF
--- a/src/chord_sheet/chord_lyrics_pair.ts
+++ b/src/chord_sheet/chord_lyrics_pair.ts
@@ -4,11 +4,16 @@ import type Line from './line';
 
 import { Accidental } from '../constants';
 import { deprecate } from '../utilities';
+import { CHORD_LYRICS_PAIR_BRAND, brandPrototype, hasBrand } from './object_brand';
 
 /**
  * Represents a chord with the corresponding (partial) lyrics
  */
 class ChordLyricsPair {
+  static [Symbol.hasInstance](instance: unknown): boolean {
+    return hasBrand(instance, CHORD_LYRICS_PAIR_BRAND);
+  }
+
   chords: string;
 
   lyrics: string | null;
@@ -138,5 +143,7 @@ class ChordLyricsPair {
     return this.clone();
   }
 }
+
+brandPrototype(ChordLyricsPair.prototype, CHORD_LYRICS_PAIR_BRAND);
 
 export default ChordLyricsPair;

--- a/src/chord_sheet/chord_pro/literal.ts
+++ b/src/chord_sheet/chord_pro/literal.ts
@@ -1,6 +1,11 @@
 import Evaluatable from './evaluatable';
+import { LITERAL_BRAND, brandPrototype, hasBrand } from '../object_brand';
 
 class Literal extends Evaluatable {
+  static [Symbol.hasInstance](instance: unknown): boolean {
+    return hasBrand(instance, LITERAL_BRAND);
+  }
+
   string: string;
 
   constructor(string: string) {
@@ -20,5 +25,7 @@ class Literal extends Evaluatable {
     return new Literal(this.string);
   }
 }
+
+brandPrototype(Literal.prototype, LITERAL_BRAND);
 
 export default Literal;

--- a/src/chord_sheet/comment.ts
+++ b/src/chord_sheet/comment.ts
@@ -1,9 +1,14 @@
 import type Line from './line';
+import { COMMENT_BRAND, brandPrototype, hasBrand } from './object_brand';
 
 /**
  * Represents a comment. See https://www.chordpro.org/chordpro/chordpro-file-format-specification/#overview
  */
 class Comment {
+  static [Symbol.hasInstance](instance: unknown): boolean {
+    return hasBrand(instance, COMMENT_BRAND);
+  }
+
   content: string;
 
   parentLine: Line | null = null;
@@ -32,5 +37,7 @@ class Comment {
     return `Comment(content=${this.content})`;
   }
 }
+
+brandPrototype(Comment.prototype, COMMENT_BRAND);
 
 export default Comment;

--- a/src/chord_sheet/object_brand.ts
+++ b/src/chord_sheet/object_brand.ts
@@ -1,0 +1,25 @@
+// ChordSheetJS publishes multiple entrypoints. Some bundlers load those
+// entrypoints as separate module graphs, which gives each graph its own class
+// constructors. These global brands preserve nominal `instanceof` behavior for
+// public chord-sheet model objects across those duplicate module instances.
+export const CHORD_LYRICS_PAIR_BRAND = Symbol.for('chordsheetjs.ChordLyricsPair');
+export const COMMENT_BRAND = Symbol.for('chordsheetjs.Comment');
+export const LITERAL_BRAND = Symbol.for('chordsheetjs.Literal');
+export const SOFT_LINE_BREAK_BRAND = Symbol.for('chordsheetjs.SoftLineBreak');
+export const TAG_BRAND = Symbol.for('chordsheetjs.Tag');
+
+export function brandPrototype(prototype: object, brand: symbol): void {
+  Object.defineProperty(prototype, brand, {
+    value: true,
+    enumerable: false,
+    configurable: false,
+  });
+}
+
+export function hasBrand(instance: unknown, brand: symbol): boolean {
+  return !!(
+    instance &&
+    typeof instance === 'object' &&
+    (instance as Record<symbol, unknown>)[brand] === true
+  );
+}

--- a/src/chord_sheet/soft_line_break.ts
+++ b/src/chord_sheet/soft_line_break.ts
@@ -1,7 +1,13 @@
+import { SOFT_LINE_BREAK_BRAND, brandPrototype, hasBrand } from './object_brand';
+
 /**
  * Represents a soft line break in the lyrics, typically rendered as a space or optional break point.
  */
 class SoftLineBreak {
+  static [Symbol.hasInstance](instance: unknown): boolean {
+    return hasBrand(instance, SOFT_LINE_BREAK_BRAND);
+  }
+
   /**
    * The content of the soft line break, defaults to a single space.
    */
@@ -18,5 +24,7 @@ class SoftLineBreak {
     return new SoftLineBreak();
   }
 }
+
+brandPrototype(SoftLineBreak.prototype, SOFT_LINE_BREAK_BRAND);
 
 export default SoftLineBreak;

--- a/src/chord_sheet/tag.ts
+++ b/src/chord_sheet/tag.ts
@@ -49,6 +49,7 @@ import {
 } from './tags';
 
 import { END_TAG, START_TAG } from '../constants';
+import { TAG_BRAND, brandPrototype, hasBrand } from './object_brand';
 
 const CHORDFONT_SHORT = 'cf';
 const CHORDSIZE_SHORT = 'cs';
@@ -170,6 +171,10 @@ const translateTagNameAlias = (name: string) => {
  * Represents a tag/directive. See https://www.chordpro.org/chordpro/chordpro-directives/
  */
 class Tag extends AstComponent {
+  static [Symbol.hasInstance](instance: unknown): boolean {
+    return hasBrand(instance, TAG_BRAND);
+  }
+
   _isMetaTag = false;
 
   _originalName = '';
@@ -411,5 +416,7 @@ class Tag extends AstComponent {
     );
   }
 }
+
+brandPrototype(Tag.prototype, TAG_BRAND);
 
 export default Tag;

--- a/test/formatter/pdf_formatter_cross_entrypoint.test.ts
+++ b/test/formatter/pdf_formatter_cross_entrypoint.test.ts
@@ -1,0 +1,58 @@
+import '../util/matchers';
+import ChordProParser from '../../src/parser/chord_pro_parser';
+import PdfFormatter from '../../src/formatter/pdf_formatter';
+import StubbedPdfDoc from '../util/stubbed_pdf_doc';
+import type { RenderedItem, RenderedText } from '../util/stubbed_pdf_doc';
+
+function loadIsolatedParser(): typeof ChordProParser {
+  let Parser!: typeof ChordProParser;
+
+  jest.isolateModules(() => {
+    Parser = jest.requireActual('../../src/parser/chord_pro_parser').default;
+  });
+
+  return Parser;
+}
+
+function loadIsolatedFormatter(): typeof PdfFormatter {
+  let Formatter!: typeof PdfFormatter;
+
+  jest.isolateModules(() => {
+    Formatter = jest.requireActual('../../src/formatter/pdf_formatter').default;
+  });
+
+  return Formatter;
+}
+
+function renderedText(doc: StubbedPdfDoc): string {
+  return doc.renderedItems
+    .filter((item: RenderedItem): item is RenderedText => item.type === 'text')
+    .map((item: RenderedText) => item.text)
+    .join(' ');
+}
+
+describe('PdfFormatter across package entrypoints', () => {
+  it('formats body content from a song parsed by a different module instance', () => {
+    const Parser = loadIsolatedParser();
+    const Formatter = loadIsolatedFormatter();
+    const song = new Parser().parse(`
+{title: Cross-entry PDF}
+{start_of_verse: Verse 1}
+[A]Let it [C]render
+{end_of_verse}
+`, { softLineBreaks: true });
+
+    const formatter = new Formatter();
+    formatter.format(song, StubbedPdfDoc);
+    const doc = formatter.getDocumentWrapper().doc as StubbedPdfDoc;
+    const text = renderedText(doc);
+
+    expect(text).toContain('Cross-entry PDF');
+    expect(text).toContain('Verse 1');
+    expect(text).toContain('Let');
+    expect(text).toContain('it');
+    expect(text).toContain('render');
+    expect(text).toContain('A');
+    expect(text).toContain('C');
+  });
+});


### PR DESCRIPTION
## Objective

Make `PdfFormatter` accept normal public `Song` objects produced by the main `chordsheetjs` entrypoint while keeping PDF support isolated behind the `chordsheetjs/pdf` subpath.

The intended consumer API should work:

```ts
import { ChordProParser } from 'chordsheetjs';
import { PdfFormatter } from 'chordsheetjs/pdf';

const song = new ChordProParser().parse(source);
new PdfFormatter().format(song);
```

## Problem

`chordsheetjs/pdf` is built as a separate entrypoint. In real package usage, that can give the PDF entrypoint its own copies of chord-sheet model constructors such as `ChordLyricsPair`, `Tag`, and `SoftLineBreak`.

The PDF formatting/layout/rendering path uses `instanceof` checks against those constructors. If a `Song` was parsed through the main entrypoint, its body items can be structurally valid but fail the PDF entrypoint's `instanceof` checks. Metadata can still render, while body content is treated as empty.

## Fix

This PR adds shared runtime brands to the public chord-sheet model classes that are used in these `instanceof` checks:

- `ChordLyricsPair`
- `Tag`
- `Comment`
- `SoftLineBreak`
- `Literal`

Each class receives a non-enumerable `Symbol.for(...)` brand on its prototype and a `Symbol.hasInstance` implementation that recognizes the brand. That keeps existing `instanceof` checks working when the same model object crosses package-entrypoint module graphs.

The regression test parses with one isolated module instance and formats with another, matching the failure mode from separate package entrypoints.

## Packaging note

The ideal package layout would have `chordsheetjs` and `chordsheetjs/pdf` share one runtime copy of the internal model modules, so there is only one `ChordLyricsPair`, one `Tag`, one `Song`, etc. Then regular `instanceof` checks would work without any compatibility layer.

That would require a broader build/output change to how the PDF subpath is emitted. It also must preserve the important package boundary that keeps PDF and `jspdf` out of the main entrypoint, because PDF support is an optional dependency.

This change keeps the existing public API and optional PDF subpath intact while making public `Song` objects work correctly across the current entrypoint boundary.
