### PR TITLE
Add applyChordStyle option to ChordProFormatter

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -101,6 +101,7 @@ export const SYMBOL = 'symbol';
 export const NUMERIC = 'numeric';
 export const NUMERAL = 'numeral';
 export const SOLFEGE = 'solfege';
+export const NUMBER = 'number';
 
 export const ROMAN_NUMERALS = ['I', 'II', 'III', 'IV', 'V', 'VI', 'VII'];
 

--- a/src/formatter/chord_pro_formatter.ts
+++ b/src/formatter/chord_pro_formatter.ts
@@ -1,8 +1,10 @@
+import Chord from '../chord';
 import ChordLyricsPair from '../chord_sheet/chord_lyrics_pair';
 import Comment from '../chord_sheet/comment';
 import Evaluatable from '../chord_sheet/chord_pro/evaluatable';
 import Formatter from './formatter';
 import Item from '../chord_sheet/item';
+import Key from '../key';
 import Line from '../chord_sheet/line';
 import Literal from '../chord_sheet/chord_pro/literal';
 import Metadata from '../chord_sheet/metadata';
@@ -11,15 +13,22 @@ import Song from '../chord_sheet/song';
 import Tag from '../chord_sheet/tag';
 import Ternary from '../chord_sheet/chord_pro/ternary';
 
-import { BaseFormatterConfiguration } from './configuration/base_configuration';
+import { CHORD_STYLE } from '../chord_sheet/tags';
 import { getBaseDefaultConfig } from './configuration/default_config_manager';
+import {
+  ChordProFormatterConfiguration,
+  chordProSpecificDefaults,
+} from './configuration/chord_pro_configuration';
+import {
+  NUMBER, NUMERAL, NullableChordStyle, SOLFEGE, SYMBOL,
+} from '../constants';
 
 /**
  * Formats a song into a ChordPro chord sheet
  */
