### PR TITLE
Fix expanded {chorus} to keep original label

### DIFF
--- a/src/chord_sheet/line_expander.ts
+++ b/src/chord_sheet/line_expander.ts
@@ -23,7 +23,7 @@ class LineExpander {
   expand(): Line[] {
     const expandedLines = this.line.items.flatMap((item: Item) => {
       if (item instanceof Tag && item.name === CHORUS) {
-        return this.getLastChorusBefore(this.line.lineNumber, !item.hasLabel());
+        return this.getLastChorusBefore(this.line.lineNumber, { keepOriginalLabel: !item.hasLabel() });
       }
 
       return [];
@@ -32,7 +32,10 @@ class LineExpander {
     return [this.line, ...expandedLines];
   }
 
-  private getLastChorusBefore(lineNumber: number | null, includeStartOfChorusLabel: boolean): Line[] {
+  private getLastChorusBefore(
+    lineNumber: number | null,
+    { keepOriginalLabel }: { keepOriginalLabel: boolean },
+  ): Line[] {
     const lines: Line[] = [];
 
     if (!lineNumber) {
@@ -46,7 +49,7 @@ class LineExpander {
         break;
       }
 
-      if (line.type === CHORUS && (line.isEmpty() || this.lineHasChorusContent(line, includeStartOfChorusLabel))) {
+      if (line.type === CHORUS && (line.isEmpty() || this.lineHasChorusContent(line, { keepOriginalLabel }))) {
         lines.unshift(line);
       }
     }
@@ -54,11 +57,11 @@ class LineExpander {
     return lines;
   }
 
-  private lineHasChorusContent(line: Line, includeStartOfChorusLabel: boolean): boolean {
+  private lineHasChorusContent(line: Line, { keepOriginalLabel }: { keepOriginalLabel: boolean }): boolean {
     return line.items.some((item: Item) => {
       if (item instanceof Tag) {
         if (item.name === END_OF_CHORUS) return false;
-        if (item.name === START_OF_CHORUS) return includeStartOfChorusLabel && item.hasLabel();
+        if (item.name === START_OF_CHORUS) return keepOriginalLabel && item.hasLabel();
       }
 
       return true;

--- a/src/chord_sheet/line_expander.ts
+++ b/src/chord_sheet/line_expander.ts
@@ -23,7 +23,7 @@ class LineExpander {
   expand(): Line[] {
     const expandedLines = this.line.items.flatMap((item: Item) => {
       if (item instanceof Tag && item.name === CHORUS) {
-        return this.getLastChorusBefore(this.line.lineNumber);
+        return this.getLastChorusBefore(this.line.lineNumber, !item.hasLabel());
       }
 
       return [];
@@ -32,7 +32,7 @@ class LineExpander {
     return [this.line, ...expandedLines];
   }
 
-  private getLastChorusBefore(lineNumber: number | null): Line[] {
+  private getLastChorusBefore(lineNumber: number | null, includeStartOfChorusLabel: boolean): Line[] {
     const lines: Line[] = [];
 
     if (!lineNumber) {
@@ -46,7 +46,7 @@ class LineExpander {
         break;
       }
 
-      if (line.type === CHORUS && (line.isEmpty() || this.lineHasMoreThanChorusDirectives(line))) {
+      if (line.type === CHORUS && (line.isEmpty() || this.lineHasChorusContent(line, includeStartOfChorusLabel))) {
         lines.unshift(line);
       }
     }
@@ -54,12 +54,11 @@ class LineExpander {
     return lines;
   }
 
-  private lineHasMoreThanChorusDirectives(line: Line): boolean {
+  private lineHasChorusContent(line: Line, includeStartOfChorusLabel: boolean): boolean {
     return line.items.some((item: Item) => {
       if (item instanceof Tag) {
-        if (item.name === START_OF_CHORUS || item.name === END_OF_CHORUS) {
-          return false;
-        }
+        if (item.name === END_OF_CHORUS) return false;
+        if (item.name === START_OF_CHORUS) return includeStartOfChorusLabel && item.hasLabel();
       }
 
       return true;

--- a/test/integration/chord_pro_to_chord_sheet.test.ts
+++ b/test/integration/chord_pro_to_chord_sheet.test.ts
@@ -144,6 +144,42 @@ describe('chordpro to chord sheet', () => {
     expect(formatted).toEqual(expectedText);
   });
 
+  it('uses the original chorus label when {chorus} has no label', () => {
+    const chordSheet = heredoc`
+      {start_of_chorus: REFRAIN}
+      [G]Chorus [C]lyrics [G]here
+      More chorus [D]lyrics here
+      {end_of_chorus}
+
+      {start_of_verse: Verse 1}
+      [G]Amazing [C]grace
+      {end_of_verse}
+
+      {chorus}`;
+
+    const expectedText = heredoc`
+      REFRAIN
+      G      C      G
+      Chorus lyrics here
+                  D
+      More chorus lyrics here
+
+      Verse 1
+      G       C
+      Amazing grace
+
+      REFRAIN
+      G      C      G
+      Chorus lyrics here
+                  D
+      More chorus lyrics here`;
+
+    const song = new ChordProParser().parse(chordSheet);
+    const formatted = new TextFormatter({ expandChorusDirective: true }).format(song);
+
+    expect(formatted).toEqual(expectedText);
+  });
+
   it('does not expand chorus directives when expandChorusDirective=false', () => {
     const chordSheet = heredoc`
       {start_of_chorus: Chorus 1:}


### PR DESCRIPTION
## Summary
- When `{chorus}` was used without its own label, the label from `{start_of_chorus: LABEL}` was dropped during expansion.
- `LineExpander` now keeps the `start_of_chorus` line in the expansion whenever the calling `{chorus}` tag has no label of its own. `{chorus: MYLABEL}` still takes precedence and skips the original label as before.

## Test plan
- [x] New integration test `uses the original chorus label when {chorus} has no label`
- [x] Existing `can expand chorus directives when expandChorusDirective=true` still passes
- [x] Full test suite: 44744 passed
- [x] Lint clean

Closes #2222