### PR TITLE
Rebase numeral grade using originalKeyString

### DIFF
--- a/src/key.ts
+++ b/src/key.ts
@@ -342,14 +342,13 @@ class Key implements KeyProperties {
     return this.set({});
   }
 
-  private ensureGrade(forceMajorLookup = false) {
-    if (this.grade === null) this.calculateGradeFromNumber(forceMajorLookup);
+  private ensureGrade() {
+    if (this.grade === null) this.calculateGradeFromNumber();
   }
 
-  private calculateGradeFromNumber(forceMajorLookup = false) {
+  private calculateGradeFromNumber() {
     if (this.number === null) throw new Error('Cannot calculate grade, number is null');
-    const asMinor = forceMajorLookup ? false : this.isMinor();
-    this.grade = keyToGrade(this.number.toString(), this.accidental || NO_ACCIDENTAL, NUMERIC, asMinor);
+    this.grade = keyToGrade(this.number.toString(), this.accidental || NO_ACCIDENTAL, NUMERIC, this.isMinor());
     this.number = null;
   }
 
@@ -366,7 +365,8 @@ class Key implements KeyProperties {
   private convertToChordType(key: Key | string | null, type: ChordType, referenceKeyWasMinor: boolean): Key {
     const { accidental } = this;
     const keyObj = Key.wrapOrFail(key);
-    this.ensureGrade(!referenceKeyWasMinor);
+    this.rebaseNumeralGradeForMajorReference(referenceKeyWasMinor);
+    this.ensureGrade();
 
     const minorResult = this.handleMinorKeyConversion(keyObj, referenceKeyWasMinor);
     if (minorResult) return minorResult;
@@ -381,6 +381,14 @@ class Key implements KeyProperties {
 
     const normalized = converted.normalizeEnharmonics(keyObj);
     return accidental ? normalized.set({ preferredAccidental: accidental, accidental: null }) : normalized;
+  }
+
+  private rebaseNumeralGradeForMajorReference(referenceKeyWasMinor: boolean) {
+    if (referenceKeyWasMinor || !this.minor || !this.originalKeyString) return;
+    if (!(this.isNumeral() || this.isNumeric())) return;
+    const num = Key.getNumberFromKey(this.originalKeyString, this.type);
+    const grade = num ? keyToGrade(num.toString(), this.accidental || NO_ACCIDENTAL, NUMERIC, false) : null;
+    if (grade !== null) { this.grade = grade; this.number = null; }
   }
 
   private handleMinorKeyConversion(keyObj: Key, referenceKeyWasMinor: boolean): Key | null {

--- a/test/formatter/chord_pro_formatter.test.ts
+++ b/test/formatter/chord_pro_formatter.test.ts
@@ -135,6 +135,18 @@ describe('ChordProFormatter', () => {
 
       expect(formatted).toContain('[Am]');
     });
+
+    it('converts lowercase Roman input to the correct major-scale symbol', () => {
+      const romanSheet = heredoc`
+        {key: C}
+        {chord_style: symbol}
+
+        [I] [ii] [iii] [IV] [V] [vi] [vii]`;
+      const song = new ChordProParser().parse(romanSheet);
+      const formatted = new ChordProFormatter({ applyChordStyle: true }).format(song);
+
+      expect(formatted).toContain('[C] [Dm] [Em] [F] [G] [Am] [Bm]');
+    });
   });
 
   it('correctly formats non-standard metadata', () => {


### PR DESCRIPTION
The major-key rebase in `Key.convertToChordType` (added in #2230) relied on `ensureGrade` being a no-op the first time round, which meant it was skipped whenever the chord had already been through `Chord.normalize` — as happens in the `ChordProFormatter` pipeline when `applyChordStyle` is set. Result: `[vi]` in a `{key: C}` sheet round-tripped to `[Abm]` instead of `[Am]`.

Rebase from the parse-time `originalKeyString` instead, so the fix applies regardless of prior grade calculation.

Refs #2171.