### PR TITLE
Output lowercase Roman numerals for minor chords

### DIFF
--- a/src/chord.ts
+++ b/src/chord.ts
@@ -302,23 +302,29 @@ class Chord implements ChordProperties {
    * @returns {string} the chord string
    */
   toString({ useUnicodeModifier = false } = {}): string {
-    let chordString = '';
-    let suffix = this.suffix || '';
-    const showMinor = suffix[0] !== 'm';
-
-    if (useUnicodeModifier) {
-      suffix = suffix.replace(/#(?=\d)/g, '\u266f').replace(/b(?=\d)/g, '\u266d');
-    }
-
-    if (this.root) chordString = this.root.toString({ showMinor, useUnicodeModifier }) + suffix;
+    const suffix = this.unicodeSuffix(useUnicodeModifier);
+    const { root, suffix: renderedSuffix } = this.renderRoot(suffix, useUnicodeModifier);
+    let chordString = root + renderedSuffix;
     if (this.bass) chordString = `${chordString}/${this.bass.toString({ useUnicodeModifier })}`;
-
-    // Wrap in parentheses if optional
-    if (this.optional) {
-      chordString = `(${chordString})`;
-    }
-
+    if (this.optional) chordString = `(${chordString})`;
     return chordString;
+  }
+
+  private unicodeSuffix(useUnicodeModifier: boolean): string {
+    const suffix = this.suffix || '';
+    if (!useUnicodeModifier) return suffix;
+    return suffix.replace(/#(?=\d)/g, '\u266f').replace(/b(?=\d)/g, '\u266d');
+  }
+
+  private renderRoot(suffix: string, useUnicodeModifier: boolean): { root: string; suffix: string } {
+    if (!this.root) return { root: '', suffix };
+    const showMinor = suffix[0] !== 'm';
+    const rootString = this.root.toString({ showMinor, useUnicodeModifier });
+    if (this.root.is(NUMERAL) && this.isMinor()) {
+      const remainingSuffix = suffix.startsWith('m') ? suffix.substring(1) : suffix;
+      return { root: rootString.toLowerCase(), suffix: remainingSuffix };
+    }
+    return { root: rootString, suffix };
   }
 
   /**

--- a/test/chord_symbol/to_numeral.test.ts
+++ b/test/chord_symbol/to_numeral.test.ts
@@ -15,8 +15,27 @@ describe('Chord', () => {
         expect(Chord.parse('Dsus/F#')?.toNumeral('Ab').toString()).toEqual('bVsus/bVII');
       });
 
-      it.skip('supports a minor chord', () => {
+      it('supports a minor chord', () => {
         expect(Chord.parse('Gm')?.toNumeral('Bb').toString()).toEqual('vi');
+      });
+
+      it('lowercases the numeral and drops the m suffix for any minor chord', () => {
+        expect(Chord.parse('Am')?.toNumeral('C').toString()).toEqual('vi');
+        expect(Chord.parse('Dm')?.toNumeral('C').toString()).toEqual('ii');
+        expect(Chord.parse('Em')?.toNumeral('C').toString()).toEqual('iii');
+      });
+
+      it('preserves extensions beyond the minor indicator', () => {
+        expect(Chord.parse('Am7')?.toNumeral('C').toString()).toEqual('vi7');
+        expect(Chord.parse('Dm9')?.toNumeral('C').toString()).toEqual('ii9');
+      });
+
+      it('does not lowercase major chords with maj suffix', () => {
+        expect(Chord.parse('Cmaj7')?.toNumeral('C').toString()).toEqual('Ima7');
+      });
+
+      it('lowercases the root but keeps the bass uppercase', () => {
+        expect(Chord.parse('Am/E')?.toNumeral('C').toString()).toEqual('vi/III');
       });
     });
   });

--- a/test/formatter/chord_pro_formatter.test.ts
+++ b/test/formatter/chord_pro_formatter.test.ts
@@ -107,7 +107,7 @@ describe('ChordProFormatter', () => {
       const song = new ChordProParser().parse(chordSheet);
       const formatted = new ChordProFormatter({ applyChordStyle: true }).format(song);
 
-      expect(formatted).toContain('[VIm]');
+      expect(formatted).toContain('[vi]');
       expect(formatted).toContain('[IV]');
       expect(formatted).toContain('[I]');
       expect(formatted).toContain('[V]');

--- a/test/helpers/render_chord.test.ts
+++ b/test/helpers/render_chord.test.ts
@@ -167,7 +167,7 @@ describe('renderChord helper', () => {
        1 | "Gm"        |         | "symbol"   | "Gm"    |
        2 | "Gm"        | "Bb"    | "symbol"   | "Gm"    |
        s | "Gm"        | "Bb"    | "number"   | "6"     |
-       s | "Gm"        | "Bb"    | "numeral"  | "vi"    |
+       4 | "Gm"        | "Bb"    | "numeral"  | "vi"    |
        5 | "IV"        |         | "numeral"  | "IV"    |
        6 | "IV"        |         | "number"   | "4"     |
        7 | "IV"        | "Bb"    | "symbol"   | "Eb"    |


### PR DESCRIPTION
`Am.toNumeral('C')` now renders as `vi` instead of `VIm`, following standard Roman numeral notation where case encodes chord quality. Extensions and bass notes are preserved: `Am7` → `vi7`, `Am/E` → `vi/III`.

Refs #2171.