### PR TITLE
Honor expandChorusDirective in ChordsOverWordsFormatter

### DIFF
--- a/src/formatter/chords_over_words_formatter.ts
+++ b/src/formatter/chords_over_words_formatter.ts
@@ -69,7 +69,9 @@ class ChordsOverWordsFormatter extends Formatter {
 
   formatParagraphs(): string {
     const metadata = this.song.getMetadata(this.configuration);
-    const paragraphs = this.song.filterParagraphs(this.song.bodyParagraphs, this.configuration);
+    const { bodyParagraphs, expandedBodyParagraphs } = this.song;
+    const bodyParagraphsToFormat = this.configuration.expandChorusDirective ? expandedBodyParagraphs : bodyParagraphs;
+    const paragraphs = this.song.filterParagraphs(bodyParagraphsToFormat, this.configuration);
     const count = paragraphs.length;
 
     const formattedParagraphs = paragraphs.map((paragraph) => this.formatParagraph(paragraph, metadata));

--- a/test/formatter/chords_over_words_formatter.test.ts
+++ b/test/formatter/chords_over_words_formatter.test.ts
@@ -16,6 +16,66 @@ import {
 } from '../util/utilities';
 
 describe('ChordsOverWordsFormatter', () => {
+  it('expands chorus directives when expandChorusDirective=true', () => {
+    const chordSheet = heredoc`
+      {start_of_chorus: Chorus 1:}
+      [C]Whisper words of
+      {end_of_chorus}
+
+      {start_of_verse: Verse 1:}
+      Let it [Am]be
+      {end_of_verse}
+
+      {chorus: Repeat chorus 1:}`;
+
+    const expectedChordSheet = heredoc`
+      Chorus 1:
+      C
+      Whisper words of
+
+      Verse 1:
+             Am
+      Let it be
+
+      Repeat chorus 1:
+      C
+      Whisper words of`;
+
+    const song = new ChordProParser().parse(chordSheet);
+    const formatted = new ChordsOverWordsFormatter({ expandChorusDirective: true }).format(song);
+
+    expect(formatted).toEqual(expectedChordSheet);
+  });
+
+  it('does not expand chorus directives when expandChorusDirective=false', () => {
+    const chordSheet = heredoc`
+      {start_of_chorus: Chorus 1:}
+      [C]Whisper words of
+      {end_of_chorus}
+
+      {start_of_verse: Verse 1:}
+      Let it [Am]be
+      {end_of_verse}
+
+      {chorus: Repeat chorus 1:}`;
+
+    const expectedChordSheet = heredoc`
+      Chorus 1:
+      C
+      Whisper words of
+
+      Verse 1:
+             Am
+      Let it be
+
+      Repeat chorus 1:`;
+
+    const song = new ChordProParser().parse(chordSheet);
+    const formatted = new ChordsOverWordsFormatter({ expandChorusDirective: false }).format(song);
+
+    expect(formatted).toEqual(expectedChordSheet);
+  });
+
   it('formats a symbol song to a text chord sheet correctly', () => {
     const formatter = new ChordsOverWordsFormatter();
 


### PR DESCRIPTION
The `ChordsOverWordsFormatter` now uses `expandedBodyParagraphs` when `expandChorusDirective: true` is passed, so `{chorus}` directives are expanded the same way `TextFormatter`, `HtmlFormatter`, and `PdfFormatter` already do.

Closes #2241