-class ChordProFormatter extends Formatter {
-  protected getDefaultConfiguration(): BaseFormatterConfiguration {
-    return { ...getBaseDefaultConfig(), normalizeChordSuffix: false };
+class ChordProFormatter extends Formatter<ChordProFormatterConfiguration> {
+  protected getDefaultConfiguration(): ChordProFormatterConfiguration {
+    return { ...getBaseDefaultConfig(), ...chordProSpecificDefaults } as ChordProFormatterConfiguration;
   }
 
   /**
@@ -32,7 +41,7 @@ class ChordProFormatter extends Formatter {
     const metadata = song.getMetadata(this.configuration);
     const { metadataLines, contentLines } = this.separateMetadataFromContent(lines);
     const formattedMetadataLines = this.formatMetadataSection(metadataLines);
-    const formattedContentLines = this.formatContentSection(contentLines, metadata);
+    const formattedContentLines = this.formatContentSection(contentLines, metadata, song);
     return this.combineMetadataAndContent(formattedMetadataLines, formattedContentLines);
   }
 
@@ -72,36 +81,25 @@ class ChordProFormatter extends Formatter {
     });
   }
 
-  private formatContentSection(contentLines: Line[], metadata: Metadata): string {
+  private formatContentSection(contentLines: Line[], metadata: Metadata, song: Song): string {
     return contentLines
-      .map((line) => this.formatLine(line, metadata))
+      .map((line) => this.formatLine(line, metadata, song))
       .join('\n');
   }
 
-  private combineMetadataAndContent(formattedMetadataLines: string[], formattedContentLines: string): string {
-    if (formattedMetadataLines.length > 0) {
-      if (formattedContentLines.trim().length > 0) {
-        return `${formattedMetadataLines.join('\n')}\n${formattedContentLines}`;
-      }
-      return formattedMetadataLines.join('\n');
-    }
-
-    return formattedContentLines;
-  }
-
-  formatLine(line: Line, metadata: Metadata): string {
+  formatLine(line: Line, metadata: Metadata, song: Song): string {
     return line.items
-      .map((item) => this.formatItem(item, metadata))
+      .map((item) => this.formatItem(item, metadata, line, song))
       .join('');
   }
 
-  formatItem(item: Item, metadata: Metadata): string {
+  formatItem(item: Item, metadata: Metadata, line: Line, song: Song): string {
     type constructor = any;
     type handlerFunc = any;
 
     const handlers = new Map<constructor, handlerFunc>([
       [Tag, (i: Item) => this.formatTag(i as Tag)],
-      [ChordLyricsPair, (i: Item) => this.formatChordLyricsPair(i as ChordLyricsPair)],
+      [ChordLyricsPair, (i: Item) => this.formatChordLyricsPair(i as ChordLyricsPair, line, song)],
       [Comment, (i: Item) => this.formatComment(i as Comment)],
       [SoftLineBreak, (_i: Item) => '\\ '],
     ]);
@@ -117,6 +115,17 @@ class ChordProFormatter extends Formatter {
     }
 
     throw new Error(`Don't know how to format a ${item}`);
+  }
+
+  private combineMetadataAndContent(formattedMetadataLines: string[], formattedContentLines: string): string {
+    if (formattedMetadataLines.length > 0) {
+      if (formattedContentLines.trim().length > 0) {
+        return `${formattedMetadataLines.join('\n')}\n${formattedContentLines}`;
+      }
+      return formattedMetadataLines.join('\n');
+    }
+
+    return formattedContentLines;
   }
 
   formatOrEvaluateItem(item: Evaluatable, metadata: Metadata): string {
@@ -203,23 +212,30 @@ class ChordProFormatter extends Formatter {
     return keys.map((key) => `${key}="${tag.attributes[key]}"`).join(' ');
   }
 
-  formatChordLyricsPair(chordLyricsPair: ChordLyricsPair): string {
+  formatChordLyricsPair(chordLyricsPair: ChordLyricsPair, line: Line, song: Song): string {
     return [
-      this.formatChordLyricsPairChords(chordLyricsPair),
+      this.formatChordLyricsPairChords(chordLyricsPair, line, song),
       this.formatChordLyricsPairLyrics(chordLyricsPair),
     ].join('');
   }
 
-  formatChordLyricsPairChords(chordLyricsPair: ChordLyricsPair): string {
+  formatChordLyricsPairChords(chordLyricsPair: ChordLyricsPair, line: Line, song: Song): string {
     if (chordLyricsPair.chords) {
       const chordObj = chordLyricsPair.chord;
       if (!chordObj) {
         return `[${chordLyricsPair.chords}]`;
       }
 
-      const finalChord = this.configuration.normalizeChords ?
-        chordObj.normalize(null, { normalizeSuffix: this.configuration.normalizeChordSuffix }) :
+      const contextKey = this.configuration.applyChordStyle ? Key.wrap(line.key || song.key) : null;
+
+      const normalizedChord = this.configuration.normalizeChords ?
+        chordObj.normalize(contextKey, { normalizeSuffix: this.configuration.normalizeChordSuffix }) :
         chordObj;
+
+      const finalChord = this.configuration.applyChordStyle ?
+        this.changeChordType(normalizedChord, contextKey, song) :
+        normalizedChord;
+
       return `[${finalChord}]`;
     }
 
@@ -228,6 +244,23 @@ class ChordProFormatter extends Formatter {
     }
 
     return '';
+  }
+
+  private changeChordType(chord: Chord, contextKey: Key | null, song: Song): Chord {
+    const style = song.metadata.getSingle(CHORD_STYLE) as NullableChordStyle;
+
+    switch (style) {
+      case SYMBOL:
+        return chord.toChordSymbol(contextKey);
+      case SOLFEGE:
+        return chord.toChordSolfege(contextKey);
+      case NUMERAL:
+        return chord.toNumeral(contextKey);
+      case NUMBER:
+        return chord.toNumeric(contextKey);
+      default:
+        return chord;
+    }
   }
 
   formatChordLyricsPairLyrics(chordLyricsPair: ChordLyricsPair): string {

--- a/src/formatter/configuration/chord_pro_configuration.ts
+++ b/src/formatter/configuration/chord_pro_configuration.ts
@@ -1,0 +1,10 @@
+import { BaseFormatterConfiguration } from './base_configuration';
+
+export interface ChordProFormatterConfiguration extends BaseFormatterConfiguration {
+  applyChordStyle: boolean;
+}
+
+export const chordProSpecificDefaults: Partial<ChordProFormatterConfiguration> = {
+  applyChordStyle: false,
+  normalizeChordSuffix: false,
+};

--- a/src/formatter/configuration/index.ts
+++ b/src/formatter/configuration/index.ts
@@ -13,6 +13,11 @@ import {
 } from './base_configuration';
 
 import {
+  ChordProFormatterConfiguration,
+  chordProSpecificDefaults,
+} from './chord_pro_configuration';
+
+import {
   CSS,
   HTMLConfigurationProperties,
   HTMLFormatterConfiguration,
@@ -147,6 +152,9 @@ export {
   MeasuredHtmlFormatterConfiguration,
   MeasuredHtmlConfigurationProperties,
   measuredHtmlSpecificDefaults,
+
+  ChordProFormatterConfiguration,
+  chordProSpecificDefaults,
 
   CSS,
   HtmlTemplateCssClasses,

--- a/test/formatter/chord_pro_formatter.test.ts
+++ b/test/formatter/chord_pro_formatter.test.ts
@@ -1,5 +1,7 @@
 import { ChordProFormatter, ChordProParser } from '../../src';
-import { chordLyricsPair, createSongFromAst, tag } from '../util/utilities';
+import {
+  chordLyricsPair, createSongFromAst, heredoc, tag,
+} from '../util/utilities';
 import { chordProSheetSolfege, chordProSheetSymbol } from '../fixtures/chord_pro_sheet';
 import { exampleSongSolfege, exampleSongSymbol } from '../fixtures/song';
 
@@ -82,6 +84,57 @@ describe('ChordProFormatter', () => {
     const formatted = new ChordProFormatter().format(song);
 
     expect(formatted).toEqual(chordSheet);
+  });
+
+  describe('applyChordStyle', () => {
+    const chordSheet = heredoc`
+      {key: C}
+      {chord_style: numeral}
+
+      Let it [Am]be, let it [F]be, let it [C]be
+      [C]Whisper words of [G]wisdom, let it [F]be`;
+
+    it('preserves original chord notation by default (backward compatible)', () => {
+      const song = new ChordProParser().parse(chordSheet);
+      const formatted = new ChordProFormatter().format(song);
+
+      expect(formatted).toContain('[Am]');
+      expect(formatted).toContain('[F]');
+      expect(formatted).toContain('[G]');
+    });
+
+    it('applies chord_style directive when enabled', () => {
+      const song = new ChordProParser().parse(chordSheet);
+      const formatted = new ChordProFormatter({ applyChordStyle: true }).format(song);
+
+      expect(formatted).toContain('[VIm]');
+      expect(formatted).toContain('[IV]');
+      expect(formatted).toContain('[I]');
+      expect(formatted).toContain('[V]');
+      expect(formatted).not.toContain('[Am]');
+    });
+
+    it('applies chord_style: number when enabled', () => {
+      const numberSheet = chordSheet.replace('numeral', 'number');
+      const song = new ChordProParser().parse(numberSheet);
+      const formatted = new ChordProFormatter({ applyChordStyle: true }).format(song);
+
+      expect(formatted).toContain('[6m]');
+      expect(formatted).toContain('[4]');
+      expect(formatted).toContain('[1]');
+      expect(formatted).toContain('[5]');
+    });
+
+    it('leaves chord notation untouched when chord_style is absent even if enabled', () => {
+      const noStyle = heredoc`
+        {key: C}
+
+        Let it [Am]be`;
+      const song = new ChordProParser().parse(noStyle);
+      const formatted = new ChordProFormatter({ applyChordStyle: true }).format(song);
+
+      expect(formatted).toContain('[Am]');
+    });
   });
 
   it('correctly formats non-standard metadata', () => {


### PR DESCRIPTION
Adds an opt-in `applyChordStyle` option to `ChordProFormatter`. When enabled, the `{chord_style: ...}` directive (`symbol` / `solfege` / `numeral` / `number`) is honoured during ChordPro round-trip — e.g. `[Am]` becomes `[VIm]` with `{chord_style: numeral}` and `{key: C}`.

Default is `false`, so existing output is unchanged.

The option lives on a new `ChordProFormatterConfiguration`. The previously hardcoded `normalizeChordSuffix: false` default for `ChordProFormatter` moved there too.

Refs #2171.