### PR TITLE
Make colon optional for directive attributes

### DIFF
--- a/src/parser/chord_pro/grammar.pegjs
+++ b/src/parser/chord_pro/grammar.pegjs
@@ -211,8 +211,8 @@ TagColonWithValue
     }
 
 TagSpaceWithValue
-  = __ value:TagSimpleValue {
-      return value;
+  = &__ tagValue:TagValue {
+      return tagValue;
     }
 
 TagValue

--- a/test/parser/chord_pro_parser.test.ts
+++ b/test/parser/chord_pro_parser.test.ts
@@ -164,6 +164,15 @@ describe('ChordProParser', () => {
     expect(tag.attributes).toEqual({ label: 'Verse 1' });
   });
 
+  it('parses directives with attributes without a colon', () => {
+    const chordSheet = '{start_of_verse label="Verse 1"}';
+    const song = new ChordProParser().parse(chordSheet);
+    const tag = song.lines[0].items[0] as Tag;
+
+    expect(tag.name).toEqual('start_of_verse');
+    expect(tag.attributes).toEqual({ label: 'Verse 1' });
+  });
+
   it('parses meta directives', () => {
     const chordSheetWithCustomMetaData = `
       {meta: one_directive Foo}

--- a/test/parser/chord_pro_parser.test.ts
+++ b/test/parser/chord_pro_parser.test.ts
@@ -160,8 +160,7 @@ describe('ChordProParser', () => {
     const song = new ChordProParser().parse(chordSheet);
     const tag = song.lines[0].items[0] as Tag;
 
-    expect(tag.name).toEqual('start_of_verse');
-    expect(tag.attributes).toEqual({ label: 'Verse 1' });
+    expect(tag).toMatchObject({ name: 'start_of_verse', attributes: { label: 'Verse 1' } });
   });
 
   it('parses directives with attributes without a colon', () => {
@@ -169,8 +168,7 @@ describe('ChordProParser', () => {
     const song = new ChordProParser().parse(chordSheet);
     const tag = song.lines[0].items[0] as Tag;
 
-    expect(tag.name).toEqual('start_of_verse');
-    expect(tag.attributes).toEqual({ label: 'Verse 1' });
+    expect(tag).toMatchObject({ name: 'start_of_verse', attributes: { label: 'Verse 1' } });
   });
 
   it('parses meta directives', () => {


### PR DESCRIPTION
Attributes on a directive could only be parsed when a colon separated the directive name from its value:

```
{start_of_verse: label="Verse 1"}
```

The [ChordPro spec](https://www.chordpro.org/chordpro/chordpro-directives/#arguments-and-attributes) makes the colon optional, so the following is now equally valid and yields the same attributes:

```
{start_of_verse label="Verse 1"}
```

The space-separated value branch in the grammar now parses attributes as well as plain values.

Fixes #2260