### PR TITLE
Fix wrong solfege chord names for reference keys other than C

### DIFF
--- a/src/key.ts
+++ b/src/key.ts
@@ -372,7 +372,9 @@ class Key implements KeyProperties {
     if (minorResult) return minorResult;
 
     const converted = this.set({
-      referenceKeyGrade: Key.shiftGrade(this.effectiveGrade + keyObj.effectiveGrade),
+      referenceKeyGrade: (this.isChordSymbol() || this.isChordSolfege()) ?
+        this.effectiveGrade :
+        Key.shiftGrade(this.effectiveGrade + keyObj.effectiveGrade),
       grade: 0,
       type,
       accidental: null,

--- a/test/chord_symbol/to_chord_solfege.test.ts
+++ b/test/chord_symbol/to_chord_solfege.test.ts
@@ -1,0 +1,35 @@
+import Chord from '../../src/chord';
+import Key from '../../src/key';
+
+describe('Chord', () => {
+  describe('chord symbol', () => {
+    describe('toChordSolfege', () => {
+      // Symbol and solfege are both absolute representations, so the resulting
+      // solfege name must honor the written spelling regardless of reference key.
+      // See https://github.com/martijnversluis/ChordSheetJS/issues/2285
+      const symbolToSolfege: Record<string, string> = {
+        'C#': 'Do#',
+        'D#': 'Re#',
+        'F#': 'Fa#',
+        'G#': 'Sol#',
+        'A#': 'La#',
+        'Bb': 'Sib',
+        'Eb': 'Mib',
+      };
+
+      ['C', 'E', 'Bb', 'F#'].forEach((referenceKey) => {
+        Object.entries(symbolToSolfege).forEach(([symbol, solfege]) => {
+          it(`converts ${symbol} to ${solfege} with reference key ${referenceKey}`, () => {
+            const chord = Chord.parse(symbol)!;
+            expect(chord.toChordSolfegeString(Key.wrap(referenceKey))).toEqual(solfege);
+          });
+        });
+      });
+
+      it('converts the bass note as well', () => {
+        const chord = Chord.parse('A/C#')!;
+        expect(chord.toChordSolfegeString(Key.wrap('E'))).toEqual('La/Do#');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes #2285

`Chord.toChordSolfege(key)` and `{chord_style: solfege}` returned incorrect solfege names for any reference key other than `C` (e.g. `C#` in key `E` became `Fa` instead of `Do#`).

Symbol and solfege are both absolute chord representations, so converting between them must preserve the pitch. `convertToChordType` added the reference key grade to the chord grade, which is only correct for relative types (numeral/numeric). For symbol/solfege input the grade is now kept as-is; the reference key is only used for enharmonic spelling.

Solfege output now matches symbol output exactly across all reference keys.

Adds a regression test covering symbol→solfege for keys C, E, Bb and F#.