### PR TITLE
Silence outFile deprecation warning in declaration build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0",
     "lib": ["es2018", "es2019", "es2022", "dom"],
     "module": "preserve",
     "moduleResolution": "bundler",


### PR DESCRIPTION
The `@parcel/transformer-typescript-types` transformer emits a build warning under TypeScript 6:

```
Option 'outFile' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

Adds `"ignoreDeprecations": "6.0"` to `tsconfig.json` as suggested by the compiler, silencing the warning during the `.d.ts` bundle step.