### PR TITLE
Fix formatting error upon extra chord- and lyric spacing (#2280)

### DIFF
--- a/src/parser/chord_sheet_parser.ts
+++ b/src/parser/chord_sheet_parser.ts
@@ -7,7 +7,7 @@ import { buildVisualColumnMap } from './parser_helpers';
 import { deprecate, normalizeLineEndings } from '../utilities';
 
 const WHITE_SPACE = /\s/;
-const CHORD_LINE_REGEX = /^\s*(((?:[A-G]|Do|Re|Mi|Fa|Sol|La|Si)(#|b)?([^/\s]*)(\/(?:[A-G]|Do|Re|Mi|Fa|Sol|La|Si)(#|b)?)?)(\s|$)+)+(\s|$)+/;
+const CHORD_LINE_REGEX = /^\s*(((?:[A-G]|Do|Re|Mi|Fa|Sol|La|Si)(#|b)?([^/\s]*)(\/(?:[A-G]|Do|Re|Mi|Fa|Sol|La|Si)(#|b)?)?)(\s|$)+)+$/;
 
 /**
  * Parses a normal chord sheet

--- a/src/parser/ultimate_guitar_parser.ts
+++ b/src/parser/ultimate_guitar_parser.ts
@@ -27,7 +27,7 @@ const UG_METADATA_REGEX = /^(\w+):\s*(.+)$/;
 const OTHER_METADATA_LINE_REGEX = /^\[([^\]]+)]/;
 const REPEAT_NOTATION_REGEX = /\s+(x\d+)\s*$/i;
 // eslint-disable-next-line max-len
-const CHORD_LINE_REGEX = /^\s*(((?:[A-G]|Do|Re|Mi|Fa|Sol|La|Si)(#|b)?([^/\s]*)(\/(?:[A-G]|Do|Re|Mi|Fa|Sol|La|Si)(#|b)?)?)(\s|$)+)+(\s|$)+/;
+const CHORD_LINE_REGEX = /^\s*(((?:[A-G]|Do|Re|Mi|Fa|Sol|La|Si)(#|b)?([^/\s]*)(\/(?:[A-G]|Do|Re|Mi|Fa|Sol|La|Si)(#|b)?)?)(\s|$)+)+$/;
 
 const startSectionTags: Record<string, string> = {
   [VERSE]: START_OF_VERSE,

--- a/test/parser/ultimate_guitar_parser.test.ts
+++ b/test/parser/ultimate_guitar_parser.test.ts
@@ -256,6 +256,18 @@ describe('UltimateGuitarParser', () => {
     expect(result).toEqual(expected);
   });
 
+  it('does not misdetect a lyrics line as a chord line when it has extra spacing', () => {
+    const chordSheet = heredoc`
+      Eb   Eb/D  Eb/C   Eb/Bb  F/A        Bb
+      And  the   great  est    miracle of all
+    `;
+
+    const song = new UltimateGuitarParser().parse(chordSheet);
+    const result = new ChordProFormatter().format(song).trimEnd();
+
+    expect(result).toEqual('[Eb]And  [Eb/D]the   [Eb/C]great  [Eb/Bb]est    [F/A]miracle of [Bb]all');
+  });
+
   it('support CR line endings', () => {
     const chordSheet = '       Am         C/G\rLet it be, let it be,\r       F          C\rlet it be, let it be';
 


### PR DESCRIPTION
Fixes #2280.

## What
The chord-line detection regex (`CHORD_LINE_REGEX`) in `UltimateGuitarParser` and `ChordSheetParser` was not anchored to the end of the line. As a result, any lyrics line starting with a note-like word followed by two or more spaces — e.g. `And  the   greatest...` — matched the regex and got misdetected as a chord line.

This broke chord/lyrics pairing: the lyrics line was parsed as standalone chords, and `ChordProFormatter` then threw `Not possible, grade and number are null` while trying to render words like `And` as chords. With single spacing the same input parsed fine, which is why the error only appeared when extra alignment spacing was added.

## Fix
Anchor `CHORD_LINE_REGEX` at end of line (`)+$` instead of `)+(\s|$)+`) so the whole line must consist of chord tokens. Lyrics lines with note-like first words no longer match.

## Tests
- Added a regression test in `ultimate_guitar_parser.test.ts` for the exact input from the issue.
- Full suite passes (44766 tests).