### PR TITLE
Honor expandChorusDirective in PdfFormatter

### DIFF
--- a/src/chord_sheet/song.ts
+++ b/src/chord_sheet/song.ts
@@ -17,10 +17,9 @@ import SongBuilder from '../song_builder';
 import SongMapper from './song_mapper';
 import Tag from './tag';
 
-import { Accidental } from '../constants';
-import { TEXTBLOCK } from '../constants';
 import { testSelector } from '../helpers';
 import { ABC, LILYPOND, SVG } from '../constants';
+import { Accidental, TEXTBLOCK } from '../constants';
 import { CAPO, KEY } from './tags';
 import { configurationProviders, staticProviders } from './standard_metadata_providers';
 import { deprecate, filterObject } from '../utilities';

--- a/src/chord_sheet/song.ts
+++ b/src/chord_sheet/song.ts
@@ -73,11 +73,15 @@ class Song extends MetadataAccessors {
 
   /** @deprecated No longer used internally; use {@link bodyParagraphs} or {@link expandedBodyParagraphs}. */
   get renderParagraphs(): Paragraph[] {
+    deprecate('renderParagraphs is deprecated, use bodyParagraphs or expandedBodyParagraphs instead');
     return this._renderParagraphs ?? this.bodyParagraphs;
   }
 
   /** @deprecated No longer used internally. See {@link renderParagraphs}. */
-  set renderParagraphs(paragraphs: Paragraph[]) { this._renderParagraphs = paragraphs; }
+  set renderParagraphs(paragraphs: Paragraph[]) {
+    deprecate('renderParagraphs is deprecated, use bodyParagraphs or expandedBodyParagraphs instead');
+    this._renderParagraphs = paragraphs;
+  }
 
   selectRenderableItems(items: (Line | Paragraph)[]): (Line | Paragraph)[] {
     const copy = [...items];

--- a/src/chord_sheet/song.ts
+++ b/src/chord_sheet/song.ts
@@ -71,10 +71,12 @@ class Song extends MetadataAccessors {
     return this._bodyParagraphs;
   }
 
+  /** @deprecated No longer used internally; use {@link bodyParagraphs} or {@link expandedBodyParagraphs}. */
   get renderParagraphs(): Paragraph[] {
     return this._renderParagraphs ?? this.bodyParagraphs;
   }
 
+  /** @deprecated No longer used internally. See {@link renderParagraphs}. */
   set renderParagraphs(paragraphs: Paragraph[]) { this._renderParagraphs = paragraphs; }
 
   selectRenderableItems(items: (Line | Paragraph)[]): (Line | Paragraph)[] {

--- a/src/formatter/formatter.ts
+++ b/src/formatter/formatter.ts
@@ -21,7 +21,11 @@ class Formatter<T extends BaseFormatterConfiguration = BaseFormatterConfiguratio
    * transposed from the song's original key (as indicated by the `{key}` directive) to the specified key.
    * Note that transposing will only work if the original song key is set.
    * @param {boolean} [configuration.expandChorusDirective=false] Whether or not to expand `{chorus}` directives
-   * by rendering the last defined chorus inline after the directive.
+   * by rendering the last defined chorus inline after the directive. Note that for the measurement-based
+   * formatters ({@link PdfFormatter}, {@link MeasuredHtmlFormatter}) `expandChorusDirective` runs before the
+   * `repeatedSections` display rule: an expanded chorus counts as a repeated section, so a collapsing
+   * `repeatedSections` mode (the PDF default is `title_only`) can hide part or all of the recalled chorus. Use
+   * `repeatedSections: "full"` to render the full chorus.
    * @param {boolean} [configuration.useUnicodeModifiers=false] Whether or not to use unicode flat and sharp
    * symbols.
    * @param {boolean} [configuration.normalizeChords=true] Whether or not to automatically normalize chords

--- a/src/formatter/measured_html_formatter.ts
+++ b/src/formatter/measured_html_formatter.ts
@@ -107,6 +107,7 @@ class MeasuredHtmlFormatter extends MeasurementBasedFormatter<MeasuredHtmlFormat
       displayLyricsOnly: !!this.configuration.layout.sections?.base?.display?.lyricsOnly,
       decapo: this.configuration.decapo,
       repeatedSections: this.configuration.layout.sections?.base?.display?.repeatedSections,
+      expandChorusDirective: this.configuration.expandChorusDirective,
     };
 
     // Return the layout engine

--- a/src/formatter/pdf_formatter.ts
+++ b/src/formatter/pdf_formatter.ts
@@ -97,6 +97,7 @@ class PdfFormatter extends MeasurementBasedFormatter<PDFFormatterConfiguration> 
       displayLyricsOnly: !!this.configuration.layout.sections?.base?.display?.lyricsOnly,
       decapo: this.configuration.decapo,
       repeatedSections: this.configuration.layout.sections?.base?.display?.repeatedSections,
+      expandChorusDirective: this.configuration.expandChorusDirective,
     };
 
     if (this.configuration.layout.sections.global.columnCount) {

--- a/src/layout/engine/layout_engine.ts
+++ b/src/layout/engine/layout_engine.ts
@@ -55,15 +55,15 @@ export class LayoutEngine {
 
   private sectionCache: Map<string, Paragraph> = new Map<string, Paragraph>();
 
+  private readonly paragraphs: Paragraph[];
+
   constructor(
     private song: Song,
     private measurer: Measurer,
     private config: LayoutConfig,
   ) {
-    // Process repeated sections before layout computation
-    this.processRepeatedSections();
+    this.paragraphs = this.resolveParagraphs();
 
-    // Initialize component classes
     this.itemProcessor = new ItemProcessor(this.measurer, this.config, this.song);
     this.layoutFactory = new LayoutFactory(config);
     this.lineBreaker = new LineBreaker(this.itemProcessor, this.layoutFactory);
@@ -119,33 +119,39 @@ export class LayoutEngine {
     return tag.label || tag.value || null;
   }
 
-  /**
-   * Process repeated sections by modifying the song's bodyParagraphs array
-   * This is called in the constructor to preprocess the song before layout computation
-   */
-  private processRepeatedSections(): void {
+  private resolveParagraphs(): Paragraph[] {
+    const sourceParagraphs = this.getSourceParagraphs();
+
     if (!this.config.repeatedSections) {
-      return;
+      return sourceParagraphs;
     }
 
+    return this.processRepeatedSections(sourceParagraphs);
+  }
+
+  private getSourceParagraphs(): Paragraph[] {
+    return this.config.expandChorusDirective ? this.song.expandedBodyParagraphs : this.song.bodyParagraphs;
+  }
+
+  private processRepeatedSections(sourceParagraphs: Paragraph[]): Paragraph[] {
     this.sectionCache.clear();
 
     const processedParagraphs: Paragraph[] = [];
     const skipIndices = new Set<number>();
-    const { bodyParagraphs } = this.song.clone();
 
-    bodyParagraphs.forEach((paragraph, index) => {
+    sourceParagraphs.forEach((paragraph, index) => {
       this.processParagraph({
         paragraph,
         index,
         processedParagraphs,
         skipIndices,
-        bodyParagraphs,
+        bodyParagraphs: sourceParagraphs,
       });
     });
 
-    (this.song as any).renderParagraphs = processedParagraphs;
     this.sectionCache.clear();
+
+    return processedParagraphs;
   }
 
   private processParagraph(params: ProcessParagraphParams): void {
@@ -400,7 +406,7 @@ export class LayoutEngine {
       currentColumn: 1,
     };
 
-    this.song.renderParagraphs.forEach((paragraph) => {
+    this.paragraphs.forEach((paragraph) => {
       state = this.processParagraphLayout(paragraph, layouts, state);
     });
 

--- a/src/layout/engine/layout_engine.ts
+++ b/src/layout/engine/layout_engine.ts
@@ -10,6 +10,7 @@ import SoftLineBreak from '../../chord_sheet/soft_line_break';
 import Song from '../../chord_sheet/song';
 import Tag from '../../chord_sheet/tag';
 import TitleSeparatorTag from './title_separator_tag';
+import { warn } from '../../utilities';
 import { LayoutConfig, LineLayout, ParagraphLayoutResult } from './types';
 import { calculateTotalHeight, isColumnBreakLayout } from './layout_helpers';
 import { isComment, isTag, lineHasContents } from '../../template_helpers';
@@ -130,7 +131,21 @@ export class LayoutEngine {
   }
 
   private getSourceParagraphs(): Paragraph[] {
-    return this.config.expandChorusDirective ? this.song.expandedBodyParagraphs : this.song.bodyParagraphs;
+    if (!this.config.expandChorusDirective) {
+      return this.song.bodyParagraphs;
+    }
+
+    this.warnAboutRepeatedSections();
+    return this.song.expandedBodyParagraphs;
+  }
+
+  private warnAboutRepeatedSections(): void {
+    if (this.config.repeatedSections && this.config.repeatedSections !== 'full') {
+      warn(
+        'expandChorusDirective runs before repeatedSections. The current repeated-section mode can hide part or ' +
+        'all of the recalled chorus. Use repeatedSections: "full" to show the full chorus.',
+      );
+    }
   }
 
   private processRepeatedSections(sourceParagraphs: Paragraph[]): Paragraph[] {

--- a/src/layout/engine/types.ts
+++ b/src/layout/engine/types.ts
@@ -85,6 +85,7 @@ export interface LayoutConfig {
   displayLyricsOnly?: boolean;
   decapo: boolean;
   repeatedSections?: 'hide' | 'title_only' | 'lyrics_only' | 'full';
+  expandChorusDirective?: boolean;
 }
 
 export interface ParagraphLayoutResult {

--- a/test/formatter/pdf_formatter.test.ts
+++ b/test/formatter/pdf_formatter.test.ts
@@ -1,9 +1,16 @@
 import '../util/matchers';
+import ChordProParser from '../../src/parser/chord_pro_parser';
 import { PDFConfigurationProperties } from '../../src/formatter/configuration';
 import PdfFormatter from '../../src/formatter/pdf_formatter';
 import Song from '../../src/chord_sheet/song';
 import StubbedPdfDoc from '../util/stubbed_pdf_doc';
 import { exampleSongSymbol } from '../fixtures/song';
+
+function countRenderedText(doc: StubbedPdfDoc, text: string): number {
+  return doc.renderedItems
+    .filter((item) => item.type === 'text' && (item as { text: string }).text.includes(text))
+    .length;
+}
 
 describe('PdfFormatter', () => {
   it('correctly formats a basic song', () => {
@@ -86,6 +93,44 @@ describe('PdfFormatter', () => {
     expect(doc).toHaveText('C/E', 263, 570);
     // Moved to next column
     expect(doc).toHaveText('Dm', 54, 640);
+  });
+
+  describe('expandChorusDirective', () => {
+    const chordSheet = [
+      '{start_of_chorus: Chorus}',
+      'Whisper words of wisdom',
+      '{end_of_chorus}',
+      '',
+      '{start_of_verse: Verse 1}',
+      'Let it be',
+      '{end_of_verse}',
+      '',
+      '{chorus}',
+    ].join('\n');
+
+    function renderChorusPdf({ expandChorusDirective }: { expandChorusDirective: boolean }): StubbedPdfDoc {
+      const song = new ChordProParser().parse(chordSheet);
+      const formatter = new PdfFormatter();
+      formatter
+        .configure({
+          layout: { sections: { base: { display: { repeatedSections: 'full' } } } },
+          expandChorusDirective,
+        })
+        .format(song, StubbedPdfDoc);
+      return formatter.getDocumentWrapper().doc as StubbedPdfDoc;
+    }
+
+    it('expands {chorus} directives when expandChorusDirective=true', () => {
+      const doc = renderChorusPdf({ expandChorusDirective: true });
+
+      expect(countRenderedText(doc, 'Whisper words of wisdom')).toEqual(2);
+    });
+
+    it('does not expand {chorus} directives when expandChorusDirective=false', () => {
+      const doc = renderChorusPdf({ expandChorusDirective: false });
+
+      expect(countRenderedText(doc, 'Whisper words of wisdom')).toEqual(1);
+    });
   });
 
   it('renders header content', () => {

--- a/test/layout/engine/layout_engine.test.ts
+++ b/test/layout/engine/layout_engine.test.ts
@@ -4,6 +4,7 @@ import Paragraph from '../../../src/chord_sheet/paragraph';
 import Song from '../../../src/chord_sheet/song';
 import Tag from '../../../src/chord_sheet/tag';
 
+import * as utilities from '../../../src/utilities';
 import { LayoutEngine } from '../../../src/layout/engine/layout_engine';
 import { LayoutConfig, ParagraphLayoutResult } from '../../../src/layout/engine/types';
 import { Measurer, TextDimensions } from '../../../src/layout/measurement';
@@ -243,6 +244,48 @@ describe('LayoutEngine', () => {
       const processedParagraphs = (engine as any).paragraphs;
 
       expect(processedParagraphs.length).toEqual(paragraphs.length);
+    });
+
+    describe('warning about expandChorusDirective and repeatedSections', () => {
+      let warnSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        warnSpy = jest.spyOn(utilities, 'warn').mockImplementation(() => {});
+      });
+
+      afterEach(() => {
+        warnSpy.mockRestore();
+      });
+
+      it('warns when expandChorusDirective is set with a collapsing repeatedSections mode', () => {
+        const song = createTestSong();
+        const config = createTestConfig({ expandChorusDirective: true, repeatedSections: 'title_only' });
+
+        // eslint-disable-next-line no-new
+        new LayoutEngine(song, measurer, config);
+
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('repeatedSections'));
+      });
+
+      it('does not warn when repeatedSections is "full"', () => {
+        const song = createTestSong();
+        const config = createTestConfig({ expandChorusDirective: true, repeatedSections: 'full' });
+
+        // eslint-disable-next-line no-new
+        new LayoutEngine(song, measurer, config);
+
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+
+      it('does not warn when expandChorusDirective is not set', () => {
+        const song = createTestSong();
+        const config = createTestConfig({ repeatedSections: 'title_only' });
+
+        // eslint-disable-next-line no-new
+        new LayoutEngine(song, measurer, config);
+
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/test/layout/engine/layout_engine.test.ts
+++ b/test/layout/engine/layout_engine.test.ts
@@ -261,8 +261,7 @@ describe('LayoutEngine', () => {
         const song = createTestSong();
         const config = createTestConfig({ expandChorusDirective: true, repeatedSections: 'title_only' });
 
-        // eslint-disable-next-line no-new
-        new LayoutEngine(song, measurer, config);
+        const _engine = new LayoutEngine(song, measurer, config);
 
         expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('repeatedSections'));
       });
@@ -271,8 +270,7 @@ describe('LayoutEngine', () => {
         const song = createTestSong();
         const config = createTestConfig({ expandChorusDirective: true, repeatedSections: 'full' });
 
-        // eslint-disable-next-line no-new
-        new LayoutEngine(song, measurer, config);
+        const _engine = new LayoutEngine(song, measurer, config);
 
         expect(warnSpy).not.toHaveBeenCalled();
       });
@@ -281,8 +279,7 @@ describe('LayoutEngine', () => {
         const song = createTestSong();
         const config = createTestConfig({ repeatedSections: 'title_only' });
 
-        // eslint-disable-next-line no-new
-        new LayoutEngine(song, measurer, config);
+        const _engine = new LayoutEngine(song, measurer, config);
 
         expect(warnSpy).not.toHaveBeenCalled();
       });

--- a/test/layout/engine/layout_engine.test.ts
+++ b/test/layout/engine/layout_engine.test.ts
@@ -228,7 +228,7 @@ describe('LayoutEngine', () => {
       const config = createTestConfig({ repeatedSections: 'hide' });
 
       const engine = new LayoutEngine(song, measurer, config);
-      const processedParagraphs = (engine as any).song.renderParagraphs;
+      const processedParagraphs = (engine as any).paragraphs;
 
       expect(processedParagraphs.length).toBeLessThan(paragraphs.length);
     });
@@ -240,7 +240,7 @@ describe('LayoutEngine', () => {
       const config = createTestConfig();
 
       const engine = new LayoutEngine(song, measurer, config);
-      const processedParagraphs = (engine as any).song.renderParagraphs;
+      const processedParagraphs = (engine as any).paragraphs;
 
       expect(processedParagraphs.length).toEqual(paragraphs.length);
     });
@@ -457,7 +457,7 @@ describe('LayoutEngine', () => {
       const config = createTestConfig({ repeatedSections: 'hide' });
       const engine = new LayoutEngine(song, measurer, config);
 
-      const processedParagraphs = (engine as any).song.renderParagraphs;
+      const processedParagraphs = (engine as any).paragraphs;
       expect(processedParagraphs.length).toBe(1);
     });
 
@@ -467,7 +467,7 @@ describe('LayoutEngine', () => {
       const config = createTestConfig({ repeatedSections: 'hide' });
       const engine = new LayoutEngine(song, measurer, config);
 
-      const processedParagraphs = (engine as any).song.renderParagraphs;
+      const processedParagraphs = (engine as any).paragraphs;
       expect(processedParagraphs.length).toBe(2);
     });
 
@@ -511,7 +511,7 @@ describe('LayoutEngine', () => {
 
       // The original cached paragraph should not be modified
       // Check that the first paragraph in renderParagraphs (the original) still has its content
-      const processedParagraphs = (engine as any).song.renderParagraphs;
+      const processedParagraphs = (engine as any).paragraphs;
       const originalParagraph = processedParagraphs[0];
       const originalFirstLine = originalParagraph.lines[0];
 


### PR DESCRIPTION
Fixes #2240

The PDF layout engine always read the song's `bodyParagraphs`, so `{chorus}` directives were never expanded in PDF output — unlike `TextFormatter` and `HtmlFormatter`, which honor `expandChorusDirective`.

## Changes
- `LayoutEngine` now resolves the paragraphs to lay out from the config: it uses `expandedBodyParagraphs` when `expandChorusDirective` is enabled, and returns the resolved array instead of writing it back onto the song.
- `expandChorusDirective` is added to `LayoutConfig` and passed through from `PdfFormatter`.
- Dropped the redundant `song.clone()` in paragraph selection: the source paragraphs are never mutated (all pushed paragraphs are clones), and cloning stripped line numbers, which `LineExpander` needs to expand `{chorus}`.
- `Song#renderParagraphs` is no longer used internally and is deprecated.

## Note on `repeatedSections`
The PDF default `repeatedSections: 'title_only'` collapses repeated sections to their title. Since an expanded `{chorus}` reproduces the chorus, it is treated as a repeat and collapsed to its title under the default config. To get output identical to text/HTML (the expanded chorus rendered in full), combine `expandChorusDirective: true` with a non-collapsing `repeatedSections` such as `'full'`.

## Tests
Added PDF formatter tests asserting chorus lyrics are laid out twice when `expandChorusDirective: true` and once when `false` (with `repeatedSections: 'full'`).